### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @deliveryhero/helm-chart-admins
-/stable @deliveryhero/helm-chart-maintainers @deliveryhero/helm-chart-admins
+/stable @deliveryhero/helm-chart-maintainers


### PR DESCRIPTION
I misunderstood how this worked before. It was requiring chart changes to be approved by both groups, which is just annoying. So I've added all our team to both groups and then now remove admin group from `/stable`