### PR TITLE
[stable/kube-downscaler] Add cronjob to remove annotations periodically

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: 0.1.1
+version: "0.2"
 appVersion: 0.5.1
 description: Scale down Kubernetes deployments after work hours
 keywords:

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 0.5.1](https://img.shields.io/badge/AppVersion-0.5.1-informational?style=flat-square)
+![Version: 0.2](https://img.shields.io/badge/Version-0.2-informational?style=flat-square) ![AppVersion: 0.5.1](https://img.shields.io/badge/AppVersion-0.5.1-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 
@@ -46,18 +46,30 @@ helm install my-release deliveryhero/kube-downscaler -f values.yaml
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| affinity | object | `{}` |  |
 | debug.enable | bool | `false` |  |
 | deployment.environment.DEFAULT_UPTIME | string | `"Mon-Fri 07:00-20:00 Europe/Berlin"` |  |
 | extraLabels | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
 | image.args | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"hjacobs/kube-downscaler"` |  |
 | image.tag | string | `"19.10.1"` |  |
+| imagePullSecrets | list | `[]` |  |
 | interval | int | `60` |  |
-| name | string | `"kube-downscaler"` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
 | rbac.create | bool | `true` |  |
 | rbac.serviceAccountName | string | `"default"` |  |
 | replicaCount | int | `1` |  |
+| resetAnnotationsCronjob.enabled | bool | `false` |  |
+| resetAnnotationsCronjob.image | string | `"bitnami/kubectl:latest"` |  |
+| resetAnnotationsCronjob.labelSelectors[0] | string | `"environment=staging"` |  |
+| resetAnnotationsCronjob.resources.limits.cpu | string | `"50m"` |  |
+| resetAnnotationsCronjob.resources.limits.memory | string | `"50Mi"` |  |
+| resetAnnotationsCronjob.resources.requests.cpu | string | `"50m"` |  |
+| resetAnnotationsCronjob.resources.requests.memory | string | `"50Mi"` |  |
+| resetAnnotationsCronjob.schedule | string | `"0 7 * * *"` |  |
 | resources.limits.cpu | string | `"50m"` |  |
 | resources.limits.memory | string | `"200Mi"` |  |
 | resources.requests.cpu | string | `"50m"` |  |
@@ -65,6 +77,7 @@ helm install my-release deliveryhero/kube-downscaler -f values.yaml
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.runAsUser | int | `1000` |  |
+| tolerations | list | `[]` |  |
 
 ## Maintainers
 

--- a/stable/kube-downscaler/templates/_helpers.tpl
+++ b/stable/kube-downscaler/templates/_helpers.tpl
@@ -6,10 +6,6 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "imagePullSecret" }}
-{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.imageCredentials.registry (printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password | b64enc) | b64enc }}
-{{- end }}
-
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -28,6 +24,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kube-downscaler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for RBAC APIs.
 */}}
 {{- define "rbac.apiVersion" -}}
@@ -36,4 +39,17 @@ Return the appropriate apiVersion for RBAC APIs.
 {{- else -}}
 "rbac.authorization.k8s.io/v1beta1"
 {{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kube-downscaler.labels" -}}
+app.kubernetes.io/name: {{ include "kube-downscaler.name" . }}
+helm.sh/chart: {{ include "kube-downscaler.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/stable/kube-downscaler/templates/clusterrole.yaml
+++ b/stable/kube-downscaler/templates/clusterrole.yaml
@@ -3,10 +3,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "kube-downscaler.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+{{ include "kube-downscaler.labels" . | indent 4 }}
   name: {{ template "kube-downscaler.fullname" . }}
 rules:
 - apiGroups:

--- a/stable/kube-downscaler/templates/clusterrolebinding.yaml
+++ b/stable/kube-downscaler/templates/clusterrolebinding.yaml
@@ -3,10 +3,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "kube-downscaler.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+{{ include "kube-downscaler.labels" . | indent 4 }}
   name: {{ template "kube-downscaler.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/kube-downscaler/templates/cronjob.yaml
+++ b/stable/kube-downscaler/templates/cronjob.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.resetAnnotationsCronjob.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "kube-downscaler.fullname" . }}-de-annotate
+  labels:
+{{ include "kube-downscaler.labels" . | indent 4 }}
+    {{- if .Values.extraLabels }}
+      {{- toYaml .Values.extraLabels | nindent 4 }}
+    {{- end }}
+spec:
+  schedule: "{{ .Values.resetAnnotationsCronjob.schedule }}"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "kube-downscaler.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
+        spec:
+        {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+          serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-downscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+          restartPolicy: Never
+          containers:
+{{- range $index, $label := .Values.resetAnnotationsCronjob.labelSelectors }}
+            - name: remove-annotations-{{ $index }}
+              image: "{{ $.Values.resetAnnotationsCronjob.image }}"
+              command:
+                - "sh"
+                - "-c"
+              args: ["for d in $(kubectl get deployments -l {{ $label }} --no-headers -o custom-columns=':metadata.name'); do kubectl annotate deployment $d downscaler/exclude-; done"]
+              resources:
+                {{- toYaml $.Values.resources | nindent 16 }}
+{{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+{{- end }}

--- a/stable/kube-downscaler/templates/deployment.yaml
+++ b/stable/kube-downscaler/templates/deployment.yaml
@@ -3,11 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "kube-downscaler.fullname" . }}
   labels:
-    type: deployment
-    app: {{ template "kube-downscaler.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+{{ include "kube-downscaler.labels" . | indent 4 }}
     {{- if .Values.extraLabels }}
       {{- toYaml .Values.extraLabels | nindent 4 }}
     {{- end }}
@@ -15,15 +11,19 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "kube-downscaler.fullname" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "kube-downscaler.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "kube-downscaler.fullname" . }}
-        release: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ include "kube-downscaler.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-downscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
       - name: {{ template "kube-downscaler.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -47,4 +47,16 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+          {{- toYaml .Values.resources | nindent 10 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/stable/kube-downscaler/templates/serviceaccount.yaml
+++ b/stable/kube-downscaler/templates/serviceaccount.yaml
@@ -4,9 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "kube-downscaler.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+{{ include "kube-downscaler.labels" . | indent 4 }}
   name: {{ template "kube-downscaler.fullname" . }}
 {{- end -}}

--- a/stable/kube-downscaler/values.yaml
+++ b/stable/kube-downscaler/values.yaml
@@ -1,10 +1,6 @@
-## Default values for kube-downscaler.
-## This is a YAML-formatted file.
-## Declare variables to be passed into your templates.
-
 ## How many kube-downscaler pods should run in deployment
 replicaCount: 1
-name: kube-downscaler
+
 debug:
   enable: false
 
@@ -14,7 +10,7 @@ debug:
 #  active_in:
 ## How frequently kube-downscaler should query applications uptime, unit is in seconds.
 
-## Default is 1 minute.
+## Default is 60 seconds
 interval: 60
 
 rbac:
@@ -43,19 +39,33 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
-  ## Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes >= 1.6)
-  # tolerations: []
-
-  ## Allow the DaemonSet to schedule on selected nodes
-  # Ref: https://kubernetes.io/docs/user-guide/node-selection/
-  # nodeSelector: {}
-
-  ## Allow the DaemonSet to schedule ussing affinity rules
-  # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-  # affinity: {}
-
 extraLabels: {}
 
 deployment:
   environment:
     DEFAULT_UPTIME: "Mon-Fri 07:00-20:00 Europe/Berlin"
+
+# This will periodically remove all annotations preventing downscaling
+# Sometimes people forget to remove the annotations and this can incur costs
+resetAnnotationsCronjob:
+  enabled: false
+  image: bitnami/kubectl:latest
+  # Cron schedule for when to reset the annotations
+  schedule: 0 7 * * *
+  # A kubectl selector to identify what deployments to remove the annotation from
+  labelSelectors:
+    - environment=staging
+  resources:
+    limits:
+      cpu: 50m
+      memory: 50Mi
+    requests:
+      cpu: 50m
+      memory: 50Mi
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
This will periodically remove the annotations preventing downscaling. Adding because many of our developers add the annotation to run a load test over night or something similar and then never remove it, incurring extra AWS costs.

Also making labels and templating more modern for this chart.

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] Github actions are passing
