### PR TITLE
[stable/toxiproxy] Misc fixes

### DIFF
--- a/stable/toxiproxy/Chart.yaml
+++ b/stable/toxiproxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: toxiproxy
 description: A TCP proxy to simulate network and system conditions for chaos and resiliency testing.
-version: "1.0"
+version: "1.1"
 appVersion: "2.1.2"
 home: https://github.com/Shopify/toxiproxy
 sources:

--- a/stable/toxiproxy/README.md
+++ b/stable/toxiproxy/README.md
@@ -1,6 +1,6 @@
 # toxiproxy
 
-![Version: 1.0](https://img.shields.io/badge/Version-1.0-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
+![Version: 1.1](https://img.shields.io/badge/Version-1.1-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
 
 A TCP proxy to simulate network and system conditions for chaos and resiliency testing.
 

--- a/stable/toxiproxy/templates/_helpers.tpl
+++ b/stable/toxiproxy/templates/_helpers.tpl
@@ -42,9 +42,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- if .Values.extraLabels -}}
-{{ toYaml .Values.extraLabels }}
-{{- end -}}
+{{- range $key, $value := .Values.extraLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/stable/toxiproxy/templates/deployment.yaml
+++ b/stable/toxiproxy/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
       containers:
       - name: toxiproxy
         resources:
-  {{ toYaml .Values.resources | indent 10 }}
+{{ toYaml .Values.resources | indent 10 }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:

--- a/stable/toxiproxy/templates/deployment.yaml
+++ b/stable/toxiproxy/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             protocol: TCP
   {{- range $key, $value := .Values.service.proxies.ports }}
           - containerPort: {{ $value }}
-            name: proxy
+            name: {{ $value }}-proxy
             protocol: TCP
   {{- end }}
         livenessProbe:

--- a/stable/toxiproxy/templates/service.yaml
+++ b/stable/toxiproxy/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
     - port: {{ $value }}
       targetPort: {{ $value }}
       protocol: TCP
-      name:  proxy
+      name: {{ $value }}-proxy
 {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "toxiproxy.name" . }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

- Fixed trying to use the same `name` for all the ports defined in `Values.service.proxies.ports`
- Fixed wrong mapping when trying to specify extra labels that should be applied to the resources. 
- Fixed wrong indentation when specifying resources. 

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] Github actions are passing
