### PR TITLE
[stable/toxiproxy] allow passing configmap to chart to store toxics

### DIFF
--- a/stable/toxiproxy/Chart.yaml
+++ b/stable/toxiproxy/Chart.yaml
@@ -17,7 +17,7 @@ description: |
   helm install locust deliveryhero/toxiproxy \
     --set toxiproxyConfig=my-toxiproxy-config
   ```
-  
+
 version: "1.2"
 appVersion: "2.1.2"
 home: https://github.com/Shopify/toxiproxy

--- a/stable/toxiproxy/Chart.yaml
+++ b/stable/toxiproxy/Chart.yaml
@@ -1,7 +1,24 @@
 apiVersion: v1
 name: toxiproxy
-description: A TCP proxy to simulate network and system conditions for chaos and resiliency testing.
-version: "1.1"
+description: |
+  A TCP proxy to simulate network and system conditions for chaos and resiliency testing.
+
+  By default the chart will install toxiproxy with blank configuration. You can add [toxics](https://github.com/Shopify/toxiproxy#toxics) to the running configuration using the [API](https://github.com/Shopify/toxiproxy#http-api).
+
+  For large configurations it is easier to store your toxics in a JSON file, in a `ConfigMap` and pass this to the chart to be used by toxiproxy:
+
+  ```console
+  kubectl create configmap my-toxiproxy-config --from-file path/to/your/toxiproxy.json
+  ```
+
+  And then install the chart passing the name of the `ConfigMap` as a value:
+
+  ```console
+  helm install locust deliveryhero/toxiproxy \
+    --set toxiproxyConfig=my-toxiproxy-config
+  ```
+  
+version: "1.2"
 appVersion: "2.1.2"
 home: https://github.com/Shopify/toxiproxy
 sources:

--- a/stable/toxiproxy/README.md
+++ b/stable/toxiproxy/README.md
@@ -1,8 +1,23 @@
 # toxiproxy
 
-![Version: 1.1](https://img.shields.io/badge/Version-1.1-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
+![Version: 1.2](https://img.shields.io/badge/Version-1.2-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
 
 A TCP proxy to simulate network and system conditions for chaos and resiliency testing.
+
+By default the chart will install toxiproxy with blank configuration. You can add [toxics](https://github.com/Shopify/toxiproxy#toxics) to the running configuration using the [API](https://github.com/Shopify/toxiproxy#http-api).
+
+For large configurations it is easier to store your toxics in a JSON file, in a `ConfigMap` and pass this to the chart to be used by toxiproxy:
+
+```console
+kubectl create configmap my-toxiproxy-config --from-file path/to/your/toxiproxy.json
+```
+
+And then install the chart passing the name of the `ConfigMap` as a value:
+
+```console
+helm install locust deliveryhero/toxiproxy \
+  --set toxiproxyConfig=my-toxiproxy-config
+```
 
 **Homepage:** <https://github.com/Shopify/toxiproxy>
 
@@ -77,6 +92,7 @@ helm install my-release deliveryhero/toxiproxy -f values.yaml
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `nil` |  |
 | tolerations | list | `[]` |  |
+| toxiproxyConfig | string | `""` |  |
 
 ## Maintainers
 

--- a/stable/toxiproxy/templates/configmap-proxies.yaml
+++ b/stable/toxiproxy/templates/configmap-proxies.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ template "toxiproxy.fullname" . }}-proxies
-  labels:
-{{ include "toxiproxy.labels" . | indent 4 }}
-data:
-{{ (.Files.Glob (printf "consumers/%s/proxies/*" .Values.consumer.name)).AsConfig | indent 2 }}

--- a/stable/toxiproxy/templates/deployment.yaml
+++ b/stable/toxiproxy/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
 {{ include "toxiproxy.labels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}
-        checksum/consumers: {{ include (print $.Template.BasePath "/configmap-proxies.yaml") . | sha256sum }}
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -102,12 +101,12 @@ spec:
       - name: working
         emptyDir: {}
       - name: proxies
-{{ if eq .Values.toxiproxyConfig "" -}}
+{{ if eq .Values.toxiproxyConfig "" }}
         emptyDir: {}
-{{ else -}}
+{{ else }}
         configMap:
           name: {{ .Values.toxiproxyConfig }}
-{{ end -}}
+{{ end }}
       - name: config
         configMap:
           name: {{ template "toxiproxy.fullname" . }}-config

--- a/stable/toxiproxy/templates/deployment.yaml
+++ b/stable/toxiproxy/templates/deployment.yaml
@@ -102,8 +102,12 @@ spec:
       - name: working
         emptyDir: {}
       - name: proxies
+{{ if eq .Values.toxiproxyConfig "" -}}
+        emptyDir: {}
+{{ else -}}
         configMap:
-          name: {{ template "toxiproxy.fullname" . }}-proxies
+          name: {{ .Values.toxiproxyConfig }}
+{{ end -}}
       - name: config
         configMap:
           name: {{ template "toxiproxy.fullname" . }}-config

--- a/stable/toxiproxy/values.yaml
+++ b/stable/toxiproxy/values.yaml
@@ -1,6 +1,4 @@
-# Default values for toxiproxy.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+toxiproxyConfig: ""
 
 replicaCount: 1
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
