### PR TITLE
[stable/kube-bench] Use latest image of kube-bench for security tests

### DIFF
--- a/stable/kube-bench/Chart.yaml
+++ b/stable/kube-bench/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-appVersion: "0.1.0"
 description: "Helm chart to deploy run kube-bench as a cronjob on gke or eks."
 name: kube-bench
 version: 0.1.0

--- a/stable/kube-bench/Chart.yaml
+++ b/stable/kube-bench/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: "Helm chart to deploy run kube-bench as a cronjob on gke or eks."
 name: kube-bench
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/aquasecurity/kube-bench
 icon: https://raw.githubusercontent.com/aquasecurity/kube-bench/master/images/kube-bench.png
 sources:

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -1,6 +1,6 @@
 # kube-bench
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
 
 Helm chart to deploy run kube-bench as a cronjob on gke or eks.
 

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -50,7 +50,7 @@ helm install my-release deliveryhero/kube-bench -f values.yaml
 | cronjob.schedule | string | `"0 0 1 * *"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"aquasec/kube-bench"` |  |
-| image.tag | string | `"0.1.0"` |  |
+| image.tag | string | `"latest"` |  |
 | nodeSelector | object | `{}` |  |
 | provider | string | `"eks"` |  |
 | resources | object | `{}` |  |

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -1,6 +1,6 @@
 # kube-bench
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
 
 Helm chart to deploy run kube-bench as a cronjob on gke or eks.
 
@@ -50,7 +50,7 @@ helm install my-release deliveryhero/kube-bench -f values.yaml
 | cronjob.schedule | string | `"0 0 1 * *"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"aquasec/kube-bench"` |  |
-| image.tag | string | `"latest"` |  |
+| image.tag | string | `"0.4.0"` |  |
 | nodeSelector | object | `{}` |  |
 | provider | string | `"eks"` |  |
 | resources | object | `{}` |  |

--- a/stable/kube-bench/values.yaml
+++ b/stable/kube-bench/values.yaml
@@ -5,7 +5,7 @@ cronjob:
 
 image:
   repository: aquasec/kube-bench
-  tag: 0.1.0
+  tag: latest
   pullPolicy: IfNotPresent
 
 resources: {}

--- a/stable/kube-bench/values.yaml
+++ b/stable/kube-bench/values.yaml
@@ -5,7 +5,7 @@ cronjob:
 
 image:
   repository: aquasec/kube-bench
-  tag: latest
+  tag: 0.4.0
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

This PR removes app version from the chart.yaml file as the chart is not tied to a specific version of kube-bench. The version of kube-bench to be used can be specified using the values.yaml file. It also sets the default value of kube-bench image tag to latest.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] Github actions are passing
