### PR TITLE
[stable/node-problem-detector] Fix psp with hostNetwork and allow setting hostPID

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.8.0"
-appVersion: v0.8.1
+version: "1.8.1"
+appVersion: v0.8.4
 home: https://github.com/kubernetes/node-problem-detector
 description: |
   This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square) ![AppVersion: v0.8.4](https://img.shields.io/badge/AppVersion-v0.8.4-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -54,10 +54,11 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | Run pod on host network Flag to run Node Problem Detector on the host's network. This is typically not recommended, but may be useful for certain use cases. |
+| hostPID | bool | `false` |  |
 | hostpath.logdir | string | `"/var/log/"` | Log directory path on K8s host |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"k8s.gcr.io/node-problem-detector"` |  |
-| image.tag | string | `"v0.8.1"` |  |
+| image.repository | string | `"k8s.gcr.io/node-problem-detector/node-problem-detector"` |  |
+| image.tag | string | `"v0.8.4"` |  |
 | labels | object | `{}` |  |
 | maxUnavailable | int | `1` | The max pods unavailable during an update |
 | metrics.serviceMonitor.additionalLabels | object | `{}` |  |

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -37,6 +37,7 @@ spec:
     spec:
       serviceAccountName: {{ template "node-problem-detector.serviceAccountName" . }}
       hostNetwork: {{ .Values.hostNetwork }}
+      hostPID: {{ .Values.hostPID }}
       terminationGracePeriodSeconds: 30
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/stable/node-problem-detector/templates/psp.yaml
+++ b/stable/node-problem-detector/templates/psp.yaml
@@ -21,9 +21,9 @@ spec:
   - 'downwardAPI'
   - 'persistentVolumeClaim'
   - 'hostPath'
-  hostNetwork: false
+  hostNetwork: {{ .Values.hostNetwork }}
   hostIPC: false
-  hostPID: false
+  hostPID: {{ .Values.hostPID }}
   runAsUser:
     rule: 'RunAsAny'
   seLinux:

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -49,8 +49,8 @@ hostpath:
   logdir: /var/log/
 
 image:
-  repository: k8s.gcr.io/node-problem-detector
-  tag: v0.8.1
+  repository: k8s.gcr.io/node-problem-detector/node-problem-detector
+  tag: v0.8.4
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -64,6 +64,7 @@ rbac:
 # Flag to run Node Problem Detector on the host's network. This is typically
 # not recommended, but may be useful for certain use cases.
 hostNetwork: false
+hostPID: false
 
 priorityClassName: ""
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

* Fixed when `hostNetwork` is set the psp will not allow `hostNetwork` pods to start
* Added `hostPID` to expose the host pid namespace for node problem detector
* Updated the node problem detector image repository & version to latest release, v0.8.4

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
