### PR TITLE
[stable/cluster-overprovisioner]: Adding separate annotations to Pods and putting annotations on Deployment level

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.4.3
+version: 1.0.0
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 1.0.0
+version: 0.5.0
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -10,37 +10,12 @@ This approach is the [current recommended method to achieve overprovisioning](ht
 
 **Homepage:** <https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler>
 
-## How to install this chart
+## Maintainers
 
-Add Delivery Hero public chart repo:
-
-```console
-helm repo add deliveryhero https://charts.deliveryhero.io/
-```
-
-A simple install with default values:
-
-```console
-helm install deliveryhero/cluster-overprovisioner
-```
-
-To install the chart with the release name `my-release`:
-
-```console
-helm install my-release deliveryhero/cluster-overprovisioner
-```
-
-To install with some set values:
-
-```console
-helm install my-release deliveryhero/cluster-overprovisioner --set values_key1=value1 --set values_key2=value2
-```
-
-To install with custom values file:
-
-```console
-helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
-```
+| Name | Email | Url |
+| ---- | ------ | --- |
+| max-rocket-internet | max.williams@deliveryhero.com |  |
+| mmingorance-dh | miguel.mingorance@deliveryhero.com |  |
 
 ## Source Code
 
@@ -58,6 +33,7 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | deployments[0].labels | object | `{}` | Default Deployment - Optional labels tolerations |
 | deployments[0].name | string | `"default"` | Default Deployment - Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) |
 | deployments[0].nodeSelector | object | `{}` | Default Deployment - Node labels for pod assignment |
+| deployments[0].podAnnotations | object | `{}` | Default Deployment - Annotations to add to the pods |
 | deployments[0].replicaCount | int | `3` | Default Deployment - Number of replicas |
 | deployments[0].resources.limits.cpu | string | `"1000m"` | Default Deployment - CPU limit for the overprovision pods |
 | deployments[0].resources.limits.memory | string | `"1000Mi"` | Default Deployment - Memory limit for the overprovision pods |
@@ -75,10 +51,3 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | priorityClassDefault.value | int | `0` | Priority value of the default priorityClass |
 | priorityClassOverprovision.name | string | `"overprovisioning"` | Name of the overprovision priorityClass |
 | priorityClassOverprovision.value | int | `-1` | Priority value of the overprovision priorityClass |
-
-## Maintainers
-
-| Name | Email | Url |
-| ---- | ------ | --- |
-| max-rocket-internet | max.williams@deliveryhero.com |  |
-| mmingorance-dh | miguel.mingorance@deliveryhero.com |  |

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -10,12 +10,37 @@ This approach is the [current recommended method to achieve overprovisioning](ht
 
 **Homepage:** <https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler>
 
-## Maintainers
+## How to install this chart
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| max-rocket-internet | max.williams@deliveryhero.com |  |
-| mmingorance-dh | miguel.mingorance@deliveryhero.com |  |
+Add Delivery Hero public chart repo:
+
+```console
+helm repo add deliveryhero https://charts.deliveryhero.io/
+```
+
+A simple install with default values:
+
+```console
+helm install deliveryhero/cluster-overprovisioner
+```
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release deliveryhero/cluster-overprovisioner
+```
+
+To install with some set values:
+
+```console
+helm install my-release deliveryhero/cluster-overprovisioner --set values_key1=value1 --set values_key2=value2
+```
+
+To install with custom values file:
+
+```console
+helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
+```
 
 ## Source Code
 
@@ -30,10 +55,10 @@ This approach is the [current recommended method to achieve overprovisioning](ht
 | deployments | list | {} | Define optional additional deployments - A default deployment is included by default |
 | deployments[0].affinity | object | `{}` | Default Deployment - Map of node/pod affinities |
 | deployments[0].annotations | object | `{}` | Default Deployment - Annotations to add to the deployment |
+| deployments[0].podAnnotations | object | `{}` | Default Deployment - Annotations for pods in the deployment |
 | deployments[0].labels | object | `{}` | Default Deployment - Optional labels tolerations |
 | deployments[0].name | string | `"default"` | Default Deployment - Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) |
 | deployments[0].nodeSelector | object | `{}` | Default Deployment - Node labels for pod assignment |
-| deployments[0].podAnnotations | object | `{}` | Default Deployment - Annotations to add to the pods |
 | deployments[0].replicaCount | int | `3` | Default Deployment - Number of replicas |
 | deployments[0].resources.limits.cpu | string | `"1000m"` | Default Deployment - CPU limit for the overprovision pods |
 | deployments[0].resources.limits.memory | string | `"1000Mi"` | Default Deployment - Memory limit for the overprovision pods |
@@ -51,3 +76,10 @@ This approach is the [current recommended method to achieve overprovisioning](ht
 | priorityClassDefault.value | int | `0` | Priority value of the default priorityClass |
 | priorityClassOverprovision.name | string | `"overprovisioning"` | Name of the overprovision priorityClass |
 | priorityClassOverprovision.value | int | `-1` | Priority value of the overprovision priorityClass |
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| max-rocket-internet | max.williams@deliveryhero.com |  |
+| mmingorance-dh | miguel.mingorance@deliveryhero.com |  |

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -10,12 +10,37 @@ This approach is the [current recommended method to achieve overprovisioning](ht
 
 **Homepage:** <https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler>
 
-## Maintainers
+## How to install this chart
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| max-rocket-internet | max.williams@deliveryhero.com |  |
-| mmingorance-dh | miguel.mingorance@deliveryhero.com |  |
+Add Delivery Hero public chart repo:
+
+```console
+helm repo add deliveryhero https://charts.deliveryhero.io/
+```
+
+A simple install with default values:
+
+```console
+helm install deliveryhero/cluster-overprovisioner
+```
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release deliveryhero/cluster-overprovisioner
+```
+
+To install with some set values:
+
+```console
+helm install my-release deliveryhero/cluster-overprovisioner --set values_key1=value1 --set values_key2=value2
+```
+
+To install with custom values file:
+
+```console
+helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
+```
 
 ## Source Code
 
@@ -51,3 +76,10 @@ This approach is the [current recommended method to achieve overprovisioning](ht
 | priorityClassDefault.value | int | `0` | Priority value of the default priorityClass |
 | priorityClassOverprovision.name | string | `"overprovisioning"` | Name of the overprovision priorityClass |
 | priorityClassOverprovision.value | int | `-1` | Priority value of the overprovision priorityClass |
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| max-rocket-internet | max.williams@deliveryhero.com |  |
+| mmingorance-dh | miguel.mingorance@deliveryhero.com |  |

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -55,7 +55,6 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | deployments | list | {} | Define optional additional deployments - A default deployment is included by default |
 | deployments[0].affinity | object | `{}` | Default Deployment - Map of node/pod affinities |
 | deployments[0].annotations | object | `{}` | Default Deployment - Annotations to add to the deployment |
-| deployments[0].podAnnotations | object | `{}` | Default Deployment - Annotations for pods in the deployment |
 | deployments[0].labels | object | `{}` | Default Deployment - Optional labels tolerations |
 | deployments[0].name | string | `"default"` | Default Deployment - Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) |
 | deployments[0].nodeSelector | object | `{}` | Default Deployment - Node labels for pod assignment |

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -10,37 +10,12 @@ This approach is the [current recommended method to achieve overprovisioning](ht
 
 **Homepage:** <https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler>
 
-## How to install this chart
+## Maintainers
 
-Add Delivery Hero public chart repo:
-
-```console
-helm repo add deliveryhero https://charts.deliveryhero.io/
-```
-
-A simple install with default values:
-
-```console
-helm install deliveryhero/cluster-overprovisioner
-```
-
-To install the chart with the release name `my-release`:
-
-```console
-helm install my-release deliveryhero/cluster-overprovisioner
-```
-
-To install with some set values:
-
-```console
-helm install my-release deliveryhero/cluster-overprovisioner --set values_key1=value1 --set values_key2=value2
-```
-
-To install with custom values file:
-
-```console
-helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
-```
+| Name | Email | Url |
+| ---- | ------ | --- |
+| max-rocket-internet | max.williams@deliveryhero.com |  |
+| mmingorance-dh | miguel.mingorance@deliveryhero.com |  |
 
 ## Source Code
 
@@ -58,6 +33,7 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | deployments[0].labels | object | `{}` | Default Deployment - Optional labels tolerations |
 | deployments[0].name | string | `"default"` | Default Deployment - Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) |
 | deployments[0].nodeSelector | object | `{}` | Default Deployment - Node labels for pod assignment |
+| deployments[0].podAnnotations | object | `{}` | Default Deployment - Annotations to add to the pods |
 | deployments[0].replicaCount | int | `3` | Default Deployment - Number of replicas |
 | deployments[0].resources.limits.cpu | string | `"1000m"` | Default Deployment - CPU limit for the overprovision pods |
 | deployments[0].resources.limits.memory | string | `"1000Mi"` | Default Deployment - Memory limit for the overprovision pods |
@@ -75,10 +51,3 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | priorityClassDefault.value | int | `0` | Priority value of the default priorityClass |
 | priorityClassOverprovision.name | string | `"overprovisioning"` | Name of the overprovision priorityClass |
 | priorityClassOverprovision.value | int | `-1` | Priority value of the overprovision priorityClass |
-
-## Maintainers
-
-| Name | Email | Url |
-| ---- | ------ | --- |
-| max-rocket-internet | max.williams@deliveryhero.com |  |
-| mmingorance-dh | miguel.mingorance@deliveryhero.com |  |

--- a/stable/cluster-overprovisioner/ci/ct-values.yaml
+++ b/stable/cluster-overprovisioner/ci/ct-values.yaml
@@ -1,6 +1,7 @@
 deployments:
   - name: ci-one
     annotations: {}
+    podAnnotations: {}
     replicaCount: 1
     nodeSelector: {}
     resources: {}
@@ -10,6 +11,7 @@ deployments:
 
   - name: ci-two
     annotations: {}
+    podAnnotations: {}
     replicaCount: 0
     nodeSelector: {}
     resources: {}

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -21,6 +21,10 @@ metadata:
   labels:
     {{- $commonLabels | nindent 4 }}
     app.cluster-overprovisioner/deployment: {{ .name }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
 spec:
   strategy:
     type: Recreate
@@ -31,7 +35,7 @@ spec:
       app.cluster-overprovisioner/deployment: {{ .name }}
   template:
     metadata:
-    {{- with .annotations }}
+    {{- with .podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -46,6 +46,8 @@ deployments:
   - name: default
     # deployments[0].annotations -- Default Deployment - Annotations to add to the deployment
     annotations: {}
+     # deployments[0].podAnnotations -- Default Deployment - Annotations to add to the pods
+    podAnnotations: {}
     # deployments[0].replicaCount -- Default Deployment - Number of replicas
     replicaCount: 3
     # deployments[0].nodeSelector -- Default Deployment - Node labels for pod assignment


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

When using this helm chart we required annotations to be added directly to the top level Deployment object, rather than just at POD level so have updated the chart to use the `annotations` variable for the top level object, and have added a `podAnnotation` variable so POD level annotations can still be supported. This will be a breaking change for people using the `annotations` for POD level annotations, and they will need update inputs to use the `podAnnotations` variable instead.

I am happy for any suggested changes, or variable names to be adjusted. Thanks!

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] Github actions are passing
