### PR TITLE
[stable/node-problem-detector] Add support for imagePullSecrets

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.8.4"
+version: "1.8.5"
 appVersion: v0.8.5
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 1.8.4](https://img.shields.io/badge/Version-1.8.4-informational?style=flat-square) ![AppVersion: v0.8.5](https://img.shields.io/badge/AppVersion-v0.8.5-informational?style=flat-square)
+![Version: 1.8.5](https://img.shields.io/badge/Version-1.8.5-informational?style=flat-square) ![AppVersion: v0.8.5](https://img.shields.io/badge/AppVersion-v0.8.5-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -59,6 +59,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"k8s.gcr.io/node-problem-detector/node-problem-detector"` |  |
 | image.tag | string | `"v0.8.5"` |  |
+| imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | maxUnavailable | int | `1` | The max pods unavailable during an update |
 | metrics.serviceMonitor.additionalLabels | object | `{}` |  |

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -39,6 +39,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "node-problem-detector.serviceAccountName" . }}
+      imagePullSecrets: {{ .Values.imagePullSecrets }}
       hostNetwork: {{ .Values.hostNetwork }}
       hostPID: {{ .Values.hostPID }}
       terminationGracePeriodSeconds: 30

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -53,6 +53,8 @@ image:
   tag: v0.8.5
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Add support for imagePullSecrets for downloading docker images from repository requiring
authentication. May come handy given dockerhub usage quotas introduction. 

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
