### PR TITLE
[stable/node-problem-detector] Fix rendering of imagePullSecrets

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.8.5"
+version: "1.8.6"
 appVersion: v0.8.5
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 1.8.5](https://img.shields.io/badge/Version-1.8.5-informational?style=flat-square) ![AppVersion: v0.8.5](https://img.shields.io/badge/AppVersion-v0.8.5-informational?style=flat-square)
+![Version: 1.8.6](https://img.shields.io/badge/Version-1.8.6-informational?style=flat-square) ![AppVersion: v0.8.5](https://img.shields.io/badge/AppVersion-v0.8.5-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -39,7 +39,9 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "node-problem-detector.serviceAccountName" . }}
-      imagePullSecrets: {{ .Values.imagePullSecrets }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       hostPID: {{ .Values.hostPID }}
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

My previous PR introducing imagePullSecrets was incorrect, as it did not account 
for proper rendering of list. This PR fixes the issue. Using values.yaml as:

```
imagePullSecrets:
  - name: secret1
  - name: secret2
```
it renders properly:
```
      imagePullSecrets:
        - name: secret1
        - name: secret2
```

Sorry for the mess...

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
