### PR TITLE
[stable/locust]Allow config maps to be mounted in locust helm chart

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.9.5"
+version: "0.9.6"
 appVersion: 1.4.1
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.5](https://img.shields.io/badge/Version-0.9.5-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
+![Version: 0.9.6](https://img.shields.io/badge/Version-0.9.6-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -63,7 +63,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| extraConfigMaps | object | `{}` | Extra config maps to be mounted |
+| extraConfigMaps | object | `{}` | Any extra configmaps to mount for the master and worker. Can be used for extra python packages |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -63,7 +63,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| configMaps | object | `{}` | Config Maps to be mounted |
+| extraConfigMaps | object | `{}` | Config Maps to be mounted |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -63,7 +63,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| extraConfigMaps | object | `{}` | Config Maps to be mounted |
+| extraConfigMaps | object | `{}` | Extra config maps to be mounted |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -63,6 +63,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| configMaps | object | `{}` | Config Maps to be mounted |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -63,7 +63,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| extraConfigMaps | object | `{}` | Any extra configmaps to mount for the master and worker. Can be used for extra python packages |
+| extraConfigMaps | object | `{}` |  |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -62,8 +62,8 @@ spec:
             mountPath: /mnt/locust/lib
           - name: config
             mountPath: /config
-{{- if .Values.configMaps }}
-{{- range $key, $value := .Values.configMaps }}
+{{- if .Values.extraConfigMaps }}
+{{- range $key, $value := .Values.extraConfigMaps }}
           - name: {{ $key }}
             mountPath: {{ $value }}
 {{- end }}

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -62,6 +62,12 @@ spec:
             mountPath: /mnt/locust/lib
           - name: config
             mountPath: /config
+{{- if .Values.configMaps }}
+{{- range $key, $value := .Values.configMaps }}
+          - name: {{ $key }}
+            mountPath: {{ $value }}
+{{- end }}
+{{- end}}
         env:
           - name: LOCUST_HOST
             value: "{{ .Values.loadtest.locust_host }}"

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -63,6 +63,12 @@ spec:
             mountPath: /mnt/locust/lib
           - name: config
             mountPath: /config
+{{- if .Values.extraConfigMaps }}
+{{- range $key, $value := .Values.extraConfigMaps }}
+          - name: {{ $key }}
+            mountPath: {{ $value }}
+{{- end }}
+{{- end}}
         env:
           - name: LOCUST_HOST
             value: "{{ .Values.loadtest.locust_host }}"

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -102,6 +102,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+configMaps: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -102,7 +102,8 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-configMaps: {}
+#  extraConfigMaps -- Any extra configmaps to mount for the master and worker. Can be used for extra python packages
+extraConfigMaps: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Allow config maps to be mounted in locust helm chart

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] Github actions are passing
