### PR TITLE
[stable/toxiproxy] Adding toxiproxy frontend

### DIFF
--- a/stable/toxiproxy/Chart.yaml
+++ b/stable/toxiproxy/Chart.yaml
@@ -18,11 +18,12 @@ description: |
     --set toxiproxyConfig=my-toxiproxy-config
   ```
 
-version: "1.2"
+version: "1.3.0"
 appVersion: "2.1.2"
 home: https://github.com/Shopify/toxiproxy
 sources:
   - https://github.com/Shopify/toxiproxy
+  - https://github.com/buckle/toxiproxy-frontend
 maintainers:
   - name: nreymundo
     email: no-reply@deliveryhero.com

--- a/stable/toxiproxy/README.md
+++ b/stable/toxiproxy/README.md
@@ -69,7 +69,7 @@ helm install my-release deliveryhero/toxiproxy -f values.yaml
 | environment | list | `[]` |  |
 | extraLabels | object | `{}` |  |
 | frontend.enabled | bool | `false` |  |
-| frontend.host | string | `nil` |  |
+| frontend.host | string | `"chart-example-ui.local"` |  |
 | frontend.repository | string | `"buckle/toxiproxy-frontend"` |  |
 | frontend.resources | object | `{}` |  |
 | fullnameOverride | string | `""` |  |

--- a/stable/toxiproxy/README.md
+++ b/stable/toxiproxy/README.md
@@ -1,6 +1,6 @@
 # toxiproxy
 
-![Version: 1.2](https://img.shields.io/badge/Version-1.2-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
 
 A TCP proxy to simulate network and system conditions for chaos and resiliency testing.
 
@@ -56,6 +56,7 @@ helm install my-release deliveryhero/toxiproxy -f values.yaml
 ## Source Code
 
 * <https://github.com/Shopify/toxiproxy>
+* <https://github.com/buckle/toxiproxy-frontend>
 
 ## Values
 
@@ -67,6 +68,10 @@ helm install my-release deliveryhero/toxiproxy -f values.yaml
 | deploymentAnnotations | object | `{}` |  |
 | environment | list | `[]` |  |
 | extraLabels | object | `{}` |  |
+| frontend.enabled | bool | `false` |  |
+| frontend.host | string | `nil` |  |
+| frontend.repository | string | `"buckle/toxiproxy-frontend"` |  |
+| frontend.resources | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"shopify/toxiproxy"` |  |

--- a/stable/toxiproxy/templates/_helpers.tpl
+++ b/stable/toxiproxy/templates/_helpers.tpl
@@ -47,6 +47,19 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end -}}
 
+{{- define "toxiproxy_frontend.labels" -}}
+app.kubernetes.io/name: {{ include "toxiproxy.name" . }}-frontend
+helm.sh/chart: {{ include "toxiproxy.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- range $key, $value := .Values.extraLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end -}}
+
 {{/*
 Create the name of the service account to use
 */}}

--- a/stable/toxiproxy/templates/_helpers.tpl
+++ b/stable/toxiproxy/templates/_helpers.tpl
@@ -47,19 +47,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end -}}
 
-{{- define "toxiproxy_frontend.labels" -}}
-app.kubernetes.io/name: {{ include "toxiproxy.name" . }}-frontend
-helm.sh/chart: {{ include "toxiproxy.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- range $key, $value := .Values.extraLabels }}
-{{ $key }}: {{ $value | quote }}
-{{- end }}
-{{- end -}}
-
 {{/*
 Create the name of the service account to use
 */}}

--- a/stable/toxiproxy/templates/deployment-frontend.yaml
+++ b/stable/toxiproxy/templates/deployment-frontend.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: "{{ include "toxiproxy.fullname" . }}-frontend"
   labels:
-{{ include "toxiproxy_frontend.labels" . | indent 4 }}
+{{ include "toxiproxy.labels" . | indent 4 }}
 {{- with .Values.deploymentAnnotations }}
   annotations:
 {{- toYaml . | nindent 4 }}
@@ -15,11 +15,13 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "toxiproxy.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      component: frontend
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "toxiproxy.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        component: frontend
 {{ include "toxiproxy.labels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}

--- a/stable/toxiproxy/templates/deployment-frontend.yaml
+++ b/stable/toxiproxy/templates/deployment-frontend.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.frontend.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "toxiproxy.fullname" . }}-frontend"
+  labels:
+{{ include "toxiproxy_frontend.labels" . | indent 4 }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "toxiproxy.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "toxiproxy.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "toxiproxy.labels" . | indent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}
+    spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+      serviceAccountName: {{ template "toxiproxy.serviceAccountName" . }}
+      securityContext:
+{{- toYaml .Values.podSecurityContext | nindent 8 }}
+{{- if .Values.initContainer }}
+{{ toYaml .Values.initContainer | indent 6 }}
+{{- end }}
+      containers:
+      - name: toxiproxy-frontend
+        resources:
+{{ toYaml .Values.frontend.resources | indent 10 }}
+        image: "{{ .Values.frontend.repository }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+          - containerPort: 8080
+            name: ui
+            protocol: TCP
+        livenessProbe:
+          periodSeconds: 30
+          initialDelaySeconds: 10
+          timeoutSeconds: 30
+          failureThreshold: 2
+          httpGet:
+            path: /
+            port: ui
+        readinessProbe:
+          periodSeconds: 30
+          initialDelaySeconds: 10
+          timeoutSeconds: 30
+          failureThreshold: 2
+          httpGet:
+            path: /
+            port: ui
+        env:
+          - name: TOXIPROXY_URL
+            value: "http://{{ .Release.Name }}"
+  {{- range $key, $value := .Values.environment }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+  {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/stable/toxiproxy/templates/deployment-frontend.yaml
+++ b/stable/toxiproxy/templates/deployment-frontend.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: "{{ include "toxiproxy.fullname" . }}-frontend"
   labels:
+    component: frontend
 {{ include "toxiproxy.labels" . | indent 4 }}
 {{- with .Values.deploymentAnnotations }}
   annotations:

--- a/stable/toxiproxy/templates/ingress-frontend.yaml
+++ b/stable/toxiproxy/templates/ingress-frontend.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.frontend.enabled -}}
+{{- $fullName := include "toxiproxy.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: "{{ $fullName }}-frontend"
+  labels:
+{{ include "toxiproxy.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    - host: {{ .Values.frontend.host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}-frontend
+              servicePort: {{ $svcPort }}
+{{- end }}

--- a/stable/toxiproxy/templates/ingress-frontend.yaml
+++ b/stable/toxiproxy/templates/ingress-frontend.yaml
@@ -10,6 +10,7 @@ kind: Ingress
 metadata:
   name: "{{ $fullName }}-frontend"
   labels:
+    component: frontend
 {{ include "toxiproxy.labels" . | indent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:

--- a/stable/toxiproxy/templates/service-frontend.yaml
+++ b/stable/toxiproxy/templates/service-frontend.yaml
@@ -4,7 +4,8 @@ kind: Service
 metadata:
   name: "{{ include "toxiproxy.fullname" . }}-frontend"
   labels:
-{{ include "toxiproxy_frontend.labels" . | indent 4 }}
+    component: frontend
+{{ include "toxiproxy.labels" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/toxiproxy/templates/service-frontend.yaml
+++ b/stable/toxiproxy/templates/service-frontend.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.frontend.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ include "toxiproxy.fullname" . }}-frontend"
+  labels:
+{{ include "toxiproxy_frontend.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: ui
+      protocol: TCP
+      name: ui
+  selector:
+    app.kubernetes.io/name: {{ include "toxiproxy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/stable/toxiproxy/templates/service-frontend.yaml
+++ b/stable/toxiproxy/templates/service-frontend.yaml
@@ -16,4 +16,5 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "toxiproxy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    component: frontend
 {{- end }}

--- a/stable/toxiproxy/values.yaml
+++ b/stable/toxiproxy/values.yaml
@@ -7,6 +7,14 @@ image:
   tag: 2.1.4
   pullPolicy: IfNotPresent
 
+frontend:
+  repository: buckle/toxiproxy-frontend
+  # Whether we want to deploy the charts for the frontend or not
+  enabled: false
+  resources: {}
+  # Frontend host address to access it
+  host: 
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/stable/toxiproxy/values.yaml
+++ b/stable/toxiproxy/values.yaml
@@ -13,7 +13,7 @@ frontend:
   enabled: false
   resources: {}
   # Frontend host address to access it
-  host:
+  host: chart-example-ui.local
 
 imagePullSecrets: []
 nameOverride: ""

--- a/stable/toxiproxy/values.yaml
+++ b/stable/toxiproxy/values.yaml
@@ -13,7 +13,7 @@ frontend:
   enabled: false
   resources: {}
   # Frontend host address to access it
-  host: 
+  host:
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Added an optional frontend to ToxiProxy that is deployed as a separate pod. 

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] Github actions are passing
