### PR TITLE
[stable/rds-downscaler] Handle empty env values

### DIFF
--- a/stable/rds-downscaler/Chart.yaml
+++ b/stable/rds-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: "1.0.2"
+version: "1.0.3"
 description: |
   A small python script that runs on a cron schedule and periodically downscales AWS RDS instances.
 

--- a/stable/rds-downscaler/README.md
+++ b/stable/rds-downscaler/README.md
@@ -1,6 +1,6 @@
 # rds-downscaler
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A small python script that runs on a cron schedule and periodically downscales AWS RDS instances.
 
@@ -62,7 +62,7 @@ helm install my-release deliveryhero/rds-downscaler -f values.yaml
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| tag | object | `{"key":"environment","value":"staging"}` | AWS tag used to find RDS instances/clusters |
+| tag | object | `{"key":"","values":""}` | AWS tag used to find RDS instances/clusters |
 | tolerations | list | `[]` |  |
 
 ## Maintainers

--- a/stable/rds-downscaler/templates/cronjob.yaml
+++ b/stable/rds-downscaler/templates/cronjob.yaml
@@ -36,12 +36,18 @@ spec:
               args: ["/usr/local/bin/python", "-u", "/config/run.py"]
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               env:
+              {{- if .Values.tag.key }}
               - name: TAG_KEY
                 value: {{ .Values.tag.key }}
+              {{- end }}
+              {{- if .Values.tag.values }}
               - name: TAG_VALUES
                 value: {{ .Values.tag.values }}
+              {{- end }}
+              {{- if .Values.instanceIdentifier }}
               - name: INSTANCE_IDENTIFIER
                 value: {{ .Values.instanceIdentifier }}
+              {{- end }}
     {{- range $key, $value := .Values.environment }}
               - name: {{ $key }}
                 value: {{ $value | quote }}

--- a/stable/rds-downscaler/values.yaml
+++ b/stable/rds-downscaler/values.yaml
@@ -1,9 +1,9 @@
 # tag -- AWS tag used to find RDS instances/clusters
 tag:
   # key -- The tag name
-  key: environment
+  key: ""
   # value -- The tag value
-  value: staging
+  values: ""
 
 # instanceIdentifier -- AWS RDS instance identifier
 instanceIdentifier: ""


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

This PR handles the empty values for environment variables correctly for rds-downscaler chart. Default values for tag_key and tag_values has been set to empty strings.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
