### PR TITLE
[stable/locust] add options for headless

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.9.8"
+version: "0.9.9"
 appVersion: 1.4.1
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -74,7 +74,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.tls | list | `[]` |  |
-| loadtest.environment | object | `{}` | environment variables used in the load test |
+| loadtest.environment | object | `{}` | environment variables used in the load test for both master and workers |
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |
 | loadtest.locust_lib_configmap | string | `""` | name of a configmap containing your lib |
@@ -82,9 +82,11 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.locust_locustfile_configmap | string | `""` | name of a configmap containing your locustfile |
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |
+| master.args | list | `[]` | Any extra command args for the master |
 | master.args_include_default | bool | `true` | Whether to include default command args |
 | master.command[0] | string | `"sh"` |  |
 | master.command[1] | string | `"/config/docker-entrypoint.sh"` |  |
+| master.environment | object | `{}` | environment variables for the master |
 | master.image | string | `""` | A custom docker image including tag |
 | master.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
 | master.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the master pod |
@@ -99,9 +101,11 @@ helm install my-release deliveryhero/locust -f values.yaml
 | service.extraLabels | object | `{}` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |
+| worker.args | list | `[]` | Any extra command args for the workers |
 | worker.args_include_default | bool | `true` | Whether to include default command args |
 | worker.command[0] | string | `"sh"` |  |
 | worker.command[1] | string | `"/config/docker-entrypoint.sh"` |  |
+| worker.environment | object | `{}` | environment variables for the workers |
 | worker.hpa.enabled | bool | `false` |  |
 | worker.hpa.maxReplicas | int | `100` |  |
 | worker.hpa.minReplicas | int | `1` |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.8](https://img.shields.io/badge/Version-0.9.8-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
+![Version: 0.9.9](https://img.shields.io/badge/Version-0.9.9-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -75,6 +75,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.tls | list | `[]` |  |
 | loadtest.environment | object | `{}` | environment variables used in the load test |
+| loadtest.headless | bool | `false` | whether to run locust with headless settings |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |
 | loadtest.locust_lib_configmap | string | `""` | name of a configmap containing your lib |
 | loadtest.locust_locustfile | string | `"main.py"` | the name of the locustfile |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -78,6 +78,10 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
 {{- end }}
+{{- range $key, $value := .Values.master.environment }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+{{- end }}
 {{- range $key, $value := .Values.loadtest.environment_secret }}
           - name: {{ $key }}
             valueFrom:

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -51,6 +51,9 @@ spec:
           - --locustfile=/mnt/locust/{{ .Values.loadtest.locust_locustfile }}
           - --host={{ .Values.loadtest.locust_host }}
           - --loglevel={{ .Values.master.logLevel }}
+{{- if .Values.loadtest.headless }}
+          - --headless
+{{- end }}
 {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
@@ -92,22 +95,19 @@ spec:
           - containerPort: 5558
             name: loc-master-p2
             protocol: TCP
-        livenessProbe:
-          periodSeconds: 30
-          initialDelaySeconds: 10
-          timeoutSeconds: 30
-          failureThreshold: 2
-          httpGet:
-            path: /
-            port: 8089
         readinessProbe:
           initialDelaySeconds: 5
           periodSeconds: 30
           timeoutSeconds: 30
           failureThreshold: 2
+{{- if .Values.loadtest.headless }}
+          tcpSocket:
+            port: 5557
+{{ else }}
           httpGet:
             path: /
             port: 8089
+{{- end }}
       restartPolicy: Always
       volumes:
         - name: lib

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -76,6 +76,10 @@ spec:
             value: "{{ template "locust.fullname" . }}"
           - name: LOCUST_MASTER_PORT
             value: "5557"
+{{- range $key, $value := .Values.worker.environment }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+{{- end }}
 {{- range $key, $value := .Values.loadtest.environment }}
           - name: {{ $key }}
             value: {{ $value | quote }}

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -14,6 +14,8 @@ loadtest:
   # loadtest.environment -- environment variables used in the load test
   environment: {}
     # VAR: VALUE
+  # loadtest.headless -- whether to run locust with headless settings
+  headless: false
 
 image:
   repository: locustio/locust

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -11,7 +11,7 @@ loadtest:
   locust_host: https://www.google.com
   # loadtest.pip_packages -- a list of extra python pip packages to install
   pip_packages: []
-  # loadtest.environment -- environment variables used in the load test
+  # loadtest.environment -- environment variables used in the load test for both master and workers
   environment: {}
     # VAR: VALUE
   # loadtest.headless -- whether to run locust with headless settings
@@ -41,8 +41,12 @@ master:
     #   cpu: 1000m
     #   memory: 1024Mi
   serviceAccountAnnotations: {}
+  # master.environment -- environment variables for the master
+  environment: {}
   # master.args_include_default -- Whether to include default command args
   args_include_default: true
+  # master.args -- Any extra command args for the master
+  args: []
   command:
     - sh
     - /config/docker-entrypoint.sh
@@ -72,8 +76,12 @@ worker:
     #   cpu: 500m
     #   memory: 256Mi
   serviceAccountAnnotations: {}
+  # worker.environment -- environment variables for the workers
+  environment: {}
   # worker.args_include_default -- Whether to include default command args
   args_include_default: true
+  # worker.args -- Any extra command args for the workers
+  args: []
   command:
     - sh
     - /config/docker-entrypoint.sh


### PR DESCRIPTION
- Also removing liveliness probe as I don't think it's ever useful to have the master restarted.
- Add separate env vars for master/worker
- Add doc for master/worker `args`

Resolves https://github.com/deliveryhero/helm-charts/issues/108

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
