### PR TITLE
WIP: [stable/cluster-overprovisoner] Add service account to cluster-overprovisioner chart

### DIFF
--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -76,6 +76,11 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | priorityClassDefault.value | int | `0` | Priority value of the default priorityClass |
 | priorityClassOverprovision.name | string | `"overprovisioning"` | Name of the overprovision priorityClass |
 | priorityClassOverprovision.value | int | `-1` | Priority value of the overprovision priorityClass |
+| serviceAccount.annotations | object | `{}` | Additional Service Account annotations. |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for a Service Account. |
+| serviceAccount.create | bool | `true` | Determine whether a Service Account should be created or it should reuse a exiting one. |
+| serviceAccount.name | string | `""` | The name of the ServiceAccount to use. If not set and create is `true`, a name is generated using the fullname template. |
+
 
 ## Maintainers
 

--- a/stable/cluster-overprovisioner/templates/_helpers.tpl
+++ b/stable/cluster-overprovisioner/templates/_helpers.tpl
@@ -64,3 +64,14 @@ Common labels
 app.kubernetes.io/name: {{ include "cluster-overprovisioner.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{/*
+Return the cluster-overprovisioner service account name
+*/}}
+{{- define "cluster-overprovisioner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cluster-overprovisioner.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -46,6 +46,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      serviceAccountName: {{ template "cluster-overprovisioner.serviceAccountName" . }}
       priorityClassName: {{ $priorityClassName }}
       securityContext:
         {{- toYaml $podSecurityContext | nindent 8 }}

--- a/stable/cluster-overprovisioner/templates/serviceaccount.yaml
+++ b/stable/cluster-overprovisioner/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cluster-overprovisioner.serviceAccountName" . }}
+  labels: {{ include "cluster-overprovisioner.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -69,3 +69,15 @@ deployments:
     affinity: {}
     # deployments[0].labels -- Default Deployment - Optional labels tolerations
     labels: {}
+
+serviceAccount:
+  create: true
+  ## Service Account for pods
+  ##
+  name:
+  ## Annotations for the Service Account
+  ##
+  annotations: {}
+  ## Automount API credentials for a service account.
+  ##
+  automountServiceAccountToken: true


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Allow for configuring a non-default service account for the cluster-overprovisioner

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] Github actions are passing
