### PR TITLE
[stable/cluster-overprovisioner] Add service account to cluster-overprovisioner chart

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.5.0
+version: 0.6.0
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -76,6 +76,10 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | priorityClassDefault.value | int | `0` | Priority value of the default priorityClass |
 | priorityClassOverprovision.name | string | `"overprovisioning"` | Name of the overprovision priorityClass |
 | priorityClassOverprovision.value | int | `-1` | Priority value of the overprovision priorityClass |
+| serviceAccount.annotations | object | `{}` | Additional Service Account annotations |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for a Service Account |
+| serviceAccount.create | bool | `true` | Determine whether a Service Account should be created or it should reuse an exiting one |
+| serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is `true`, a name is generated using the fullname template |
 
 ## Maintainers
 

--- a/stable/cluster-overprovisioner/templates/_helpers.tpl
+++ b/stable/cluster-overprovisioner/templates/_helpers.tpl
@@ -64,3 +64,14 @@ Common labels
 app.kubernetes.io/name: {{ include "cluster-overprovisioner.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+Return the cluster-overprovisioner service account name
+*/}}
+{{- define "cluster-overprovisioner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cluster-overprovisioner.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -12,6 +12,7 @@
 {{- $imageTag := .Values.image.tag }}
 {{- $pullPolicy := .Values.image.pullPolicy }}
 {{- $imagePullSecrets := .Values.image.pullSecrets }}
+{{- $serviceAccountName := include "cluster-overprovisioner.serviceAccountName" . -}}
 
 {{ range .Values.deployments }}
 apiVersion: apps/v1
@@ -46,6 +47,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      serviceAccountName: {{ $serviceAccountName }}
       priorityClassName: {{ $priorityClassName }}
       securityContext:
         {{- toYaml $podSecurityContext | nindent 8 }}

--- a/stable/cluster-overprovisioner/templates/serviceaccount.yaml
+++ b/stable/cluster-overprovisioner/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cluster-overprovisioner.serviceAccountName" . }}
+  labels: {{ include "cluster-overprovisioner.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -69,3 +69,13 @@ deployments:
     affinity: {}
     # deployments[0].labels -- Default Deployment - Optional labels tolerations
     labels: {}
+
+serviceAccount:
+  # serviceAccount.create -- Determine whether a Service Account should be created or it should reuse an exiting one
+  create: true
+  # serviceAccount.name -- The name of the ServiceAccount to use. If not set and create is `true`, a name is generated using the fullname template
+  name:
+  # serviceAccount.annotations -- Additional Service Account annotations
+  annotations: {}
+  # serviceAccount.automountServiceAccountToken -- Automount API credentials for a Service Account
+  automountServiceAccountToken: true


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Add ability to use a non-default service account for the cluster-overprovisioner

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
