### PR TITLE
[stable/kube-downscaler] upgrade image and clusterrole to enable usage with horizontalpodautoscalers 

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,14 +1,15 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.2"
-appVersion: 0.5.1
+version: "0.3"
+appVersion: 21.2.0
 description: Scale down Kubernetes deployments after work hours
 keywords:
 - k8s pods scheduler
 - scheduled lifecycle
 sources:
-- https://github.com/hjacobs/kube-downscaler
-home: https://github.com/hjacobs/kube-downscaler
+- https://github.com/deliveryhero/helm-charts
+- https://codeberg.org/hjacobs/kube-downscaler
+home: https://codeberg.org/hjacobs/kube-downscaler
 maintainers:
 - name: hjacobs
-  url: https://github.com/hjacobs
+  url: https://codeberg.org/hjacobs

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,10 +1,10 @@
 # kube-downscaler
 
-![Version: 0.2](https://img.shields.io/badge/Version-0.2-informational?style=flat-square) ![AppVersion: 0.5.1](https://img.shields.io/badge/AppVersion-0.5.1-informational?style=flat-square)
+![Version: 0.3](https://img.shields.io/badge/Version-0.3-informational?style=flat-square) ![AppVersion: 21.2.0](https://img.shields.io/badge/AppVersion-21.2.0-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 
-**Homepage:** <https://github.com/hjacobs/kube-downscaler>
+**Homepage:** <https://codeberg.org/hjacobs/kube-downscaler>
 
 ## How to install this chart
 
@@ -40,7 +40,8 @@ helm install my-release deliveryhero/kube-downscaler -f values.yaml
 
 ## Source Code
 
-* <https://github.com/hjacobs/kube-downscaler>
+* <https://github.com/deliveryhero/helm-charts>
+* <https://codeberg.org/hjacobs/kube-downscaler>
 
 ## Values
 
@@ -54,7 +55,7 @@ helm install my-release deliveryhero/kube-downscaler -f values.yaml
 | image.args | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"hjacobs/kube-downscaler"` |  |
-| image.tag | string | `"19.10.1"` |  |
+| image.tag | string | `"21.2.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | interval | int | `60` |  |
 | nameOverride | string | `""` |  |
@@ -83,4 +84,4 @@ helm install my-release deliveryhero/kube-downscaler -f values.yaml
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| hjacobs |  | https://github.com/hjacobs |
+| hjacobs |  | https://codeberg.org/hjacobs |

--- a/stable/kube-downscaler/templates/clusterrole.yaml
+++ b/stable/kube-downscaler/templates/clusterrole.yaml
@@ -18,9 +18,11 @@ rules:
 - apiGroups:
   - extensions
   - apps
+  - autoscaling
   resources:
   - deployments
   - statefulsets
+  - horizontalpodautoscalers
   verbs:
   - get
   - watch

--- a/stable/kube-downscaler/values.yaml
+++ b/stable/kube-downscaler/values.yaml
@@ -21,7 +21,7 @@ rbac:
 
 image:
   repository: hjacobs/kube-downscaler
-  tag: 19.10.1
+  tag: 21.2.0
   pullPolicy: IfNotPresent
   args: []
     # --default-uptime="Mon-Fri 07:30-20:30 Europe/Berlin"


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
Hi :wave:
<!--- Describe your changes in detail -->
This updates the image used by the Helm chart to allow usage of the downscaler with HPAs. The `ClusterRole` has been amended to allow the `kube-downscaler` to interact with the API. 

A few links pointed to the archived github.com repos that Henning Jacobs used to use, I've updated the links to point at the new location on codeberg.org and added a link to this repo to help users discover more of your useful charts. 

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
