### PR TITLE
[stable/node-problem-detector] mountvolume and cli args improvement

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.8.7"
+version: "2.0.0"
 appVersion: v0.8.7
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 1.8.7](https://img.shields.io/badge/Version-1.8.7-informational?style=flat-square) ![AppVersion: v0.8.7](https://img.shields.io/badge/AppVersion-v0.8.7-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: v0.8.7](https://img.shields.io/badge/AppVersion-v0.8.7-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -55,12 +55,13 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | Run pod on host network Flag to run Node Problem Detector on the host's network. This is typically not recommended, but may be useful for certain use cases. |
 | hostPID | bool | `false` |  |
-| hostpath.logdir | string | `"/var/log/"` | Log directory path on K8s host |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"k8s.gcr.io/node-problem-detector/node-problem-detector"` |  |
 | image.tag | string | `"v0.8.7"` |  |
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
+| logDir.host | string | `"/var/log/"` | log directory on k8s host |
+| logDir.pod | string | `""` | log directory on pod (volume mount), use logDir.host if empty |
 | maxUnavailable | int | `1` | The max pods unavailable during an update |
 | metrics.serviceMonitor.additionalLabels | object | `{}` |  |
 | metrics.serviceMonitor.enabled | bool | `false` |  |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -61,7 +61,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |
-| logDir.pod | string | `""` | log directory on pod (volume mount), use logDir.host if empty |
+| logDir.pod | string | `""` | log directory in pod (volume mount), use logDir.host if empty |
 | maxUnavailable | int | `1` | The max pods unavailable during an update |
 | metrics.serviceMonitor.additionalLabels | object | `{}` |  |
 | metrics.serviceMonitor.enabled | bool | `false` |  |

--- a/stable/node-problem-detector/templates/_helpers.tpl
+++ b/stable/node-problem-detector/templates/_helpers.tpl
@@ -59,3 +59,37 @@ Return the appropriate apiVersion for podSecurityPolicy.
 {{- print "extensions/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+  Concat npd.config.* to make node-problem-detector CLI args more readable
+*/}}
+{{- define "npd.cli.args" -}}
+{{ include "npd.config.systemLogMonitor" . }}{{ include "npd.config.customPluginMonitor" . }}{{ include "npd.config.prometheus" . }}{{ include "npd.config.k8sExporter" . }}
+{{- end -}}
+
+{{- define "npd.config.systemLogMonitor" -}}
+--config.system-log-monitor=
+{{- range $index, $monitor := .Values.settings.log_monitors -}}
+  {{- if ne $index 0 -}},{{- end -}}
+  {{- $monitor -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "npd.config.customPluginMonitor" -}}
+{{- if .Values.settings.custom_plugin_monitors -}}
+--confgi.custom-plugin-monitors=
+{{- range $index, $monitor := .Values.settings.custom_plugin_monitors -}}
+  {{- if ne $index 0 -}},{{- end -}}
+  {{- $monitor -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "npd.config.prometheus" -}}
+{{- printf "--prometheus-address=%s --prometheus-port=%.0f " .Values.settings.prometheus_address .Values.settings.prometheus_port -}}
+{{- end -}}
+
+{{- define "npd.config.k8sExporter" -}}
+--k8s-exporter-heartbeat-period={{ .Values.settings.heartBeatPeriod }}
+{{- end -}}

--- a/stable/node-problem-detector/templates/_helpers.tpl
+++ b/stable/node-problem-detector/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Return the appropriate apiVersion for podSecurityPolicy.
 
 {{- define "npd.config.customPluginMonitor" -}}
 {{- if .Values.settings.custom_plugin_monitors -}}
---confgi.custom-plugin-monitors=
+--config.custom-plugin-monitors=
 {{- range $index, $monitor := .Values.settings.custom_plugin_monitors -}}
   {{- if ne $index 0 -}},{{- end -}}
   {{- $monitor -}}

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -55,11 +55,11 @@ spec:
           command:
             - "/bin/sh"
             - "-c"
-            - "exec /node-problem-detector --logtostderr --config.system-log-monitor={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- if .Values.settings.custom_plugin_monitors }} --custom-plugin-monitors={{- range $index, $monitor := .Values.settings.custom_plugin_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- end }} --prometheus-address={{ .Values.settings.prometheus_address }} --prometheus-port={{ .Values.settings.prometheus_port }} --k8s-exporter-heartbeat-period={{ .Values.settings.heartBeatPeriod }}"
-{{- if .Values.securityContext }}
+            - "exec /node-problem-detector --logtostderr {{ include "npd.cli.args" $ }}"
+          {{- if .Values.securityContext }}
           securityContext:
-{{ toYaml .Values.securityContext | indent 12 }}
-{{- end }}
+          {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           env:
             - name: NODE_NAME
               valueFrom:

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -70,7 +70,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: log
-              mountPath: {{ .Values.hostpath.logdir }}
+              mountPath: {{ default (default "/var/log/" .Values.logDir.host) .Values.logDir.pod }}
             - name: localtime
               mountPath: /etc/localtime
               readOnly: true
@@ -100,7 +100,7 @@ spec:
       volumes:
         - name: log
           hostPath:
-            path: {{ .Values.hostpath.logdir }}
+            path: {{ default "/var/log/" .Values.logDir.host }}
         - name: localtime
           hostPath:
             path: /etc/localtime

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -13,10 +13,10 @@ metadata:
 spec:
   updateStrategy:
     type: {{ .Values.updateStrategy }}
-{{- if eq .Values.updateStrategy "RollingUpdate"}}
+    {{- if eq .Values.updateStrategy "RollingUpdate"}}
     rollingUpdate:
       maxUnavailable: {{ .Values.maxUnavailable }}
-{{- end}}
+    {{- end}}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
@@ -34,9 +34,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/custom-config-configmap.yaml") . | sha256sum }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
-{{- if .Values.annotations }}
-{{ toYaml .Values.annotations | indent 8 }}
-{{- end }}
+        {{- if .Values.annotations }}
+        {{- toYaml .Values.annotations | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "node-problem-detector.serviceAccountName" . }}
       {{- if .Values.imagePullSecrets }}
@@ -65,9 +65,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-{{- if .Values.env }}
-{{ toYaml .Values.env | indent 12 }}
-{{- end }}
+          {{- if .Values.env }}
+          {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: log
               mountPath: {{ .Values.hostpath.logdir }}
@@ -77,26 +77,26 @@ spec:
             - name: custom-config
               mountPath: /custom-config
               readOnly: true
-{{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | indent 12 }}
-{{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.settings.prometheus_port }}
               name: exporter
           resources:
-{{ toYaml .Values.resources | indent 12 }}
-    {{- with .Values.affinity }}
+          {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-{{- if .Values.nodeSelector }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-{{- end }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
       volumes:
         - name: log
           hostPath:
@@ -108,6 +108,6 @@ spec:
         - name: custom-config
           configMap:
             name: {{ include "node-problem-detector.customConfig" . }}
-{{- if .Values.extraVolumes }}
-{{ toYaml .Values.extraVolumes | indent 8 }}
-{{- end }}
+      {{- if .Values.extraVolumes }}
+      {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}

--- a/stable/node-problem-detector/templates/servicemonitor.yaml
+++ b/stable/node-problem-detector/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- toYaml .Values.metrics.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -44,9 +44,11 @@ settings:
   # settings.heartBeatPeriod -- Syncing interval with API server
   heartBeatPeriod: 5m0s
 
-hostpath:
-  # hostpath.logdir -- Log directory path on K8s host
-  logdir: /var/log/
+logDir:
+  # logDir.host -- log directory on k8s host
+  host: /var/log/
+  # logDir.pod -- log directory on pod (volume mount), use logDir.host if empty
+  pod: ""
 
 image:
   repository: k8s.gcr.io/node-problem-detector/node-problem-detector

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -47,7 +47,7 @@ settings:
 logDir:
   # logDir.host -- log directory on k8s host
   host: /var/log/
-  # logDir.pod -- log directory on pod (volume mount), use logDir.host if empty
+  # logDir.pod -- log directory in pod (volume mount), use logDir.host if empty
   pod: ""
 
 image:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

This PR attempt to make the chart more flexible using different log directory in host and in pod. This improvement allows to keep default configuration even if the log directory is not on `/var/log/`. This modification implies Breaking Changes as `hostpath.logdir` is replaced by `logDir.host` and `logDir.pod` (see https://github.com/deliveryhero/helm-charts/commit/48c42008adbf9cfb1f37bf9f7ece8a0adf170b3d)

Another improvement is to move the node-problem-detector cli args to _helpers, this change make the chart more readable (see https://github.com/deliveryhero/helm-charts/commit/081204842f8efbc987b8a74b0d8a09955136dd2e)

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
