### PR TITLE
[stable/node-problem-detector] fix npd cli args

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.0.0"
+version: "2.0.1"
 appVersion: v0.8.7
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: v0.8.7](https://img.shields.io/badge/AppVersion-v0.8.7-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: v0.8.7](https://img.shields.io/badge/AppVersion-v0.8.7-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 

--- a/stable/node-problem-detector/templates/_helpers.tpl
+++ b/stable/node-problem-detector/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Return the appropriate apiVersion for podSecurityPolicy.
   Concat npd.config.* to make node-problem-detector CLI args more readable
 */}}
 {{- define "npd.cli.args" -}}
-{{ include "npd.config.systemLogMonitor" . }}{{ include "npd.config.customPluginMonitor" . }}{{ include "npd.config.prometheus" . }}{{ include "npd.config.k8sExporter" . }}
+{{ include "npd.config.systemLogMonitor" . }} {{ include "npd.config.customPluginMonitor" . }} {{ include "npd.config.prometheus" . }} {{ include "npd.config.k8sExporter" . }}
 {{- end -}}
 
 {{- define "npd.config.systemLogMonitor" -}}
@@ -78,7 +78,7 @@ Return the appropriate apiVersion for podSecurityPolicy.
 
 {{- define "npd.config.customPluginMonitor" -}}
 {{- if .Values.settings.custom_plugin_monitors -}}
---config.custom-plugin-monitors=
+--config.custom-plugin-monitor=
 {{- range $index, $monitor := .Values.settings.custom_plugin_monitors -}}
   {{- if ne $index 0 -}},{{- end -}}
   {{- $monitor -}}
@@ -87,7 +87,7 @@ Return the appropriate apiVersion for podSecurityPolicy.
 {{- end -}}
 
 {{- define "npd.config.prometheus" -}}
-{{- printf "--prometheus-address=%s --prometheus-port=%.0f " .Values.settings.prometheus_address .Values.settings.prometheus_port -}}
+{{- printf "--prometheus-address=%s --prometheus-port=%.0f" .Values.settings.prometheus_address .Values.settings.prometheus_port -}}
 {{- end -}}
 
 {{- define "npd.config.k8sExporter" -}}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Change cli flag `--config.custom-plugin-monitors` by `--config.custom-plugin-monitor`
Fix args spaces

Both issues introduced by https://github.com/deliveryhero/helm-charts/pull/123, my apologized 

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] Github actions are passing
