### PR TITLE
[stable/locust] fix locust static files notfound when use ingress & use locust ver1.4.3

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: locust
-version: "0.9.9"
-appVersion: 1.4.1
+version: "0.9.10"
+appVersion: 1.4.3
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png
 maintainers:

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.9](https://img.shields.io/badge/Version-0.9.9-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
+![Version: 0.9.10](https://img.shields.io/badge/Version-0.9.10-informational?style=flat-square) ![AppVersion: 1.4.3](https://img.shields.io/badge/AppVersion-1.4.3-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -68,7 +68,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"locustio/locust"` |  |
-| image.tag | string | `"1.4.1"` |  |
+| image.tag | string | `"1.4.3"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/stable/locust/templates/master-ingress.yaml
+++ b/stable/locust/templates/master-ingress.yaml
@@ -30,7 +30,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
+          - path: /*
             backend:
               serviceName: {{ $fullName }}
               servicePort: 8089

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -19,7 +19,7 @@ loadtest:
 
 image:
   repository: locustio/locust
-  tag: 1.4.1
+  tag: 1.4.3
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
- Locust static files(e.g.  `./static/css/application.css?v=1.4.3` ) Not Found when I use ingress
- `locustio/locust:1.4.3` is released 2 months ago [(docker hub)](https://hub.docker.com/r/locustio/locust/tags?page=1&ordering=last_updated)

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
