### PR TITLE
[stable/kubecost-reports-exporter] fix kubecost url mismatch

### DIFF
--- a/stable/kubecost-reports-exporter/Chart.yaml
+++ b/stable/kubecost-reports-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: kubecost-reports-exporter
 description: Helm chart for exporting kubernetes cost reports to S3
 home: https://www.kubecost.com
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "1.0.0"
 maintainers:
 - name: nyambati

--- a/stable/kubecost-reports-exporter/README.md
+++ b/stable/kubecost-reports-exporter/README.md
@@ -1,6 +1,6 @@
 # kubecost-reports-exporter
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for exporting kubernetes cost reports to S3
 
@@ -65,7 +65,7 @@ helm install my-release deliveryhero/kubecost-reports-exporter -f values.yaml
 | podSecurityContext | object | `{}` |  |
 | resources | object | `{}` |  |
 | restartPolicy | string | `"OnFailure"` |  |
-| schedule | string | `"\"0 * * * *\""` |  |
+| schedule | string | `"0 * * * *"` |  |
 | securityContext | object | `{}` |  |
 | serviceAccountName | string | `""` |  |
 | successfulJobsHistoryLimit | int | `1` |  |

--- a/stable/kubecost-reports-exporter/templates/aggregated-reports.yaml
+++ b/stable/kubecost-reports-exporter/templates/aggregated-reports.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "kubecost-reports-exporter.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.schedule }}
+  schedule: {{ .Values.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
   concurrencyPolicy: {{ .Values.concurrencyPolicy }}
   jobTemplate:
@@ -49,5 +49,5 @@ spec:
               - name: KUBECOST_ENDPOINT
                 value: {{ required "Kubecost analyzer endpoint is a required value" .Values.kubecost.analyzerEndpoint | quote }}
               - name: KUBECOST_URL
-                value: {{ required "Kubecost reports url is a required value" .Values.kubecost.nonAggregatedCostUrl  | quote }}
+                value: {{ required "Kubecost reports url is a required value" .Values.kubecost.aggregatedCostUrl  | quote }}
           restartPolicy: {{ .Values.restartPolicy }}

--- a/stable/kubecost-reports-exporter/templates/non-aggregated-reports.yaml
+++ b/stable/kubecost-reports-exporter/templates/non-aggregated-reports.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "kubecost-reports-exporter.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.schedule }}
+  schedule: {{ .Values.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
   concurrencyPolicy: {{ .Values.concurrencyPolicy }}
   jobTemplate:

--- a/stable/kubecost-reports-exporter/values.yaml
+++ b/stable/kubecost-reports-exporter/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-schedule: '"0 * * * *"'
+schedule: "0 * * * *"
 restartPolicy: OnFailure
 successfulJobsHistoryLimit: 1
 concurrencyPolicy: Forbid


### PR DESCRIPTION

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] Github actions are passing
