### PR TITLE
[stable/cluster-overprovisioner] Support pod topology spread constraints

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "3.1"
 description: |
   This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 

--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.6.0
+version: 0.6.1
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.6.1
+version: 0.6.2
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.6.2
+version: 0.7.0
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![AppVersion: 3.1](https://img.shields.io/badge/AppVersion-3.1-informational?style=flat-square)
+![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![AppVersion: 3.1](https://img.shields.io/badge/AppVersion-3.1-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -52,7 +52,7 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| deployments | list | {} | Define optional additional deployments - A default deployment is included by default |
+| deployments | list | [] | Define optional additional deployments - A default deployment is included by default |
 | deployments[0].affinity | object | `{}` | Default Deployment - Map of node/pod affinities |
 | deployments[0].annotations | object | `{}` | Default Deployment - Annotations to add to the deployment |
 | deployments[0].labels | object | `{}` | Default Deployment - Optional labels tolerations |

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![AppVersion: 3.1](https://img.shields.io/badge/AppVersion-3.1-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: 3.1](https://img.shields.io/badge/AppVersion-3.1-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -65,6 +65,7 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | deployments[0].resources.requests.cpu | string | `"1000m"` | Default Deployment - CPU requested for the overprovision pods |
 | deployments[0].resources.requests.memory | string | `"1000Mi"` | Default Deployment - Memory requested for the overprovision pods |
 | deployments[0].tolerations | list | `[]` | Default Deployment - Optional deployment tolerations |
+| deployments[0].topologySpreadConstraints | list | `[]` | Default Deployment - Optional topology spread constraints |
 | fullnameOverride | string | `""` | Override the fullname of the chart |
 | image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | image.repository | string | `"k8s.gcr.io/pause"` | Image repository |

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![AppVersion: 3.1](https://img.shields.io/badge/AppVersion-3.1-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -68,7 +68,7 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | fullnameOverride | string | `""` | Override the fullname of the chart |
 | image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | image.repository | string | `"k8s.gcr.io/pause"` | Image repository |
-| image.tag | float | `3.1` | Image tag |
+| image.tag | string | `.Chart.AppVersion` | Image tag |
 | nameOverride | string | `""` | Override the name of the chart |
 | podSecurityContext | object | `{}` | Pod security context object |
 | priorityClassDefault.enabled | bool | `true` | If true, enable default priorityClass |

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -14,7 +14,8 @@
 {{- $imagePullSecrets := .Values.image.pullSecrets }}
 {{- $serviceAccountName := include "cluster-overprovisioner.serviceAccountName" . -}}
 
-{{ range .Values.deployments }}
+{{- range .Values.deployments }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -75,5 +76,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
----
 {{- end }}

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -15,6 +15,7 @@
 {{- $serviceAccountName := include "cluster-overprovisioner.serviceAccountName" . -}}
 
 {{- range .Values.deployments }}
+{{- $deploymentName := .name }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -22,7 +23,7 @@ metadata:
   name: "{{ $fullname }}-{{ .name }}"
   labels:
     {{- $commonLabels | nindent 4 }}
-    app.cluster-overprovisioner/deployment: {{ .name }}
+    app.cluster-overprovisioner/deployment: {{ $deploymentName }}
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 8 }}
@@ -34,7 +35,7 @@ spec:
   selector:
     matchLabels:
       {{- $matchLabels | nindent 6 }}
-      app.cluster-overprovisioner/deployment: {{ .name }}
+      app.cluster-overprovisioner/deployment: {{ $deploymentName }}
   template:
     metadata:
     {{- with .podAnnotations }}
@@ -43,7 +44,7 @@ spec:
     {{- end }}
       labels:
         {{- $commonLabels | nindent 8 }}
-        app.cluster-overprovisioner/deployment: {{ .name }}
+        app.cluster-overprovisioner/deployment: {{ $deploymentName }}
     {{- with .labels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -75,5 +76,15 @@ spec:
     {{- with .tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- range . }}
+        - labelSelector:
+            matchLabels:
+              {{- $matchLabels | nindent 6 }}
+              app.cluster-overprovisioner/deployment: {{ $deploymentName }}
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -9,7 +9,7 @@
 {{- $podSecurityContext := .Values.podSecurityContext }}
 {{- $priorityClassName := .Values.priorityClassOverprovision.name }}
 {{- $repository := .Values.image.repository }}
-{{- $imageTag := .Values.image.tag }}
+{{- $imageTag := default .Chart.AppVersion .Values.image.tag }}
 {{- $pullPolicy := .Values.image.pullPolicy }}
 {{- $imagePullSecrets := .Values.image.pullSecrets }}
 {{- $serviceAccountName := include "cluster-overprovisioner.serviceAccountName" . -}}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -41,7 +41,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 # deployments -- Define optional additional deployments - A default deployment is included by default
-# @default -- {}
+# @default -- []
 deployments:
   # deployments[0].name -- Default Deployment - Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules)
   - name: default

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -21,7 +21,8 @@ image:
   # image.repository -- Image repository
   repository: k8s.gcr.io/pause
   # image.tag -- Image tag
-  tag: 3.1
+  # @default -- `.Chart.AppVersion`
+  tag: ""
   # image.pullPolicy -- Container pull policy
   pullPolicy: IfNotPresent
 

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -70,6 +70,14 @@ deployments:
     affinity: {}
     # deployments[0].labels -- Default Deployment - Optional labels tolerations
     labels: {}
+    # deployments[0].topologySpreadConstraints -- Default Deployment - Optional topology spread constraints
+    topologySpreadConstraints: []
+      # - maxSkew: 1
+      #   topologyKey: failure-domain.beta.kubernetes.io/zone
+      #   whenUnsatisfiable: DoNotSchedule
+      # - maxSkew: 1
+      #   topologyKey: kubernetes.io/hostname
+      #   whenUnsatisfiable: ScheduleAnyway
 
 serviceAccount:
   # serviceAccount.create -- Determine whether a Service Account should be created or it should reuse an exiting one


### PR DESCRIPTION
## Description

Add support for [pod topology spread constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/), and close #141. Also fix a few typos.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] Github actions are passing
