### PR TITLE
[stable/locust] add options for tags & excludeTags

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.9.11"
+version: "0.9.12"
 appVersion: 1.4.3
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.11](https://img.shields.io/badge/Version-0.9.11-informational?style=flat-square) ![AppVersion: 1.4.3](https://img.shields.io/badge/AppVersion-1.4.3-informational?style=flat-square)
+![Version: 0.9.12](https://img.shields.io/badge/Version-0.9.12-informational?style=flat-square) ![AppVersion: 1.4.3](https://img.shields.io/badge/AppVersion-1.4.3-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -76,6 +76,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | ingress.hosts[0].path | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
 | loadtest.environment | object | `{}` | environment variables used in the load test for both master and workers |
+| loadtest.excludeTags | string | `""` | whether to run locust with `--exclude-tags [TAG [TAG ...]]` options, so only tasks with no matching tags will be executed |
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |
 | loadtest.locust_lib_configmap | string | `""` | name of a configmap containing your lib |
@@ -83,8 +84,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.locust_locustfile_configmap | string | `""` | name of a configmap containing your locustfile |
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |
-| loadtest.tags | string | `""` | whether to run locust with --tags [TAG [TAG ...]] options, so only tasks with any matching tags will be executed |
-| loadtest.excludeTags | string | `""` | whether to run locust with --exclude-tags [TAG [TAG ...]] options, so only tasks with no matching tags will be executed |
+| loadtest.tags | string | `""` | whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed |
 | master.args | list | `[]` | Any extra command args for the master |
 | master.args_include_default | bool | `true` | Whether to include default command args |
 | master.command[0] | string | `"sh"` |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -83,6 +83,8 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.locust_locustfile_configmap | string | `""` | name of a configmap containing your locustfile |
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |
+| loadtest.tags | string | `""` | whether to run locust with --tags [TAG [TAG ...]] options, so only tasks with any matching tags will be executed |
+| loadtest.excludeTags | string | `""` | whether to run locust with --exclude-tags [TAG [TAG ...]] options, so only tasks with no matching tags will be executed |
 | master.args | list | `[]` | Any extra command args for the master |
 | master.args_include_default | bool | `true` | Whether to include default command args |
 | master.command[0] | string | `"sh"` |  |

--- a/stable/locust/templates/configmap-config.yaml
+++ b/stable/locust/templates/configmap-config.yaml
@@ -14,4 +14,4 @@ data:
     pip install --user {{ range .Values.loadtest.pip_packages }}{{ . }} {{ end }}
     {{- end }}
 
-    exec /usr/local/bin/locust "$@"
+    exec /usr/local/bin/locust $@

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -52,6 +52,12 @@ spec:
           - --host={{ .Values.loadtest.locust_host }}
           - --master-host={{ template "locust.fullname" . }}
           - --loglevel={{ .Values.worker.logLevel }}
+{{- if .Values.loadtest.tags }}
+          - --tag {{ .Values.loadtest.tags }}
+{{- end }}
+{{- if .Values.loadtest.excludeTags }}
+          - --exclude-tags {{ .Values.loadtest.excludeTags }}
+{{- end }}
 {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -16,6 +16,10 @@ loadtest:
     # VAR: VALUE
   # loadtest.headless -- whether to run locust with headless settings
   headless: false
+  # loadtest.tags -- whether to run locust with --tags [TAG [TAG ...]] options, so only tasks with any matching tags will be executed
+  tags: ""
+  # loadtest.excludeTags -- whether to run locust with --exclude-tags [TAG [TAG ...]] options, so only tasks with no matching tags will be executed
+  excludeTags: ""
 
 image:
   repository: locustio/locust

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -16,9 +16,9 @@ loadtest:
     # VAR: VALUE
   # loadtest.headless -- whether to run locust with headless settings
   headless: false
-  # loadtest.tags -- whether to run locust with --tags [TAG [TAG ...]] options, so only tasks with any matching tags will be executed
+  # loadtest.tags -- whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed
   tags: ""
-  # loadtest.excludeTags -- whether to run locust with --exclude-tags [TAG [TAG ...]] options, so only tasks with no matching tags will be executed
+  # loadtest.excludeTags -- whether to run locust with `--exclude-tags [TAG [TAG ...]]` options, so only tasks with no matching tags will be executed
   excludeTags: ""
 
 image:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
- added locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed
- added locust with `--exclude-tags [TAG [TAG ...]]` options, so only tasks with no matching tags will be executed
- fix `docker-entrypoint.sh` doesn't work with list arguments(e.g. `--tags tag1 tag2`)
- locust docs: https://docs.locust.io/en/1.0.3/writing-a-locustfile.html#tagging-tasks
<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
