### PR TITLE
[stable/wiremock] add PodDisruptionBudget

### DIFF
--- a/stable/wiremock/Chart.yaml
+++ b/stable/wiremock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wiremock
-version: "1.1.1"
+version: "1.1.2"
 appVersion: "2.26.0"
 home: http://wiremock.org/
 icon: http://wiremock.org/images/wiremock-concept-icon-01.png

--- a/stable/wiremock/README.md
+++ b/stable/wiremock/README.md
@@ -1,6 +1,6 @@
 # wiremock
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
 
 A service virtualization tool (some call it mock server) for testing purposes.
 
@@ -148,6 +148,7 @@ helm install my-release deliveryhero/wiremock -f values.yaml
 | java.xmx | string | `"2G"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget |
 | podAnnotations | object | `{}` |  |
 | probes.liveness | bool | `true` |  |
 | probes.readiness | bool | `true` |  |

--- a/stable/wiremock/templates/pdb.yaml
+++ b/stable/wiremock/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "wiremock.fullname" . }}-master
+  labels:
+    component: master
+{{ include "wiremock.labels" . | indent 4 }}
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+{{ include "wiremock.selector.labels" . | indent 6 }}
+{{- end }}

--- a/stable/wiremock/values.yaml
+++ b/stable/wiremock/values.yaml
@@ -19,6 +19,10 @@ service:
   type: ClusterIP
   port: 80
 
+# pdb.enabled -- Whether to create a PodDisruptionBudget
+pdb:
+  enabled: false
+
 ingress:
   # ingress.enabled -- whether to create an Ingress
   enabled: false


### PR DESCRIPTION
## Description

This can stop k8s moving these pods for node down scaling.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
