### PR TITLE
[stable/locust] define extra configmap volumes

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.9.15"
+version: "0.9.16"
 appVersion: 1.4.4
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.9.16"
+version: "0.9.17"
 appVersion: 1.4.4
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.16](https://img.shields.io/badge/Version-0.9.16-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.9.17](https://img.shields.io/badge/Version-0.9.17-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.15](https://img.shields.io/badge/Version-0.9.15-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.9.16](https://img.shields.io/badge/Version-0.9.16-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/templates/_helpers.tpl
+++ b/stable/locust/templates/_helpers.tpl
@@ -21,15 +21,15 @@ Expand the name of the chart.
 {{- end -}}
 
 {{- define "locust.master-svc" -}}
-{{- printf "%s-%s" .Release.Name "master-svc" | trunc 63 -}}
+{{- printf "%s-%s" (.Release.Name | trunc 52 | trimSuffix "-") "master-svc" -}}
 {{- end -}}
 
 {{- define "locust.master" -}}
-{{- printf "%s-%s" .Release.Name "master" | trunc 63 -}}
+{{- printf "%s-%s" (.Release.Name | trunc 56 | trimSuffix "-") "master" -}}
 {{- end -}}
 
 {{- define "locust.worker" -}}
-{{- printf "%s-%s" .Release.Name "worker" | trunc 63 -}}
+{{- printf "%s-%s" (.Release.Name | trunc 56 | trimSuffix "-") "worker" -}}
 {{- end -}}
 
 {{/*
@@ -52,7 +52,19 @@ Create fully qualified configmap name.
 {{ end }}
 {{- end -}}
 
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "locust.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "locust.labels" -}}
+helm.sh/chart: {{ include "locust.chart" . }}
+app.kubernetes.io/name: {{ include "locust.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 heritage: {{ .Release.Service | quote }}
 release: {{ .Release.Name | quote }}
 chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/locust/templates/_helpers.tpl
+++ b/stable/locust/templates/_helpers.tpl
@@ -52,19 +52,7 @@ Create fully qualified configmap name.
 {{ end }}
 {{- end -}}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "locust.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
 {{- define "locust.labels" -}}
-helm.sh/chart: {{ include "locust.chart" . }}
-app.kubernetes.io/name: {{ include "locust.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 heritage: {{ .Release.Service | quote }}
 release: {{ .Release.Name | quote }}
 chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -123,6 +123,13 @@ spec:
         - name: config
           configMap:
             name: {{ template "locust.fullname" . }}-config
+{{- if .Values.extraConfigMaps }}
+{{- range $key, $value := .Values.extraConfigMaps }}
+        - name: {{ $key }}
+          configMap:
+            name: {{ $key }}
+{{- end }}
+{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -108,6 +108,13 @@ spec:
         - name: config
           configMap:
             name: {{ template "locust.fullname" . }}-config
+{{- if .Values.extraConfigMaps }}
+{{- range $key, $value := .Values.extraConfigMaps }}
+        - name: {{ $key }}
+          configMap:
+            name: {{ $key }}
+{{- end }}
+{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Update master and worker deployment templates to define volumes for mounted `extraConfigMaps`.
Improved template definitions for master, worker and service definitions.
~~Added recommended k8s label definitions to solve failing conftest~~ will be checked separately

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
