### PR TITLE
[stable/cachet] support imagePullSecrets

### DIFF
--- a/stable/cachet/templates/deployment.yaml
+++ b/stable/cachet/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/cachet/values.yaml
+++ b/stable/cachet/values.yaml
@@ -9,6 +9,8 @@ image:
   tag: "2.3.15"
   pullPolicy: Always
 
+imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
## Description

This change adds support for imagePullSecrets to [stable/Cachet], currently it is no implemented which means this chart cannot be used with private image repositories.

## Checklist

- [✔️] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [] Github actions are passing
