### PR TITLE
[stable/locust] add environment variables from existing secret

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.9.18"
+version: "0.9.19"
 appVersion: 1.4.4
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -76,8 +76,8 @@ helm install my-release deliveryhero/locust -f values.yaml
 | ingress.hosts[0].path | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
 | loadtest.environment | object | `{}` | environment variables used in the load test for both master and workers |
-| loadtest.environment_secret | object | `{}` | environment variables used in the load test for both master and workers, stored as secrets |
 | loadtest.environment_external_secret | object | `{}` | environment variables used in the load test for both master and workers, stored in secrets created outside this chart |
+| loadtest.environment_secret | object | `{}` | environment variables used in the load test for both master and workers, stored as secrets |
 | loadtest.excludeTags | string | `""` | whether to run locust with `--exclude-tags [TAG [TAG ...]]` options, so only tasks with no matching tags will be executed |
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -76,6 +76,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | ingress.hosts[0].path | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
 | loadtest.environment | object | `{}` | environment variables used in the load test for both master and workers |
+| loadtest.environment_secret | object | `{}` | environment variables used in the load test for both master and workers, stored as secrets |
 | loadtest.excludeTags | string | `""` | whether to run locust with `--exclude-tags [TAG [TAG ...]]` options, so only tasks with no matching tags will be executed |
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -77,6 +77,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | ingress.tls | list | `[]` |  |
 | loadtest.environment | object | `{}` | environment variables used in the load test for both master and workers |
 | loadtest.environment_secret | object | `{}` | environment variables used in the load test for both master and workers, stored as secrets |
+| loadtest.environment_external_secret | object | `{}` | environment variables used in the load test for both master and workers, stored in secrets created outside this chart |
 | loadtest.excludeTags | string | `""` | whether to run locust with `--exclude-tags [TAG [TAG ...]]` options, so only tasks with no matching tags will be executed |
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.18](https://img.shields.io/badge/Version-0.9.18-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.9.19](https://img.shields.io/badge/Version-0.9.19-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -89,6 +89,13 @@ spec:
                 name: {{ template "locust.fullname" $ }}
                 key: {{ $key }}
 {{- end }}
+{{- range $key, $value := .Values.loadtest.environment_external_secret }}
+          - name: {{ $value }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $key }}
+                key: {{ $value }}
+{{- end }}
         ports:
           - containerPort: 8089
             name: loc-master-web

--- a/stable/locust/templates/secret.yaml
+++ b/stable/locust/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loadtest.environment_secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,7 +7,6 @@ metadata:
 {{ include "locust.labels" . | indent 4 }}
 type: Opaque
 data:
-{{- if .Values.loadtest.environment_secret }}
 {{- range $key, $value := .Values.loadtest.environment_secret }}
   {{ $key }}: {{ $value | b64enc | quote }}
 {{- end }}

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -97,6 +97,13 @@ spec:
                 name: {{ template "locust.fullname" $ }}
                 key: {{ $key }}
 {{- end }}
+{{- range $key, $value := .Values.loadtest.environment_external_secret }}
+          - name: {{ $value }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $key }}
+                key: {{ $value }}
+{{- end }}
       restartPolicy: Always
       volumes:
         - name: lib

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -14,6 +14,9 @@ loadtest:
   # loadtest.environment -- environment variables used in the load test for both master and workers
   environment: {}
     # VAR: VALUE
+  # loadtest.environment_secret -- environment variables used in the load test for both master and workers, stored as secrets
+  environment_secret: {}
+    # VAR: VALUE
   # loadtest.headless -- whether to run locust with headless settings
   headless: false
   # loadtest.tags -- whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -17,6 +17,9 @@ loadtest:
   # loadtest.environment_secret -- environment variables used in the load test for both master and workers, stored as secrets
   environment_secret: {}
     # VAR: VALUE
+  # loadtest.environment_external_secret -- environment variables used in the load test for both master and workers, stored in secrets created outside this chart
+  environment_external_secret: {}
+    # SECRET_NAME: VAR
   # loadtest.headless -- whether to run locust with headless settings
   headless: false
   # loadtest.tags -- whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->
- There is a value `environment_secret` that creates a secret and mounts its keys as environment variables. This was, however, not documented, so I added the details to `values.yaml` and the README.
- If `environment_secret` was not set, an empty secret with name `locust` would be created. I changed this, so the secret is only created if there is data to fill it with.
- While this is great, when using GitOps tools like Flux, the contents of `values.yaml` are uploaded to Git, so this is not a great way to pass secrets to the deployment for these users. To avoid this, I added the `environment_external_secret` value, so an existing secret can be used for environment variables. This way you can create the secret some other way, without keeping its contents in plain text on Git. The format I'm suggesting is:

```yaml
environment_external_secret:
  secret_name: env_var_name
```

Where `secret_name` is the name of the secret already created, not managed by the chart. And `env_var_name` is the name of the environment variable, and also the name of the relevant key in the secret containing the desired secret value.

For example, for the secret created as

```
kubectl create secret generic test-secret \
  --from-literal=token=abcd \
  -n locust
 ```

The value would be
```yaml
environment_external_secret:
  test-secret: token
```

Does this sound good to you?

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Github actions are passing
