### PR TITLE
[stable/locust] allow multiple value to passed using environment_external_secret

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.9.19"
+version: "0.9.20"
 appVersion: 1.4.4
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.21](https://img.shields.io/badge/Version-0.9.21-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.19.21](https://img.shields.io/badge/Version-0.19.21-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -76,7 +76,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | ingress.hosts[0].path | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
 | loadtest.environment | object | `{}` | environment variables used in the load test for both master and workers |
-| loadtest.environment_external_secret | object | `{}` | environment variables used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `locust-aws-credentials: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]` |
+| loadtest.environment_external_secret | object | `{}` | environment variables used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `secret_name: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]` |
 | loadtest.environment_secret | object | `{}` | environment variables used in the load test for both master and workers, stored as secrets |
 | loadtest.excludeTags | string | `""` | whether to run locust with `--exclude-tags [TAG [TAG ...]]` options, so only tasks with no matching tags will be executed |
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.19](https://img.shields.io/badge/Version-0.9.19-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.9.20](https://img.shields.io/badge/Version-0.9.20-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -76,7 +76,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | ingress.hosts[0].path | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
 | loadtest.environment | object | `{}` | environment variables used in the load test for both master and workers |
-| loadtest.environment_external_secret | object | `{}` | environment variables used in the load test for both master and workers, stored in secrets created outside this chart |
+| loadtest.environment_external_secret | object | `{}` | environment variables used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `locust-aws-credentials: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]` |
 | loadtest.environment_secret | object | `{}` | environment variables used in the load test for both master and workers, stored as secrets |
 | loadtest.excludeTags | string | `""` | whether to run locust with `--exclude-tags [TAG [TAG ...]]` options, so only tasks with no matching tags will be executed |
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -89,12 +89,14 @@ spec:
                 name: {{ template "locust.fullname" $ }}
                 key: {{ $key }}
 {{- end }}
-{{- range $key, $value := .Values.loadtest.environment_external_secret }}
+{{- range $key, $values := .Values.loadtest.environment_external_secret }}
+{{- range $value := $values }}
           - name: {{ $value }}
             valueFrom:
               secretKeyRef:
                 name: {{ $key }}
                 key: {{ $value }}
+{{- end }}
 {{- end }}
         ports:
           - containerPort: 8089

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -97,12 +97,14 @@ spec:
                 name: {{ template "locust.fullname" $ }}
                 key: {{ $key }}
 {{- end }}
-{{- range $key, $value := .Values.loadtest.environment_external_secret }}
+{{- range $key, $values := .Values.loadtest.environment_external_secret }}
+{{- range $value := $values }}
           - name: {{ $value }}
             valueFrom:
               secretKeyRef:
                 name: {{ $key }}
                 key: {{ $value }}
+{{- end }}
 {{- end }}
       restartPolicy: Always
       volumes:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -17,7 +17,7 @@ loadtest:
   # loadtest.environment_secret -- environment variables used in the load test for both master and workers, stored as secrets
   environment_secret: {}
     # VAR: VALUE
-  # loadtest.environment_external_secret -- environment variables used in the load test for both master and workers, stored in secrets created outside this chart
+  # loadtest.environment_external_secret -- environment variables used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `secret_name: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]`
   environment_external_secret: {}
     # SECRET_NAME: VAR
   # loadtest.headless -- whether to run locust with headless settings


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

https://github.com/deliveryhero/helm-charts/pull/172 added a functionality to allow existing secret to be used as environment variables. But only one value for each secret can be passed. If we have multiple key value pairs in a secret, we are able to pass only one key value pair in their with previous syntax

```
environment_external_secret:
  secret_name: env_var_name
```

This PR changes this to allow of list of environment variable to be passed.
```
environment_external_secret:
    secret_name: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]
```


## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
