### PR TITLE
stable/cachet Update Ingress Ressource to v1

### DIFF
--- a/stable/backstage/README.md
+++ b/stable/backstage/README.md
@@ -1,6 +1,6 @@
 # backstage
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1-alpha.23](https://img.shields.io/badge/AppVersion-v0.1.1--alpha.23-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1-alpha.23](https://img.shields.io/badge/AppVersion-v0.1.1--alpha.23-informational?style=flat-square)
 
 A Helm chart for Backstage
 

--- a/stable/backstage/README.md
+++ b/stable/backstage/README.md
@@ -1,6 +1,6 @@
 # backstage
 
-![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1-alpha.23](https://img.shields.io/badge/AppVersion-v0.1.1--alpha.23-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1-alpha.23](https://img.shields.io/badge/AppVersion-v0.1.1--alpha.23-informational?style=flat-square)
 
 A Helm chart for Backstage
 

--- a/stable/cachet/Chart.yaml
+++ b/stable/cachet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.3.15"
 description: The open source status page system
 name: cachet
-version: 1.2.8
+version: 1.2.9
 home: https://cachethq.io/
 sources:
   - https://github.com/CachetHQ/Docker

--- a/stable/cachet/README.md
+++ b/stable/cachet/README.md
@@ -1,6 +1,6 @@
 # cachet
 
-![Version: 1.2.8](https://img.shields.io/badge/Version-1.2.8-informational?style=flat-square) ![AppVersion: 2.3.15](https://img.shields.io/badge/AppVersion-2.3.15-informational?style=flat-square)
+![Version: 1.2.9](https://img.shields.io/badge/Version-1.2.9-informational?style=flat-square) ![AppVersion: 2.3.15](https://img.shields.io/badge/AppVersion-2.3.15-informational?style=flat-square)
 
 The open source status page system
 
@@ -88,6 +88,7 @@ helm install my-release deliveryhero/cachet -f values.yaml
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.host | string | `"chart-example.local"` |  |
+| ingress.ingressClassName | string | `"ingressClass"` | Set ingressClass for Ingress when needed |
 | ingress.path | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |

--- a/stable/cachet/README.md
+++ b/stable/cachet/README.md
@@ -88,7 +88,7 @@ helm install my-release deliveryhero/cachet -f values.yaml
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.host | string | `"chart-example.local"` |  |
-| ingress.ingressClassName | string | `"ingressClass"` | Set ingressClass for Ingress when needed |
+| ingress.ingressClassName | string | `""` | Set ingressClass for Ingress when needed |
 | ingress.path | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |

--- a/stable/cachet/templates/ingress.yaml
+++ b/stable/cachet/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "cachet.fullname" . }}
@@ -9,14 +9,19 @@ metadata:
 {{- if .Values.ingress.annotations }}
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
-
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
   - host: {{ .Values.ingress.host }}
     http:
       paths:
       - backend:
-          serviceName:  {{ include "cachet.fullname" . }}
-          servicePort: {{ .Values.service.port }}
+          service:
+            name: {{ include "cachet.fullname" . }}
+            port:
+              number: {{ .Values.service.port }}
         path: {{ .Values.ingress.path }}
+        pathType: Prefix
 {{- end }}

--- a/stable/cachet/values.yaml
+++ b/stable/cachet/values.yaml
@@ -24,7 +24,9 @@ ingress:
   host: chart-example.local
   tls: []
   path: /
-  #ingressClassName: ingressClass
+  # -- Set ingressClass for Ingress when needed
+  ingressClassName: ingressClass
+
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local

--- a/stable/cachet/values.yaml
+++ b/stable/cachet/values.yaml
@@ -24,8 +24,8 @@ ingress:
   host: chart-example.local
   tls: []
   path: /
-  # -- Set ingressClass for Ingress when needed
-  # ingressClassName: ingressClass
+  # ingress.ingressClassName -- Set ingressClass for Ingress when needed
+  ingressClassName: ""
 
   #  - secretName: chart-example-tls
   #    hosts:

--- a/stable/cachet/values.yaml
+++ b/stable/cachet/values.yaml
@@ -24,6 +24,7 @@ ingress:
   host: chart-example.local
   tls: []
   path: /
+  #ingressClassName: ingressClass
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local

--- a/stable/cachet/values.yaml
+++ b/stable/cachet/values.yaml
@@ -25,7 +25,7 @@ ingress:
   tls: []
   path: /
   # -- Set ingressClass for Ingress when needed
-  ingressClassName: ingressClass
+  # ingressClassName: ingressClass
 
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
## Description
Update Ingress Ressource to networking.k8s.io/v1 and added ingressClassName

## Checklist

- [x ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
