### PR TITLE
[stable/locust] Added the ability to enable UI basic auth from the values.yaml

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.9.19"
+version: "0.1.20"
 appVersion: 1.4.4
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.19](https://img.shields.io/badge/Version-0.9.19-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.1.20](https://img.shields.io/badge/Version-0.1.20-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -89,6 +89,9 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.tags | string | `""` | whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed |
 | master.args | list | `[]` | Any extra command args for the master |
 | master.args_include_default | bool | `true` | Whether to include default command args |
+| master.auth.enabled | bool | `false` | When enabled, UI basic auth will be enforced with the given username and password |
+| master.auth.password | string | `""` |  |
+| master.auth.username | string | `""` |  |
 | master.command[0] | string | `"sh"` |  |
 | master.command[1] | string | `"/config/docker-entrypoint.sh"` |  |
 | master.environment | object | `{}` | environment variables for the master |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -53,6 +53,9 @@ spec:
           - --loglevel={{ .Values.master.logLevel }}
 {{- if .Values.loadtest.headless }}
           - --headless
+{{- if .Values.master.auth.enabled }}
+          - --web-auth={{ cat .Values.master.auth.username ":" .Values.master.auth.password }}
+{{- end }}
 {{- end }}
 {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -118,6 +121,11 @@ spec:
           httpGet:
             path: /
             port: 8089
+{{- if .Values.master.auth.enabled }}
+            httpHeaders:
+                - name: Authorization
+                  value: Basic {{ b64enc cat .Values.master.auth.username ":" .Values.master.auth.password }}}
+{{- end }}
 {{- end }}
       restartPolicy: Always
       volumes:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -65,6 +65,11 @@ master:
   # master.pdb.enabled -- Whether to create a PodDisruptionBudget for the master pod
   pdb:
     enabled: false
+  # master.auth.enabled -- When enabled, UI basic auth will be enforced with the given username and password
+  auth:
+    enabled: false
+    username: ""
+    password: ""
 
 worker:
   # worker.image -- A custom docker image including tag


### PR DESCRIPTION
Added the ability to enable UI basic auth from the values.yaml. The template will include the necessary arg to master as well as adjust the readinessProbe using the given username and password.

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

Using master.auth.enabled, one is now able to enable basic auth on the Locust UI. This will also require providing master.auth.username and master.auth.password, which will be used to add the required args to enabled web authentication, and to adjust the readinessProbe to use basic auth. 

<!--- Describe your changes in detail -->

## Checklist

- [ X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ X] Github actions are passing
