### PR TITLE
[stable/backstage] Fix chart, also fix CI conftest

### DIFF
--- a/.github/workflows/chart-testing.yml
+++ b/.github/workflows/chart-testing.yml
@@ -19,7 +19,7 @@ jobs:
           config: ci/ct.yaml
 
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
+        uses: helm/kind-action@v1.2.0
         if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/helm-conftest.yaml
+++ b/.github/workflows/helm-conftest.yaml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Validate all charts
-        run: sh ci/helm-conftest.sh
+        run: bash ci/helm-conftest.sh

--- a/ci/helm-conftest.sh
+++ b/ci/helm-conftest.sh
@@ -11,8 +11,6 @@ if [ -f "/.dockerenv" ]; then
     curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
     chmod 700 get_helm.sh
     ./get_helm.sh --version "v3.6.2"
-    rm -f /usr/bin/helm
-    alias helm="/usr/local/bin/helm"
     echo "Helm version now installed: "
     helm version
   fi

--- a/ci/helm-conftest.sh
+++ b/ci/helm-conftest.sh
@@ -16,6 +16,7 @@ if [ -f "/.dockerenv" ]; then
     chmod 700 get_helm.sh
     ./get_helm.sh --version "v3.6.2"
     rm -f /usr/bin/helm
+    alias helm="/usr/local/bin/helm"
     echo "Helm version now installed: "
     helm version
   fi

--- a/ci/helm-conftest.sh
+++ b/ci/helm-conftest.sh
@@ -1,9 +1,21 @@
 #!/bin/sh
 
+# Check if we are running in Github actions and apply some required changes
 if [[ ! -z "${GITHUB_RUN_ID}" ]]; then
   alias conftest=/root/.helm/plugins/helm-conftest/bin/conftest
   helm repo remove local
   set -euo pipefail
+fi
+
+# Check if we are running in docker and ensure we have Helm3 if so
+if [ -f "/.dockerenv" ]; then
+  if helm version --client --short | grep -q 'v2.14'; then
+    echo "Running in docker but Helm version 2 found, will install Helm 3..."
+    export VERIFY_CHECKSUM=false
+    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+    chmod 700 get_helm.sh
+    ./get_helm.sh --version "v3.6.2"
+  fi
 fi
 
 for chart in $(find stable -maxdepth 1 -mindepth 1); do

--- a/ci/helm-conftest.sh
+++ b/ci/helm-conftest.sh
@@ -15,6 +15,9 @@ if [ -f "/.dockerenv" ]; then
     curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
     chmod 700 get_helm.sh
     ./get_helm.sh --version "v3.6.2"
+    rm -f /usr/bin/helm
+    echo "Helm version now installed: "
+    helm version
   fi
 fi
 

--- a/stable/backstage/Chart.yaml
+++ b/stable/backstage/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/backstage/backstage
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/backstage/README.md
+++ b/stable/backstage/README.md
@@ -1,6 +1,6 @@
 # backstage
 
-![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1-alpha.23](https://img.shields.io/badge/AppVersion-v0.1.1--alpha.23-informational?style=flat-square)
+![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1-alpha.23](https://img.shields.io/badge/AppVersion-v0.1.1--alpha.23-informational?style=flat-square)
 
 A Helm chart for Backstage
 

--- a/stable/backstage/README.md
+++ b/stable/backstage/README.md
@@ -1,6 +1,6 @@
 # backstage
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1-alpha.23](https://img.shields.io/badge/AppVersion-v0.1.1--alpha.23-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1-alpha.23](https://img.shields.io/badge/AppVersion-v0.1.1--alpha.23-informational?style=flat-square)
 
 A Helm chart for Backstage
 

--- a/stable/backstage/ci/ct-values.yaml
+++ b/stable/backstage/ci/ct-values.yaml
@@ -1,0 +1,5 @@
+backend:
+  resources: {}
+
+frontend:
+  resources: {}

--- a/stable/backstage/ci/ct-values.yaml
+++ b/stable/backstage/ci/ct-values.yaml
@@ -1,5 +1,5 @@
 backend:
-  resources: {}
+  enabled: false
 
 frontend:
-  resources: {}
+  enabled: false

--- a/stable/backstage/ci/ct-values.yaml
+++ b/stable/backstage/ci/ct-values.yaml
@@ -1,5 +1,0 @@
-backend:
-  enabled: false
-
-frontend:
-  enabled: false


### PR DESCRIPTION
PRs https://github.com/deliveryhero/helm-charts/pull/195 and https://github.com/deliveryhero/helm-charts/pull/194 were merged with failed CI tests. I've changed repo settings to prevent merging when tests are failing, even for admins.

So now I need to fix the current master as the failed tests are affecting other PRs.

The errors are:

```
helm-conftest running for chart: stable/backstage...
Error: parse error in "backstage/templates/ingress.yaml": template: backstage/templates/ingress.yaml:1: function "urlParse" not defined
```

And:

```
Error: Error linting charts: Error processing charts
------------------------------------------------------------------------------------------------------------------------
 ✖︎ backstage => (version: "0.1.11", path: "stable/backstage") > Chart version not ok. Needs a version bump!
------------------------------------------------------------------------------------------------------------------------
```

So here I will:

- Add some hacky solution to install Helm3 inside the conftest container
- Update Kind cluster version to fix node taints issue
- Bump backstage version