### PR TITLE
[stable/locust] - UI Basic Auth Bug - Closes #202

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.19.20"
+version: "0.19.21"
 appVersion: 1.4.4
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.19.20](https://img.shields.io/badge/Version-0.19.20-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.19.21](https://img.shields.io/badge/Version-0.19.21-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -124,7 +124,7 @@ spec:
 {{- if .Values.master.auth.enabled }}
             httpHeaders:
                 - name: Authorization
-                  value: Basic {{ b64enc cat .Values.master.auth.username ":" .Values.master.auth.password }}}
+                  value: Basic {{ cat .Values.master.auth.username ":" .Values.master.auth.password | b64enc }}
 {{- end }}
 {{- end }}
       restartPolicy: Always


### PR DESCRIPTION
## Description

Fixing a bug where multiple arguments are passed to the b64enc function, which expects only one argument. Now I pipe the result of the concatenation into the b64enc instead.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
