### PR TITLE
[stable/kube-downscaler] Enable the addition of pod annotations

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.4"
+version: "0.5"
 appVersion: 21.2.0
 description: Scale down Kubernetes deployments after work hours
 keywords:

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -61,6 +61,7 @@ helm install my-release deliveryhero/kube-downscaler -f values.yaml
 | interval | int | `60` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
 | rbac.create | bool | `true` |  |
 | rbac.serviceAccountName | string | `"default"` |  |
 | replicaCount | int | `1` |  |

--- a/stable/kube-downscaler/templates/deployment.yaml
+++ b/stable/kube-downscaler/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "kube-downscaler.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-downscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
     {{- with .Values.imagePullSecrets }}

--- a/stable/kube-downscaler/values.yaml
+++ b/stable/kube-downscaler/values.yaml
@@ -44,6 +44,8 @@ securityContext:
 
 extraLabels: {}
 
+podAnnotations: {}
+
 deployment:
   environment:
     DEFAULT_UPTIME: "Mon-Fri 07:00-20:00 Europe/Berlin"


### PR DESCRIPTION
## Description

Allow the user to add pod annotations as per the incubator/kube-downscaler chart

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
