### PR TITLE
[stable/locust] Fix hard coded locustfile name

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.19.21"
+version: "0.19.22"
 appVersion: 1.4.4
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.19.21](https://img.shields.io/badge/Version-0.19.21-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.19.22](https://img.shields.io/badge/Version-0.19.22-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/templates/configmap-locust-locustfile.yaml
+++ b/stable/locust/templates/configmap-locust-locustfile.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
 {{ include "locust.labels" . | indent 4 }}
 data:
-{{ ($.Files.Glob (printf "locustfiles/%s/main.py" .Values.loadtest.name)).AsConfig | indent 2 }}
+{{ ($.Files.Glob (printf "locustfiles/%s/%s" .Values.loadtest.name .Values.loadtest.locust_locustfile)).AsConfig | indent 2 }}
 {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Replace hard coded locustfile `main.py` with `.Values.loadtest.locust_locustfile`

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
