### PR TITLE
[stable/wiremock] expose init container image configuration

### DIFF
--- a/stable/wiremock/Chart.yaml
+++ b/stable/wiremock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wiremock
-version: "1.1.2"
+version: "1.1.3"
 appVersion: "2.26.0"
 home: http://wiremock.org/
 icon: http://wiremock.org/images/wiremock-concept-icon-01.png

--- a/stable/wiremock/README.md
+++ b/stable/wiremock/README.md
@@ -1,6 +1,6 @@
 # wiremock
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
 
 A service virtualization tool (some call it mock server) for testing purposes.
 
@@ -143,6 +143,8 @@ helm install my-release deliveryhero/wiremock -f values.yaml
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths[0] | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
+| init.image.repository | string | `"busybox"` | the docker repository and image to be used for the init container. |
+| init.image.tag | string | `"latest"` | the docker image tag for the init container image |
 | java.mms | string | `"256M"` |  |
 | java.xms | string | `"2G"` |  |
 | java.xmx | string | `"2G"` |  |

--- a/stable/wiremock/templates/deployment.yaml
+++ b/stable/wiremock/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       initContainers:
       - name: copy-stubs
-        image: busybox:latest
+        image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
 {{- if .Values.consumer.stubs }}
         env:
 {{- range $key, $value := .Values.consumer.stubs }}

--- a/stable/wiremock/values.yaml
+++ b/stable/wiremock/values.yaml
@@ -61,6 +61,13 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
+init:
+  image:
+    # init.image.repository -- the docker repository and image to be used for the init container.
+    repository: busybox
+    # init.image.tag -- the docker image tag for the init container image
+    tag: latest
+
 resources:
   requests:
     cpu: 1


### PR DESCRIPTION
## Description
This PR provides configuration settings to adjust the default `initContainer`s image and tag to be able to work around issues recently introduced by the [docker rate limiting](https://docs.docker.com/docker-hub/download-rate-limit/).

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
