### PR TITLE
[stable/toxiproxy] expose init container image configuration

### DIFF
--- a/stable/toxiproxy/Chart.yaml
+++ b/stable/toxiproxy/Chart.yaml
@@ -17,7 +17,7 @@ description: |
   helm install toxiproxy deliveryhero/toxiproxy --set toxiproxyConfig=my-toxiproxy-config
   ```
 
-version: "1.3.4"
+version: "1.3.5"
 appVersion: "2.1.2"
 home: https://github.com/Shopify/toxiproxy
 sources:

--- a/stable/toxiproxy/README.md
+++ b/stable/toxiproxy/README.md
@@ -1,6 +1,6 @@
 # toxiproxy
 
-![Version: 1.3.4](https://img.shields.io/badge/Version-1.3.4-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
+![Version: 1.3.5](https://img.shields.io/badge/Version-1.3.5-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
 
 A TCP proxy to simulate network and system conditions for chaos and resiliency testing.
 
@@ -81,6 +81,8 @@ helm install my-release deliveryhero/toxiproxy -f values.yaml
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths[0] | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
+| init.image.repository | string | `"busybox"` | the docker repository and image to be used for the init container. |
+| init.image.tag | string | `"latest"` | the docker image tag for the init container image |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget |

--- a/stable/toxiproxy/templates/deployment.yaml
+++ b/stable/toxiproxy/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
 {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
       - name: copy-mappings
-        image: busybox:latest
+        image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
         command: ['sh', '/config/init.sh']
         volumeMounts:
         - mountPath: /working

--- a/stable/toxiproxy/values.yaml
+++ b/stable/toxiproxy/values.yaml
@@ -7,6 +7,13 @@ image:
   tag: 2.1.4
   pullPolicy: IfNotPresent
 
+init:
+  image:
+    # init.image.repository -- the docker repository and image to be used for the init container.
+    repository: busybox
+    # init.image.tag -- the docker image tag for the init container image
+    tag: latest
+
 frontend:
   repository: buckle/toxiproxy-frontend
   # Whether we want to deploy the charts for the frontend or not


### PR DESCRIPTION
## Description
This PR provides configuration settings to adjust the default `initContainer`s image and tag to be able to work around issues recently introduced by the [docker rate limiting](https://docs.docker.com/docker-hub/download-rate-limit/).

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
