### PR TITLE
[stable/locust] Add the capability to mount external secret files at a specific location

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.19.23"
+version: "0.19.24"
 appVersion: 1.4.4
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.19.23](https://img.shields.io/badge/Version-0.19.23-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.19.24](https://img.shields.io/badge/Version-0.19.24-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -84,6 +84,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.locust_lib_configmap | string | `""` | name of a configmap containing your lib |
 | loadtest.locust_locustfile | string | `"main.py"` | the name of the locustfile |
 | loadtest.locust_locustfile_configmap | string | `""` | name of a configmap containing your locustfile |
+| loadtest.mount_external_secret | object | `{}` | additional mount used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `mountPath: yourMountLocation, files: { secret_name: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY] }` |
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |
 | loadtest.tags | string | `""` | whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed |

--- a/stable/locust/templates/_helpers.tpl
+++ b/stable/locust/templates/_helpers.tpl
@@ -89,3 +89,26 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- printf .Values.loadtest.locust_lib_configmap -}}
 {{ end }}
 {{- end -}}
+
+{{/* Generate external secret volume */}}
+{{- define "locust.external_secret.volume" -}}
+- name: external-secrets
+  projected:
+    sources:
+{{- range $key, $values := .Values.loadtest.mount_external_secret.files }}
+{{- range $value := $values }}
+      - secret:
+          name: {{ $key }}
+          items:
+            - key: {{ $value }}
+              path: {{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* Generate external secret volumemount */}}
+{{- define "locust.external_secret.volumemount" -}}
+- name: external-secrets
+  mountPath: {{ .Values.loadtest.mount_external_secret.mountPath }}
+  readOnly: true
+{{- end -}}

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -73,7 +73,7 @@ spec:
           - name: {{ $key }}
             mountPath: {{ $value }}
 {{- end }}
-{{- end}}
+{{- end }}
 {{- if .Values.loadtest.mount_external_secret }}
 {{- include "locust.external_secret.volumemount" . | nindent 10 }}
 {{- end}}

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -74,6 +74,9 @@ spec:
             mountPath: {{ $value }}
 {{- end }}
 {{- end}}
+{{- if .Values.loadtest.mount_external_secret }}
+{{- include "locust.external_secret.volumemount" . | nindent 10 }}
+{{- end}}
         env:
           - name: LOCUST_HOST
             value: "{{ .Values.loadtest.locust_host }}"
@@ -146,6 +149,9 @@ spec:
           configMap:
             name: {{ $key }}
 {{- end }}
+{{- end }}
+{{- if .Values.loadtest.mount_external_secret }}
+{{- include "locust.external_secret.volume" . | nindent 8 }}
 {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -75,6 +75,9 @@ spec:
             mountPath: {{ $value }}
 {{- end }}
 {{- end}}
+{{- if .Values.loadtest.mount_external_secret }}
+{{- include "locust.external_secret.volumemount" . | nindent 10 }}
+{{- end}}
         env:
           - name: LOCUST_HOST
             value: "{{ .Values.loadtest.locust_host }}"
@@ -123,6 +126,9 @@ spec:
           configMap:
             name: {{ $key }}
 {{- end }}
+{{- end }}
+{{- if .Values.loadtest.mount_external_secret }}
+{{- include "locust.external_secret.volume" . | nindent 8 }}
 {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -20,6 +20,11 @@ loadtest:
   # loadtest.environment_external_secret -- environment variables used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `secret_name: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]`
   environment_external_secret: {}
     # SECRET_NAME: VAR
+  # loadtest.mount_external_secret -- additional mount used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `mountPath: yourMountLocation, files: { secret_name: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY] }`
+  mount_external_secret: {}
+    # mountPath: yourMountLocation
+    # files:
+      # secret_name: var
   # loadtest.headless -- whether to run locust with headless settings
   headless: false
   # loadtest.tags -- whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

#197 added the functionality to load multiple keys from an existent k8s secret into an environment variable.  I found out that sometimes we need the entire file mounted because of some limitation from the running environment:
```
locust@testpod:~$ xargs --show-limits </dev/null
Your environment variables take up 2810 bytes
```
This PR add a functionality to mount k8s secrets in a given mount location:
```
mount_external_secret:
  mountPath: /my-secret-location
  files:
    secret_file_1: [key1, key2]
    secret_file_2: [key1]
```

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
