### PR TITLE
[stable/aws-s3-proxy]: provide support for serviceAccount annotations

### DIFF
--- a/stable/aws-s3-proxy/Chart.yaml
+++ b/stable/aws-s3-proxy/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   See here for configuration via environment variables: https://github.com/pottava/aws-s3-proxy#usage
 name: aws-s3-proxy
 home: https://github.com/pottava/aws-s3-proxy
-version: 0.1.2
+version: 0.1.3
 maintainers:
 - name: max-rocket-internet
   email: no-reply@deliveryhero.com

--- a/stable/aws-s3-proxy/README.md
+++ b/stable/aws-s3-proxy/README.md
@@ -1,6 +1,6 @@
 # aws-s3-proxy
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 2.0](https://img.shields.io/badge/AppVersion-2.0-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 2.0](https://img.shields.io/badge/AppVersion-2.0-informational?style=flat-square)
 
 Reverse proxy for AWS S3 with basic authentication.
 
@@ -66,6 +66,7 @@ helm install my-release deliveryhero/aws-s3-proxy -f values.yaml
 | securityContext | object | `{}` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` |  |

--- a/stable/aws-s3-proxy/templates/serviceaccount.yaml
+++ b/stable/aws-s3-proxy/templates/serviceaccount.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "aws-s3-proxy.serviceAccountName" . }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "aws-s3-proxy.labels" . | indent 4 }}
 {{- end -}}

--- a/stable/aws-s3-proxy/values.yaml
+++ b/stable/aws-s3-proxy/values.yaml
@@ -21,6 +21,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  annotations: {}
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
This PR adds support for service account annotations.
<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
