### PR TITLE
[stable/locust] Allow configuring the root path to locustfile

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.19.24"
+version: "0.19.25"
 appVersion: 1.4.4
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.19.24](https://img.shields.io/badge/Version-0.19.24-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.19.25](https://img.shields.io/badge/Version-0.19.25-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -87,6 +87,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.mount_external_secret | object | `{}` | additional mount used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `mountPath: yourMountLocation, files: { secret_name: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY] }` |
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |
+| loadtest.root_path | string | `""` | the root path to the locustfile. Configure if using a custom image with embedded locustfile NOT using configmaps. Defaults to "/mnt/locust" if empty. |
 | loadtest.tags | string | `""` | whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed |
 | master.args | list | `[]` | Any extra command args for the master |
 | master.args_include_default | bool | `true` | Whether to include default command args |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -48,7 +48,7 @@ spec:
 {{ else if .Values.master.args_include_default }}
         args:
           - --master
-          - --locustfile=/mnt/locust/{{ .Values.loadtest.locust_locustfile }}
+          - --locustfile={{ if .Values.loadtest.root_path }}{{ .Values.loadtest.root_path }}{{ else }}/mnt/locust{{ end }}/{{ .Values.loadtest.locust_locustfile }}
           - --host={{ .Values.loadtest.locust_host }}
           - --loglevel={{ .Values.master.logLevel }}
 {{- if .Values.loadtest.headless }}

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -48,7 +48,7 @@ spec:
 {{ else if .Values.worker.args_include_default }}
         args:
           - --worker
-          - --locustfile=/mnt/locust/{{ .Values.loadtest.locust_locustfile }}
+          - --locustfile={{ if .Values.loadtest.root_path }}{{ .Values.loadtest.root_path }}{{ else }}/mnt/locust{{ end }}/{{ .Values.loadtest.locust_locustfile }}
           - --host={{ .Values.loadtest.locust_host }}
           - --master-host={{ template "locust.fullname" . }}
           - --loglevel={{ .Values.worker.logLevel }}

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -9,6 +9,8 @@ loadtest:
   locust_lib_configmap: ""
   # loadtest.locust_host -- the host you will load test
   locust_host: https://www.google.com
+  # loadtest.root_path -- the root path to the locustfile. Configure if using a custom image with embedded locustfile NOT using configmaps. Defaults to "/mnt/locust" if empty.
+  root_path: ""
   # loadtest.pip_packages -- a list of extra python pip packages to install
   pip_packages: []
   # loadtest.environment -- environment variables used in the load test for both master and workers


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
Allow configuring a root path other than `/mnt/locust` for the locustfile. This is useful if you're using a custom image with configurations embedded. Since the chart mounts volumes based on the configmaps on `/mnt/locust`, the files inside the container would be lost. This change allows the configuration of a different path, avoiding this conflict.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
