### PR TITLE
[stable/locust] Move configs to env variables, fix argument inclusion conditions

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.19.24"
+version: "0.19.25"
 appVersion: 1.4.4
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.19.24](https://img.shields.io/badge/Version-0.19.24-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.19.25](https://img.shields.io/badge/Version-0.19.25-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -89,13 +89,13 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |
 | loadtest.tags | string | `""` | whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed |
 | master.args | list | `[]` | Any extra command args for the master |
-| master.args_include_default | bool | `true` | Whether to include default command args |
 | master.auth.enabled | bool | `false` | When enabled, UI basic auth will be enforced with the given username and password |
 | master.auth.password | string | `""` |  |
 | master.auth.username | string | `""` |  |
 | master.command[0] | string | `"sh"` |  |
 | master.command[1] | string | `"/config/docker-entrypoint.sh"` |  |
 | master.environment | object | `{}` | environment variables for the master |
+| master.envs_include_default | bool | `true` | Whether to include default environment variables |
 | master.image | string | `""` | A custom docker image including tag |
 | master.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
 | master.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the master pod |
@@ -111,10 +111,10 @@ helm install my-release deliveryhero/locust -f values.yaml
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |
 | worker.args | list | `[]` | Any extra command args for the workers |
-| worker.args_include_default | bool | `true` | Whether to include default command args |
 | worker.command[0] | string | `"sh"` |  |
 | worker.command[1] | string | `"/config/docker-entrypoint.sh"` |  |
 | worker.environment | object | `{}` | environment variables for the workers |
+| worker.envs_include_default | bool | `true` | Whether to include default environment variables |
 | worker.hpa.enabled | bool | `false` |  |
 | worker.hpa.maxReplicas | int | `100` |  |
 | worker.hpa.minReplicas | int | `1` |  |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -42,21 +42,16 @@ spec:
         command:
         {{- toYaml . | nindent 8 }}
 {{- end }}
-{{- if .Values.master.args }}
-        args:
-        {{- toYaml .Values.master.args | nindent 8 }}
-{{ else if .Values.master.args_include_default }}
         args:
           - --master
-          - --locustfile=/mnt/locust/{{ .Values.loadtest.locust_locustfile }}
-          - --host={{ .Values.loadtest.locust_host }}
-          - --loglevel={{ .Values.master.logLevel }}
+{{- if .Values.master.args }}
+        {{- toYaml .Values.master.args | nindent 8 }}
+{{- end }}
 {{- if .Values.loadtest.headless }}
           - --headless
+{{- end }}
 {{- if .Values.master.auth.enabled }}
           - --web-auth={{ cat .Values.master.auth.username ":" .Values.master.auth.password }}
-{{- end }}
-{{- end }}
 {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
@@ -77,9 +72,16 @@ spec:
 {{- if .Values.loadtest.mount_external_secret }}
 {{- include "locust.external_secret.volumemount" . | nindent 10 }}
 {{- end}}
+{{- if or .Values.master.envs_include_default .Values.loadtest.environment .Values.master.environment .Values.loadtest.environment_secret .Values.loadtest.environment_external_secret }}
         env:
+{{- if .Values.master.envs_include_default }}
           - name: LOCUST_HOST
             value: "{{ .Values.loadtest.locust_host }}"
+          - name: LOCUST_LOGLEVEL
+            value: "{{ .Values.master.logLevel }}"
+          - name: LOCUST_LOCUSTFILE
+            value: "/mnt/locust/{{ .Values.loadtest.locust_locustfile }}"
+{{- end }}
 {{- range $key, $value := .Values.loadtest.environment }}
           - name: {{ $key }}
             value: {{ $value | quote }}
@@ -102,6 +104,7 @@ spec:
               secretKeyRef:
                 name: {{ $key }}
                 key: {{ $value }}
+{{- end }}
 {{- end }}
 {{- end }}
         ports:

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -42,22 +42,16 @@ spec:
         command:
         {{- toYaml . | nindent 8 }}
 {{- end }}
-{{- if .Values.worker.args }}
-        args:
-        {{- toYaml .Values.worker.args | nindent 8 }}
-{{ else if .Values.worker.args_include_default }}
         args:
           - --worker
-          - --locustfile=/mnt/locust/{{ .Values.loadtest.locust_locustfile }}
-          - --host={{ .Values.loadtest.locust_host }}
-          - --master-host={{ template "locust.fullname" . }}
-          - --loglevel={{ .Values.worker.logLevel }}
+{{- if .Values.worker.args }}
+        {{- toYaml .Values.worker.args | nindent 8 }}
+{{- end }}
 {{- if .Values.loadtest.tags }}
           - --tags {{ .Values.loadtest.tags }}
 {{- end }}
 {{- if .Values.loadtest.excludeTags }}
           - --exclude-tags {{ .Values.loadtest.excludeTags }}
-{{- end }}
 {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
@@ -78,13 +72,20 @@ spec:
 {{- if .Values.loadtest.mount_external_secret }}
 {{- include "locust.external_secret.volumemount" . | nindent 10 }}
 {{- end}}
+{{- if or .Values.worker.envs_include_default .Values.loadtest.environment .Values.worker.environment .Values.loadtest.environment_secret .Values.loadtest.environment_external_secret }}
         env:
+{{- if .Values.worker.envs_include_default }}
           - name: LOCUST_HOST
             value: "{{ .Values.loadtest.locust_host }}"
-          - name: LOCUST_MASTER_HOST
+          - name: LOCUST_MASTER_NODE_HOST
             value: "{{ template "locust.fullname" . }}"
-          - name: LOCUST_MASTER_PORT
+          - name: LOCUST_MASTER_NODE_PORT
             value: "5557"
+          - name: LOCUST_LOGLEVEL
+            value: "{{ .Values.worker.logLevel }}"
+          - name: LOCUST_LOCUSTFILE
+            value: "/mnt/locust/{{ .Values.loadtest.locust_locustfile }}"
+{{- end }}
 {{- range $key, $value := .Values.worker.environment }}
           - name: {{ $key }}
             value: {{ $value | quote }}
@@ -107,6 +108,7 @@ spec:
               secretKeyRef:
                 name: {{ $key }}
                 key: {{ $value }}
+{{- end }}
 {{- end }}
 {{- end }}
       restartPolicy: Always

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -56,10 +56,10 @@ master:
     #   cpu: 1000m
     #   memory: 1024Mi
   serviceAccountAnnotations: {}
+  # master.envs_include_default -- Whether to include default environment variables
+  envs_include_default: true
   # master.environment -- environment variables for the master
   environment: {}
-  # master.args_include_default -- Whether to include default command args
-  args_include_default: true
   # master.args -- Any extra command args for the master
   args: []
   command:
@@ -96,10 +96,10 @@ worker:
     #   cpu: 500m
     #   memory: 256Mi
   serviceAccountAnnotations: {}
+  # worker.envs_include_default -- Whether to include default environment variables
+  envs_include_default: true
   # worker.environment -- environment variables for the workers
   environment: {}
-  # worker.args_include_default -- Whether to include default command args
-  args_include_default: true
   # worker.args -- Any extra command args for the workers
   args: []
   command:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
This PR makes some changes to the handling of parameters and environment variables in the chart:

- Currently, the [master](https://github.com/deliveryhero/helm-charts/blob/master/stable/locust/templates/master-deployment.yaml) and [worker](https://github.com/deliveryhero/helm-charts/blob/master/stable/locust/templates/worker-deployment.yaml) deployments don't handle arguments as expected.
Setting `Values.master.args` or `Values.workers.args` in the [values.yaml](https://github.com/deliveryhero/helm-charts/blob/master/stable/locust/values.yaml#L63) replaces all the default args, even if `Values.master.args_include_default` is true, which is not the expected outcome according to the comment/README. Also, other values (`Values.loadtest.headless`, `Values.master.auth.enabled`, `Values.loadtest.tags` and `Values.loadtest.excludeTags`) depend on `Values.master.args_include_default` being true, and `Values.master.args` being empty, which is not desirable.

- The `locust_host` is being set redundantly as an arg (`--host`) and as an env (`LOCUST_HOST`)

- Some env var names are [outdated](https://docs.locust.io/en/stable/configuration.html#all-available-configuration-options) (`LOCUST_MASTER_HOST` and `LOCUST_MASTER_PORT`)

- Since command args [override](https://docs.locust.io/en/stable/configuration.html#configuration-file) environment variables, in this PR I suggest passing most arguments to environment variables. This way, the user has more flexibility to override the chart's hardcoded defaults by passing an argument, which will override the chart's default config passed as an environment variable.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
