### PR TITLE
[stable/aws-service-events-exporter] Fix deployment labels indentation

### DIFF
--- a/stable/aws-service-events-exporter/Chart.yaml
+++ b/stable/aws-service-events-exporter/Chart.yaml
@@ -8,7 +8,7 @@ description: |
 
 
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "1.0.0"
 home: https://github.com/deliveryhero/aws-service-events-exporter
 sources:

--- a/stable/aws-service-events-exporter/README.md
+++ b/stable/aws-service-events-exporter/README.md
@@ -1,6 +1,6 @@
 # aws-service-events-exporter
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 This helm chart exports aws service events to prometheus via aws SQS queue, this include:
 

--- a/stable/aws-service-events-exporter/templates/deployment.yaml
+++ b/stable/aws-service-events-exporter/templates/deployment.yaml
@@ -17,9 +17,9 @@ spec:
       {{- end }}
       labels:
         {{- include "aws-service-events-exporter.selectorLabels" . | nindent 8 }}
-        {{- if .Values.extraLabels }}
-          {{ toYaml .Values.extraLabels | indent 8 }}
-        {{- end }}
+      {{- if .Values.extraLabels }}
+        {{ toYaml .Values.extraLabels | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
