### PR TITLE
[stable/locust] Bump Locust version to 2.1.0. Fixes #219

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: locust
-version: "0.19.25"
-appVersion: 1.4.4
+version: "0.20"
+appVersion: 2.1.0
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png
 maintainers:

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.19.25](https://img.shields.io/badge/Version-0.19.25-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 0.20](https://img.shields.io/badge/Version-0.20-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -68,7 +68,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"locustio/locust"` |  |
-| image.tag | string | `"1.4.4"` |  |
+| image.tag | string | `"2.1.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -34,7 +34,7 @@ loadtest:
 
 image:
   repository: locustio/locust
-  tag: 1.4.4
+  tag: 2.1.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
I'm not really a contributor to this repo, and have no idea if this will work. I'm very unsure about the versioning scheme for instance. But because I raised the issue, I guess I have to at least attempt to fix it :)

Bumping minor version, not just patch, because going from locust 1.x to 2.x is a potentially breaking change.

I'm also a little unsure if you prefer version. number 0.20.0 or 0.20. I'm skipping the .0 because I've seen it done like that in other places in the repo.