### PR TITLE
[stable/locust] Fix deployment arguments indentation

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.20"
+version: "0.20.1"
 appVersion: 2.1.0
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.20](https://img.shields.io/badge/Version-0.20-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.20.1](https://img.shields.io/badge/Version-0.20.1-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         args:
           - --master
 {{- if .Values.master.args }}
-        {{- toYaml .Values.master.args | nindent 8 }}
+          {{- toYaml .Values.master.args | nindent 10 }}
 {{- end }}
 {{- if .Values.loadtest.headless }}
           - --headless

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         args:
           - --worker
 {{- if .Values.worker.args }}
-        {{- toYaml .Values.worker.args | nindent 8 }}
+          {{- toYaml .Values.worker.args | nindent 10 }}
 {{- end }}
 {{- if .Values.loadtest.tags }}
           - --tags {{ .Values.loadtest.tags }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
I broke the indentation of the master and worker deployments' extra arguments with https://github.com/deliveryhero/helm-charts/pull/220

Sorry 🙏🏻 
<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
