### PR TITLE
[stable/mlflow] fix metadata.name of serviceaccount object

### DIFF
--- a/stable/mlflow/Chart.yaml
+++ b/stable/mlflow/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   This Helm chart is using Postgresql as backend and S3 as artifact store.
   Contributions for other backends and artifacts store are welcome.
 type: application
-version: 1.0.1
+version: 1.0.2
 home: https://www.mlflow.org/
 icon: https://www.mlflow.org/docs/latest/_static/MLflow-logo-final-black.png
 appVersion: "1.9.1"

--- a/stable/mlflow/README.md
+++ b/stable/mlflow/README.md
@@ -78,7 +78,7 @@ helm install my-release deliveryhero/mlflow -f values.yaml
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
+| serviceAccount.create | bool | `false` | Specifies whether a service account should be created. If true, mlflow.fullname template is used as name. |
 
 ## Maintainers
 

--- a/stable/mlflow/README.md
+++ b/stable/mlflow/README.md
@@ -1,6 +1,6 @@
 # mlflow
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.1](https://img.shields.io/badge/AppVersion-1.9.1-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.1](https://img.shields.io/badge/AppVersion-1.9.1-informational?style=flat-square)
 
 A Helm chart to install MLflow tracking, a tool to track Machine Learning experiments.
 
@@ -78,7 +78,7 @@ helm install my-release deliveryhero/mlflow -f values.yaml
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `false` |  |
+| serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 
 ## Maintainers
 

--- a/stable/mlflow/templates/serviceaccount.yaml
+++ b/stable/mlflow/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "mlflow.serviceAccountName" . }}
+  name: {{ include "mlflow.fullname" . }}
   labels:
     {{- include "mlflow.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/stable/mlflow/values.yaml
+++ b/stable/mlflow/values.yaml
@@ -17,7 +17,7 @@ service:
   port: 80
 
 serviceAccount:
-  # serviceAccount.create -- Specifies whether a service account should be created
+  # serviceAccount.create -- Specifies whether a service account should be created. If true, mlflow.fullname template is used as name.
   create: false
   annotations: {}
 

--- a/stable/mlflow/values.yaml
+++ b/stable/mlflow/values.yaml
@@ -17,6 +17,7 @@ service:
   port: 80
 
 serviceAccount:
+  # serviceAccount.create -- Specifies whether a service account should be created
   create: false
   annotations: {}
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
