### PR TITLE
[stable/node-problem-detector] Upgrade node-problem-detector to v0.8.10

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.0.5"
-appVersion: v0.8.9
+version: "2.0.6"
+appVersion: v0.8.10
 home: https://github.com/kubernetes/node-problem-detector
 description: |
   This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![AppVersion: v0.8.9](https://img.shields.io/badge/AppVersion-v0.8.9-informational?style=flat-square)
+![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![AppVersion: v0.8.10](https://img.shields.io/badge/AppVersion-v0.8.10-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -57,7 +57,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | hostPID | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"k8s.gcr.io/node-problem-detector/node-problem-detector"` |  |
-| image.tag | string | `"v0.8.9"` |  |
+| image.tag | string | `"v0.8.10"` |  |
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -52,7 +52,7 @@ logDir:
 
 image:
   repository: k8s.gcr.io/node-problem-detector/node-problem-detector
-  tag: v0.8.9
+  tag: v0.8.10
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

This pr bumps `node-problem-detector` version to [v0.8.10](https://github.com/kubernetes/node-problem-detector/releases/tag/v0.8.10).

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
