### PR TITLE
mlflow: fix the container target port for service object

### DIFF
--- a/stable/mlflow/Chart.yaml
+++ b/stable/mlflow/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   This Helm chart is using Postgresql as backend and S3 as artifact store.
   Contributions for other backends and artifacts store are welcome.
 type: application
-version: 1.0.2
+version: 1.0.3
 home: https://www.mlflow.org/
 icon: https://www.mlflow.org/docs/latest/_static/MLflow-logo-final-black.png
 appVersion: "1.9.1"

--- a/stable/mlflow/README.md
+++ b/stable/mlflow/README.md
@@ -1,6 +1,6 @@
 # mlflow
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.1](https://img.shields.io/badge/AppVersion-1.9.1-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.1](https://img.shields.io/badge/AppVersion-1.9.1-informational?style=flat-square)
 
 A Helm chart to install MLflow tracking, a tool to track Machine Learning experiments.
 

--- a/stable/mlflow/README.md
+++ b/stable/mlflow/README.md
@@ -49,6 +49,7 @@ helm install my-release deliveryhero/mlflow -f values.yaml
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| deployment.port | int | `5000` |  |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -75,7 +76,7 @@ helm install my-release deliveryhero/mlflow -f values.yaml
 | mlflow.s3.path | string | `"s3://mlflow"` |  |
 | mlflow.tolerations | list | `[]` |  |
 | nameOverride | string | `""` |  |
-| service.port | int | `80` |  |
+| service.port | int | `5000` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created. If true, mlflow.fullname template is used as name. |

--- a/stable/mlflow/templates/deployment.yaml
+++ b/stable/mlflow/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           ]
           ports:
             - name: http
-              containerPort: 5000
+              containerPort: {{ .Values.deployment.port }}
           readinessProbe:
             httpGet:
               path: /

--- a/stable/mlflow/templates/service.yaml
+++ b/stable/mlflow/templates/service.yaml
@@ -10,4 +10,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - name: http
-      port: {{ .Values.service.port }}
+      port: 80
+      protocol: TCP
+      targetPort: {{ .Values.service.port }}
+

--- a/stable/mlflow/values.yaml
+++ b/stable/mlflow/values.yaml
@@ -14,7 +14,10 @@ extraLabels: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 5000
+
+deployment:
+  port: 5000
 
 serviceAccount:
   # serviceAccount.create -- Specifies whether a service account should be created. If true, mlflow.fullname template is used as name.


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

mlflow: fix the container target port for service object

<!--- Describe your changes in detail -->

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
