### PR TITLE
mlflow: Adding a fix for using a different value for targetport

### DIFF
--- a/stable/mlflow/Chart.yaml
+++ b/stable/mlflow/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   This Helm chart is using Postgresql as backend and S3 as artifact store.
   Contributions for other backends and artifacts store are welcome.
 type: application
-version: 1.0.3
+version: 1.0.4
 home: https://www.mlflow.org/
 icon: https://www.mlflow.org/docs/latest/_static/MLflow-logo-final-black.png
 appVersion: "1.9.1"

--- a/stable/mlflow/README.md
+++ b/stable/mlflow/README.md
@@ -1,6 +1,6 @@
 # mlflow
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.1](https://img.shields.io/badge/AppVersion-1.9.1-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.1](https://img.shields.io/badge/AppVersion-1.9.1-informational?style=flat-square)
 
 A Helm chart to install MLflow tracking, a tool to track Machine Learning experiments.
 
@@ -76,7 +76,8 @@ helm install my-release deliveryhero/mlflow -f values.yaml
 | mlflow.s3.path | string | `"s3://mlflow"` |  |
 | mlflow.tolerations | list | `[]` |  |
 | nameOverride | string | `""` |  |
-| service.port | int | `5000` |  |
+| service.port | int | `80` |  |
+| service.targetPort | int | `5000` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created. If true, mlflow.fullname template is used as name. |

--- a/stable/mlflow/README.md
+++ b/stable/mlflow/README.md
@@ -49,7 +49,6 @@ helm install my-release deliveryhero/mlflow -f values.yaml
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| deployment.port | int | `5000` |  |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/stable/mlflow/templates/deployment.yaml
+++ b/stable/mlflow/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           ]
           ports:
             - name: http
-              containerPort: {{ .Values.deployment.port }}
+              containerPort: {{ .Values.service.targetPort }}
           readinessProbe:
             httpGet:
               path: /

--- a/stable/mlflow/templates/service.yaml
+++ b/stable/mlflow/templates/service.yaml
@@ -10,7 +10,6 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - name: http
-      port: 80
+      port: {{ .Values.service.port }}
       protocol: TCP
-      targetPort: {{ .Values.service.port }}
-
+      targetPort: {{ .Values.service.targetPort }}

--- a/stable/mlflow/values.yaml
+++ b/stable/mlflow/values.yaml
@@ -17,9 +17,6 @@ service:
   port: 80
   targetPort: 5000
 
-deployment:
-  port: 5000
-
 serviceAccount:
   # serviceAccount.create -- Specifies whether a service account should be created. If true, mlflow.fullname template is used as name.
   create: false

--- a/stable/mlflow/values.yaml
+++ b/stable/mlflow/values.yaml
@@ -14,7 +14,8 @@ extraLabels: {}
 
 service:
   type: ClusterIP
-  port: 5000
+  port: 80
+  targetPort: 5000
 
 deployment:
   port: 5000


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

mlflow: Adding a fix for using a different value for targetport

<!--- Describe your changes in detail -->

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
