### PR TITLE
[stable/node-problem-detector] Add Mount permission for configmaps and secrets inside clusterrole

### DIFF
--- a/stable/node-problem-detector/templates/clusterrole.yaml
+++ b/stable/node-problem-detector/templates/clusterrole.yaml
@@ -18,6 +18,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - mount
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - mount
+- apiGroups:
+  - ""
+  resources:
   - nodes/status
   verbs:
   - patch


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
I made this change to fix this [issue](https://github.com/deliveryhero/helm-charts/issues/234) The daemonset was unable to mount configmaps or secrets.
<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
