### PR TITLE
[stable/node-problem-detector] Issue-240: Added namespace field in daemonset template yaml

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.0.6"
+version: "2.0.7"
 appVersion: v0.8.10
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![AppVersion: v0.8.10](https://img.shields.io/badge/AppVersion-v0.8.10-informational?style=flat-square)
+![Version: 2.0.7](https://img.shields.io/badge/Version-2.0.7-informational?style=flat-square) ![AppVersion: v0.8.10](https://img.shields.io/badge/AppVersion-v0.8.10-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- range $key, $val := .Values.labels }}
     {{ $key }}: {{ $val | quote }}
     {{- end}}
+  namespace: {{ .Release.Namespace }}
 spec:
   updateStrategy:
     type: {{ .Values.updateStrategy }}


### PR DESCRIPTION
Signed-off-by: Sahil Raja <sahilraja242@gmail.com>

## Description

Addresses #240 

The changes add namespace field in the daemonset yaml. This is a common pattern implemented in most Helm charts and allows clients to install the chart into a namespace by passing the standard --namespace flag to Helm.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
