### PR TITLE
[stable/locust] Concatenate username:password without adding spaces

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.20.2"
+version: "0.20.3"
 appVersion: 2.1.0
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.20.2](https://img.shields.io/badge/Version-0.20.2-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.20.3](https://img.shields.io/badge/Version-0.20.3-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -54,7 +54,7 @@ spec:
           - --headless
 {{- end }}
 {{- if .Values.master.auth.enabled }}
-          - --web-auth={{ cat .Values.master.auth.username ":" .Values.master.auth.password }}
+          - --web-auth={{ .Values.master.auth.username }}:{{ .Values.master.auth.password }}
 {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:


### PR DESCRIPTION
## Description

Swap out the `cat` function for manual concatenation. The [`cat`](https://helm.sh/docs/chart_template_guide/function_list/#cat) function adds spaces between the fields, which creates invalid manifests.

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
