### PR TITLE
Fix command to push helm charts

### DIFF
--- a/.github/workflows/push-chart.yaml
+++ b/.github/workflows/push-chart.yaml
@@ -24,4 +24,4 @@ jobs:
         env:
           HELM_REPO_USERNAME: ${{ secrets.CHARTMUSEUM_USER }}
           HELM_REPO_PASSWORD: ${{ secrets.CHARTMUSEUM_PASS }}
-        run: for chart in stable/*; do helm dependencies update $chart && helm push $chart deliveryhero; done
+        run: for chart in stable/*; do helm dependencies update $chart && helm cm-push $chart deliveryhero; done

--- a/.github/workflows/push-chart.yaml
+++ b/.github/workflows/push-chart.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install git
         run: apk add --no-cache git
       - name: Install Helm Push plugin
-        run: helm plugin install https://github.com/chartmuseum/helm-push
+        run: helm plugin install https://github.com/chartmuseum/helm-push --version=0.10.0
       - name: Adding DH repository
         run: helm repo add deliveryhero https://charts.deliveryhero.io/
       - name: Push charts to DH repository


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Helm push plugin uses cm-push command instead of push command now

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
