### PR TITLE
[stable/prometheus-aws-limits-exporter ] Add serviceMonitor

### DIFF
--- a/stable/prometheus-aws-limits-exporter/Chart.yaml
+++ b/stable/prometheus-aws-limits-exporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.1.3
+version: 0.1.4
 
 appVersion: "0.4.0"
 

--- a/stable/prometheus-aws-limits-exporter/README.md
+++ b/stable/prometheus-aws-limits-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-aws-limits-exporter
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 This helmchart provides a Prometheus metrics endpoint that exposes AWS usage and limits as reported by the AWS Trusted Advisor API.
 
@@ -70,6 +70,7 @@ helm install my-release deliveryhero/prometheus-aws-limits-exporter -f values.ya
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| serviceMonitor.create | bool | `false` |  |
 | tolerations | list | `[]` |  |
 
 ## Maintainers

--- a/stable/prometheus-aws-limits-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-aws-limits-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceMonitor.create -}}
+apiVersion: "monitoring.coreos.com/v1"
+kind: ServiceMonitor
+metadata:
+  name: {{ include "prometheus-aws-limits-exporter.fullname" . }}
+  labels:
+  {{- include "prometheus-aws-limits-exporter.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - path: /metrics
+      port: http
+  selector:
+    matchLabels:
+      {{- include "prometheus-aws-limits-exporter.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/stable/prometheus-aws-limits-exporter/values.yaml
+++ b/stable/prometheus-aws-limits-exporter/values.yaml
@@ -23,6 +23,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+serviceMonitor:
+  # Specifies wether a service monitor should be created
+  # Use this for prometheus-operator support
+  create: false
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
## Description

Add an optional ServiceMonitor to support scraping from [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator)

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
