### PR TITLE
[stable/toxiproxy] Added pod annotations field to deployment template

### DIFF
--- a/stable/toxiproxy/Chart.yaml
+++ b/stable/toxiproxy/Chart.yaml
@@ -17,7 +17,7 @@ description: |
   helm install toxiproxy deliveryhero/toxiproxy --set toxiproxyConfig=my-toxiproxy-config
   ```
 
-version: "1.3.5"
+version: "1.3.6"
 appVersion: "2.1.2"
 home: https://github.com/Shopify/toxiproxy
 sources:

--- a/stable/toxiproxy/README.md
+++ b/stable/toxiproxy/README.md
@@ -86,6 +86,7 @@ helm install my-release deliveryhero/toxiproxy -f values.yaml
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget |
+| podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |

--- a/stable/toxiproxy/README.md
+++ b/stable/toxiproxy/README.md
@@ -1,6 +1,6 @@
 # toxiproxy
 
-![Version: 1.3.5](https://img.shields.io/badge/Version-1.3.5-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
+![Version: 1.3.6](https://img.shields.io/badge/Version-1.3.6-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
 
 A TCP proxy to simulate network and system conditions for chaos and resiliency testing.
 

--- a/stable/toxiproxy/templates/deployment.yaml
+++ b/stable/toxiproxy/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
 {{ include "toxiproxy.labels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}
+{{- with .Values.podAnnotations }}
+{{ toYaml . | trim | indent 8 }}
+{{- end}}
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/toxiproxy/values.yaml
+++ b/stable/toxiproxy/values.yaml
@@ -102,6 +102,8 @@ resources: {}
 
 deploymentAnnotations: {}
 
+podAnnotations: {}
+
 extraLabels: {}
 
 nodeSelector: {}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Added a new field so that we can specify pod annotations to be used when installing the Toxiproxy chart. Changes are basically the same as what's already existing in the Wiremock charts. 

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
