### PR TITLE
[stable/prometheus-aws-limits-exporter] Update appVersion and use health endpoint

### DIFF
--- a/stable/prometheus-aws-limits-exporter/Chart.yaml
+++ b/stable/prometheus-aws-limits-exporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.1.4
+version: 0.2.0
 
 appVersion: "0.6.0"
 

--- a/stable/prometheus-aws-limits-exporter/Chart.yaml
+++ b/stable/prometheus-aws-limits-exporter/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 version: 0.1.4
 
-appVersion: "0.4.0"
+appVersion: "0.6.0"
 
 home: https://github.com/danielfm/aws-limits-exporter
 sources:

--- a/stable/prometheus-aws-limits-exporter/README.md
+++ b/stable/prometheus-aws-limits-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-aws-limits-exporter
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 This helmchart provides a Prometheus metrics endpoint that exposes AWS usage and limits as reported by the AWS Trusted Advisor API.
 

--- a/stable/prometheus-aws-limits-exporter/templates/deployment.yaml
+++ b/stable/prometheus-aws-limits-exporter/templates/deployment.yaml
@@ -50,12 +50,12 @@ spec:
           {{- if not .Values.development_mode }}
           livenessProbe:
             httpGet:
-              path: /metrics
+              path: /-/healthy
               port: 8080
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /metrics
+              path: /-/healthy
               port: 8080
             timeoutSeconds: 10
           {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

In our deployment of the aws-limits-exporter, we experienced readiness/liveness probe timeouts and AWS rate limit exceedence. The reason for this is that all metrics are retrieved every time a probe is performed.

Since aws-limits-exporter version 0.5.0, there is a dedicated health endpoint.

This PR updates the appVersion to use the new aws-limits-exporter containing the health endpoint and updating the helm chart to use this health endpoint as readiness and liveness probe.

As the helm chart change requires appVersion at least to be 0.5.0, we increased the minor version of the Chart.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
