### PR TITLE
[stable/k8s-resources] Support tpl secret values via .Values.Secrets[].tplB64Keys

### DIFF
--- a/stable/k8s-resources/Chart.yaml
+++ b/stable/k8s-resources/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.4.0
+version: 0.5.0
 appVersion: 0.0.1
 name: k8s-resources
 description: |

--- a/stable/k8s-resources/README.md
+++ b/stable/k8s-resources/README.md
@@ -1,6 +1,6 @@
 # k8s-resources
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Not an application but a Helm chart to create any and many resources in Kubernetes.
 

--- a/stable/k8s-resources/ci/ct-values.yaml
+++ b/stable/k8s-resources/ci/ct-values.yaml
@@ -43,7 +43,7 @@ Secrets:
     annotations: {}
     extraLabels: {}
     tplB64Keys:
-      key1: '{{ .Values.Secrets[0].name }}'
+      key1: '{{ (index .Values.Secrets 0).name }}'
     b64Keys:
       key2: value1
     keys:
@@ -53,7 +53,7 @@ Secrets:
     annotations: {}
     extraLabels: {}
     tplB64Keys:
-      key1: '{{ .Values.Secrets[0].name }}'
+      key1: '{{ (index .Values.Secrets 0).name }}'
     b64Keys:
       key2: value1
     keys:

--- a/stable/k8s-resources/ci/ct-values.yaml
+++ b/stable/k8s-resources/ci/ct-values.yaml
@@ -42,18 +42,22 @@ Secrets:
     fullnameOverride: ""
     annotations: {}
     extraLabels: {}
+    tplB64Keys:
+      key1: '{{ .Values.Secrets[0].name }}'
     b64Keys:
-      key1: value1
+      key2: value1
     keys:
-      key2: dmFsdWUyCg==
+      key3: dmFsdWUyCg==
   - name: example-secret-2
     fullnameOverride: ""
     annotations: {}
     extraLabels: {}
+    tplB64Keys:
+      key1: '{{ .Values.Secrets[0].name }}'
     b64Keys:
-      key1: value1
+      key2: value1
     keys:
-      key2: dmFsdWUyCg==
+      key3: dmFsdWUyCg==
 
 Services:
   - name: example-service

--- a/stable/k8s-resources/templates/secret.yaml
+++ b/stable/k8s-resources/templates/secret.yaml
@@ -19,7 +19,7 @@ metadata:
   {{- end }}
 data:
 {{- if .tplB64Keys -}}
-{{- range $key, $value := .b64Keys }}
+{{- range $key, $value := .tplB64Keys }}
   {{ $key }}: {{ tpl $value $ | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/secret.yaml
+++ b/stable/k8s-resources/templates/secret.yaml
@@ -18,6 +18,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
+{{- if .tplB64Keys -}}
+{{- range $key, $value := .b64Keys }}
+  {{ $key }}: {{ tpl $value $ | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- if .b64Keys -}}
 {{- range $key, $value := .b64Keys }}
   {{ $key }}: {{ $value | b64enc | quote }}

--- a/stable/k8s-resources/values.yaml
+++ b/stable/k8s-resources/values.yaml
@@ -63,10 +63,12 @@ Secrets: []
   #   fullnameOverride: ""
   #   annotations: {}
   #   extraLabels: {}
+  #   tplB64Keys:
+  #     key1: '{{ print "https://%s:%s@%s" .Values.my.user .Values.my.pass .Values.my.host }}'
   #   b64Keys:
-  #     key1: value1
+  #     key2: value1
   #   keys:
-  #     key2: key2: dmFsdWUyCg==
+  #     key3: dmFsdWUyCg==
 
 # Services -- A list Service to create
 Services: []


### PR DESCRIPTION
## Description

I have some secrets that I template based on several other values.
I load those other values using helm-secrets. But, I need to combine them into a db connection string.
Using `tpl .tplB64Keys $` allows me to define the secret as a templatable value.

I opted to create a separate `tplB64Keys` so that this won't inadvertently affect anyone using `b64Keys`.
So, this should be backwards compatible.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
