### PR TITLE
[stable/cluster-overprovisioner] resolve pdb deprecation warning

### DIFF
--- a/ci/helm-conftest.sh
+++ b/ci/helm-conftest.sh
@@ -18,11 +18,12 @@ else
   CONFTEST=$(which conftest)
 fi
 
-for chart in $(find stable -maxdepth 1 -mindepth 1); do
+while IFS= read -r -d '' chart
+do
   echo "=============================================================="
   echo "helm-conftest running for chart: ${chart}..."
   # Remove any dependencies as we are not going to test them
   rm -f "${chart}/requirements.yaml"
   rm -rf "${chart}/charts"
   helm template "${chart}" | $CONFTEST -p ci/helm-conftest-policies test -
-done
+done < <(find stable -maxdepth 1 -mindepth 1 -print0)

--- a/ci/helm-docs.sh
+++ b/ci/helm-docs.sh
@@ -8,8 +8,8 @@ ALL_CHARTS=$(ls stable)
 
 # Create a copy of each README.md files before running helm-docs
 for chart in $ALL_CHARTS; do
-  mkdir -p .stable/$chart
-  cp stable/$chart/README.md .stable/$chart/README.md
+  mkdir -p ".stable/$chart"
+  cp "stable/$chart/README.md" ".stable/$chart/README.md"
 done
 
 # Run helm-docs to generate all README.md files from the template
@@ -19,10 +19,10 @@ helm-docs --log-level warning --template-files ./ci/README.md.gotmpl
 set +e
 for chart in $ALL_CHARTS; do
   echo "Checking stable/$chart/README.md..."
-  diff -s stable/$chart/README.md .stable/$chart/README.md > /dev/null
+  diff -s "stable/$chart/README.md" ".stable/$chart/README.md" > /dev/null
   if [ $? -eq 1 ]; then
     echo "🔴 Error: file stable/$chart/README.md needs to be updated: "
-    diff stable/$chart/README.md .stable/$chart/README.md
+    diff "stable/$chart/README.md" ".stable/$chart/README.md"
     echo "See main repo README.md for instructions"
     rm -rf .stable
     exit 1

--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.7.4
+version: 0.7.5
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![AppVersion: 3.1](https://img.shields.io/badge/AppVersion-3.1-informational?style=flat-square)
+![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square) ![AppVersion: 3.1](https://img.shields.io/badge/AppVersion-3.1-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 

--- a/stable/cluster-overprovisioner/templates/pdb.yaml
+++ b/stable/cluster-overprovisioner/templates/pdb.yaml
@@ -7,7 +7,7 @@
 {{- $deploymentName := .name }}
 {{- if .pdb }}
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ $fullname }}-{{ $deploymentName }}"


### PR DESCRIPTION
* PDB's are deprecated in policy/v1beta1 from 1.25
* fix helm-conftest.sh to be compliant with shellcheck and make
  executable
* fix helm-docs.sh to be compliant with shellcheck

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
