### PR TITLE
[stable/locust] Fix httpHeaders Authorization header value

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -7,8 +7,6 @@ icon: https://locust.io/static/img/logo.png
 maintainers:
 - name: max-rocket-internet
   email: no-reply@deliveryhero.com
-- name: Valerii Tatarin
-  email: bugaga1100@gmail.com
 description: |
   A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,12 +1,14 @@
 apiVersion: v1
 name: locust
-version: "0.21.0"
+version: "0.21.1"
 appVersion: 2.1.0
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png
 maintainers:
 - name: max-rocket-internet
   email: no-reply@deliveryhero.com
+- name: Valerii Tatarin
+  email: bugaga1100@gmail.com
 description: |
   A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.21.1](https://img.shields.io/badge/Version-0.21.1-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -133,3 +133,4 @@ helm install my-release deliveryhero/locust -f values.yaml
 | Name | Email | Url |
 | ---- | ------ | --- |
 | max-rocket-internet | no-reply@deliveryhero.com |  |
+| Valerii Tatarin | bugaga1100@gmail.com |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -133,4 +133,3 @@ helm install my-release deliveryhero/locust -f values.yaml
 | Name | Email | Url |
 | ---- | ------ | --- |
 | max-rocket-internet | no-reply@deliveryhero.com |  |
-| Valerii Tatarin | bugaga1100@gmail.com |  |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -135,7 +135,7 @@ spec:
 {{- if .Values.master.auth.enabled }}
             httpHeaders:
                 - name: Authorization
-                  value: Basic {{ cat .Values.master.auth.username ":" .Values.master.auth.password | b64enc }}
+                  value: Basic {{ printf "%s:%s" .Values.master.auth.username .Values.master.auth.password | b64enc }}
 {{- end }}
 {{- end }}
       restartPolicy: Always


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

The current implementation of health check with Basic Auth is incorrect due to an error in the code below:
```
{{- if .Values.master.auth.enabled }}
            httpHeaders:
                - name: Authorization
                  value: Basic {{ cat .Values.master.auth.username ":" .Values.master.auth.password | b64enc }}
```
to be more precise, `cat .Values.master.auth.username ":" .Values.master.auth.password` generates a string `username : password` (see spaces) according to the [Helm documentation](https://helm.sh/docs/chart_template_guide/function_list/#cat).

This results in a pod being unable to start since the base64 encoded Authorization header is not what locust is expecting (it should be a string **without** spaces):
```
Events:
  Type     Reason     Age                   From               Message
  ----     ------     ----                  ----               -------
  Normal   Scheduled  4m55s                 default-scheduler  Successfully assigned locust/deliveryhero-locust-master-7755dbffb5-2kbss to cluster
  Normal   Pulled     4m54s                 kubelet            Container image "locustio/locust:2.4.0" already present on machine
  Normal   Created    4m54s                 kubelet            Created container locust
  Normal   Started    4m54s                 kubelet            Started container locust
  Warning  Unhealthy  19s (x10 over 4m49s)  kubelet            Readiness probe failed: HTTP probe failed with statuscode: 401
```

My proposal is to switch to a `printf` function which generates a string in a correct format: `username:password` (no spaces) which can be base64 encoded later into a correct authorization header.

Thank you in advance!

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
