### PR TITLE
[stable/locust] Add support for annotations on deployments

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.21.1"
+version: "0.22.0"
 appVersion: 2.1.0
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.21.1](https://img.shields.io/badge/Version-0.21.1-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -96,6 +96,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | master.auth.username | string | `""` |  |
 | master.command[0] | string | `"sh"` |  |
 | master.command[1] | string | `"/config/docker-entrypoint.sh"` |  |
+| master.deploymentAnnotations | object | `{}` | Annotations on the deployment for master |
 | master.environment | object | `{}` | environment variables for the master |
 | master.envs_include_default | bool | `true` | Whether to include default environment variables |
 | master.image | string | `""` | A custom docker image including tag |
@@ -115,6 +116,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | worker.args | list | `[]` | Any extra command args for the workers |
 | worker.command[0] | string | `"sh"` |  |
 | worker.command[1] | string | `"/config/docker-entrypoint.sh"` |  |
+| worker.deploymentAnnotations | object | `{}` | Annotations on the deployment for workers |
 | worker.environment | object | `{}` | environment variables for the workers |
 | worker.envs_include_default | bool | `true` | Whether to include default environment variables |
 | worker.hpa.enabled | bool | `false` |  |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     component: master
 {{ include "locust.labels" . | indent 4 }}
+{{- with .Values.master.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     component: worker
 {{ include "locust.labels" . | indent 4 }}
+{{- with .Values.worker.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -56,6 +56,8 @@ master:
     #   cpu: 1000m
     #   memory: 1024Mi
   serviceAccountAnnotations: {}
+  # master.deploymentAnnotations -- Annotations on the deployment for master
+  deploymentAnnotations: {}
   # master.envs_include_default -- Whether to include default environment variables
   envs_include_default: true
   # master.environment -- environment variables for the master
@@ -96,6 +98,8 @@ worker:
     #   cpu: 500m
     #   memory: 256Mi
   serviceAccountAnnotations: {}
+  # worker.deploymentAnnotations -- Annotations on the deployment for workers
+  deploymentAnnotations: {}
   # worker.envs_include_default -- Whether to include default environment variables
   envs_include_default: true
   # worker.environment -- environment variables for the workers


### PR DESCRIPTION
## Description
Added support for specifying annotations on deployments. 
`annotations` is already used for podAnnotations so added  `deploymentAnnotations`. 

They are required when using some tools like [Reloader](https://github.com/stakater/Reloader) 
