### PR TITLE
[stable/locust] make restart policy tunable

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.22.0"
+version: "0.23.0"
 appVersion: 2.1.0
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -103,6 +103,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | master.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
 | master.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the master pod |
 | master.resources | object | `{}` | resources for the locust master |
+| master.restartPolicy | string | `"Always"` | master pod's restartPolicy. Can be Always, OnFailure, or Never. |
 | master.serviceAccountAnnotations | object | `{}` |  |
 | master.strategy.type | string | `"RollingUpdate"` |  |
 | nameOverride | string | `""` |  |
@@ -127,6 +128,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | worker.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
 | worker.replicas | int | `1` |  |
 | worker.resources | object | `{}` | resources for the locust worker |
+| worker.restartPolicy | string | `"Always"` | worker pod's restartPolicy. Can be Always, OnFailure, or Never. |
 | worker.serviceAccountAnnotations | object | `{}` |  |
 | worker.strategy.type | string | `"RollingUpdate"` |  |
 

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -142,7 +142,7 @@ spec:
                   value: Basic {{ printf "%s:%s" .Values.master.auth.username .Values.master.auth.password | b64enc }}
 {{- end }}
 {{- end }}
-      restartPolicy: Always
+      restartPolicy: {{ .Values.master.restartPolicy }}
       volumes:
         - name: lib
           configMap:

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -118,7 +118,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-      restartPolicy: Always
+      restartPolicy: {{ .Values.worker.restartPolicy }}
       volumes:
         - name: lib
           configMap:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -77,6 +77,8 @@ master:
     enabled: false
     username: ""
     password: ""
+  # master.restartPolicy -- master pod's restartPolicy. Can be Always, OnFailure, or Never.
+  restartPolicy: Always
 
 worker:
   # worker.image -- A custom docker image including tag
@@ -111,6 +113,8 @@ worker:
     - /config/docker-entrypoint.sh
   strategy:
     type: RollingUpdate
+  # worker.restartPolicy -- worker pod's restartPolicy. Can be Always, OnFailure, or Never.
+  restartPolicy: Always
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Allow the locust master and worker pod restart policy to be tunable. Basically when I have `autoquit` option set, with `restartPolicy` set to `Always`, it will attempt to restart the pod even though I want it to terminate. This will allow me to tune it to `OnFailure`.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing