### PR TITLE
[stable/cluster-overprovisioner] allow configure command and args

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.7.5
+version: 0.7.6
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square) ![AppVersion: 3.1](https://img.shields.io/badge/AppVersion-3.1-informational?style=flat-square)
+![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square) ![AppVersion: 3.1](https://img.shields.io/badge/AppVersion-3.1-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -68,6 +68,8 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | deployments[0].tolerations | list | `[]` | Default Deployment - Optional deployment tolerations |
 | deployments[0].topologySpreadConstraints | list | `[]` | Default Deployment - Optional topology spread constraints |
 | fullnameOverride | string | `""` | Override the fullname of the chart |
+| image.args | list | `[]` | Override container args |
+| image.command | list | `[]` | Override container command |
 | image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | image.repository | string | `"k8s.gcr.io/pause"` | Image repository |
 | image.tag | string | `.Chart.AppVersion` | Image tag |

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -11,6 +11,8 @@
 {{- $priorityClassName := .Values.priorityClassOverprovision.name }}
 {{- $repository := .Values.image.repository }}
 {{- $imageTag := default .Chart.AppVersion .Values.image.tag }}
+{{- $imageCommand := .Values.image.command }}
+{{- $imageArgs := .Values.image.args }}
 {{- $pullPolicy := .Values.image.pullPolicy }}
 {{- $imagePullSecrets := .Values.image.pullSecrets }}
 {{- $serviceAccountName := include "cluster-overprovisioner.serviceAccountName" . -}}
@@ -61,6 +63,12 @@ spec:
           imagePullPolicy: {{ $pullPolicy }}
           resources:
             {{- toYaml .resources | nindent 12 }}
+          {{- with $imageCommand }}
+          command: {{ $imageCommand }}
+          {{- end }}
+          {{- with $imageArgs }}
+          args: {{ $imageArgs }}
+          {{- end }}
     {{- if $imagePullSecrets }}
       imagePullSecrets:
       {{- range $imagePullSecrets }}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -25,6 +25,10 @@ image:
   tag: ""
   # image.pullPolicy -- Container pull policy
   pullPolicy: IfNotPresent
+  # image.command -- Override container command
+  command: []
+  # image.args -- Override container args
+  args: []
 
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
## Description

This commit allow to configure command and args for container.

## Checklist

- [x] Title of the PR starts with chart name (e.g. [stable/mychartname])
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
