### PR TITLE
stable/net-exporter: Added a new chart net-exporter (from: giantswarm/net-exporter)

### DIFF
--- a/stable/net-exporter/Chart.yaml
+++ b/stable/net-exporter/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: "v1"
+name: net-exporter
+description: "Helm chart for net-exporter."
+home: "https://github.com/giantswarm/net-exporter"
+version: "1.10.3"
+appVersion: "1.10.3"
+annotations:
+  config.giantswarm.io/version: 1.x.x
+maintainers:
+- name: pciang
+  url: https://github.com/pciang

--- a/stable/net-exporter/README.md
+++ b/stable/net-exporter/README.md
@@ -1,0 +1,71 @@
+# net-exporter
+
+![Version: 1.10.3](https://img.shields.io/badge/Version-1.10.3-informational?style=flat-square) ![AppVersion: 1.10.3](https://img.shields.io/badge/AppVersion-1.10.3-informational?style=flat-square)
+
+Helm chart for net-exporter.
+
+**Homepage:** <https://github.com/giantswarm/net-exporter>
+
+## How to install this chart
+
+Add Delivery Hero public chart repo:
+
+```console
+helm repo add deliveryhero https://charts.deliveryhero.io/
+```
+
+A simple install with default values:
+
+```console
+helm install deliveryhero/net-exporter
+```
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release deliveryhero/net-exporter
+```
+
+To install with some set values:
+
+```console
+helm install my-release deliveryhero/net-exporter --set values_key1=value1 --set values_key2=value2
+```
+
+To install with custom values file:
+
+```console
+helm install my-release deliveryhero/net-exporter -f values.yaml
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| NetExporter.DNSCheck.TCP.Disabled | bool | `false` |  |
+| NetExporter.Hosts | string | `""` |  |
+| NetExporter.NTPServers | string | `""` |  |
+| controlPlaneSubnets | list | `[]` |  |
+| daemonset.priorityClassName | string | `"system-node-critical"` |  |
+| dns.label | string | `"coredns"` |  |
+| dns.namespace | string | `"kube-system"` |  |
+| dns.port | int | `1053` |  |
+| dns.service | string | `"coredns"` |  |
+| groupID | int | `1000` |  |
+| image.name | string | `"giantswarm/net-exporter"` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.tag | string | `"[[ .Version ]]"` |  |
+| kubectl.image.name | string | `"giantswarm/docker-kubectl"` |  |
+| kubectl.image.registry | string | `"docker.io"` |  |
+| kubectl.image.tag | string | `"1.18.8"` |  |
+| name | string | `"net-exporter"` |  |
+| port | int | `8000` |  |
+| serviceType | string | `"managed"` |  |
+| timeout | string | `"5s"` |  |
+| userID | int | `1000` |  |
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| pciang |  | https://github.com/pciang |

--- a/stable/net-exporter/templates/_helpers.tpl
+++ b/stable/net-exporter/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "labels.common" -}}
+{{ include "labels.selector" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/name: {{ .Values.name | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+giantswarm.io/service-type: "{{ .Values.serviceType }}"
+helm.sh/chart: {{ include "chart" . | quote }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "labels.selector" -}}
+app: {{ .Values.name | quote }}
+{{- end -}}

--- a/stable/net-exporter/templates/daemonset.yaml
+++ b/stable/net-exporter/templates/daemonset.yaml
@@ -1,0 +1,82 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: net-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "labels.common" . | nindent 8 }}
+      annotations:
+        releaseRevision: {{ $.Release.Revision | quote }}
+    spec:
+      initContainers:
+      - name: label-kube-system-namespace
+        image: "{{ .Values.image.registry }}/{{ .Values.kubectl.image.name }}:{{ .Values.kubectl.image.tag }}"
+        args:
+        - label
+        - namespace
+        - kube-system
+        - name=kube-system
+        - --overwrite=true
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+      ## In our Control Plane net-exporter runs on monitoring ns
+      ## By design Kubernetes does not allow to run critical pods
+      ## having Priority Class like system-node-critical out of
+      ## the namespace kube-system
+      ##
+      ## In the TC, net-exporter runs on kube-system and so this is fine
+      priorityClassName: {{ .Values.daemonset.priorityClassName }}
+      containers:
+      - name: net-exporter
+        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        args:
+          - "-namespace={{ .Release.Namespace }}"
+          - "-timeout={{ .Values.timeout }}"
+          - "-dns-service={{ .Values.dns.service }}"
+          {{- if (.Values.NetExporter.Hosts) }}
+          - "-hosts={{ .Values.NetExporter.Hosts }}"
+          {{- end }}
+          {{- if (.Values.NetExporter.NTPServers) }}
+          - "-ntp-servers={{ .Values.NetExporter.NTPServers }}"
+          {{- end }}
+          {{- if (.Values.NetExporter.DNSCheck.TCP.Disabled) }}
+          - "-disable-dns-tcp-check={{ .Values.NetExporter.DNSCheck.TCP.Disabled }}"
+          {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 5
+        resources:
+          # cpu limits removed so that throttling doesn't cause any unwanted
+          # side-effects to measurements.
+          requests:
+            cpu: 50m
+            memory: 75Mi
+          limits:
+            memory: 150Mi
+      serviceAccountName: net-exporter
+      securityContext:
+        runAsUser: {{ .Values.userID }}
+        runAsGroup: {{ .Values.groupID }}
+      tolerations:
+      # Tolerate all taints for observability
+      - operator: "Exists"

--- a/stable/net-exporter/templates/np.yaml
+++ b/stable/net-exporter/templates/np.yaml
@@ -1,0 +1,74 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.name }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+  - ports:
+    - port: {{ .Values.port }}
+      protocol: TCP
+    from:
+    - podSelector:
+        matchLabels:
+          {{- include "labels.selector" . | nindent 10 }}
+    - podSelector:
+        matchLabels:
+          app: prometheus
+    {{ $privateSubnets := list "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" }}
+    {{ range $index, $privateSubnet := $privateSubnets }}
+    - ipBlock:
+        cidr: {{ $privateSubnet }}
+    {{ end }}
+  egress:
+  - ports:
+    - port: {{ .Values.port }}
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          {{- include "labels.selector" . | nindent 10 }}
+  - ports:
+    - port: 123
+      protocol: UDP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+  - ports:
+    - port: {{ .Values.dns.port }}
+      protocol: UDP
+    - port: {{ .Values.dns.port }}
+      protocol: TCP
+    # legacy port kept for compatibility
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          k8s-app: {{ .Values.dns.label }}
+      namespaceSelector:
+        matchLabels:
+          name: {{ .Values.dns.namespace }}
+  - ports:
+    - port: 443
+      protocol: TCP
+    # legacy port kept for compatibility
+    - port: 6443
+      protocol: TCP
+    to:
+    {{ $privateSubnets := list "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" -}}
+    {{- range $index, $privateSubnet := $privateSubnets -}}
+    - ipBlock:
+        cidr: {{ $privateSubnet }}
+    {{ end -}}
+

--- a/stable/net-exporter/templates/psp.yaml
+++ b/stable/net-exporter/templates/psp.yaml
@@ -1,0 +1,28 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  volumes:
+    - 'secret'
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/stable/net-exporter/templates/rbac.yaml
+++ b/stable/net-exporter/templates/rbac.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: net-exporter
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  resourceNames:
+  - net-exporter
+  - {{ .Values.dns.service }}
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  resourceNames:
+  - {{ .Values.dns.namespace }}
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ .Values.name }}
+  verbs:
+  - "use"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: net-exporter
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: net-exporter
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: net-exporter
+  apiGroup: rbac.authorization.k8s.io

--- a/stable/net-exporter/templates/service-account.yaml
+++ b/stable/net-exporter/templates/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: net-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}

--- a/stable/net-exporter/templates/service.yaml
+++ b/stable/net-exporter/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: net-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    giantswarm.io/monitoring: "true"
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/scheme: "http"
+spec:
+  ports:
+    - port: {{ .Values.port }}
+  selector:
+    {{- include "labels.selector" . | nindent 4 }}

--- a/stable/net-exporter/values.yaml
+++ b/stable/net-exporter/values.yaml
@@ -1,0 +1,40 @@
+name: net-exporter
+serviceType: managed
+
+userID: 1000
+groupID: 1000
+
+port: 8000
+
+dns:
+  port: 1053
+  label: coredns
+  namespace: kube-system
+  service: coredns
+
+timeout: 5s
+
+image:
+  registry: docker.io
+  name: giantswarm/net-exporter
+  tag: "[[ .Version ]]"
+
+kubectl:
+  image:
+    registry: docker.io
+    name: giantswarm/docker-kubectl
+    tag: 1.18.8
+
+daemonset:
+  priorityClassName: system-node-critical
+
+# Control-plane subnets used to generate network policies
+# for managed applications.
+controlPlaneSubnets: []
+
+NetExporter:
+  Hosts: ""
+  NTPServers: ""
+  DNSCheck:
+    TCP:
+      Disabled: false


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

* Moved [net-exporter](https://github.com/giantswarm/net-exporter/tree/v1.10.3)`v1.10.3` to deliveryhero/helm-charts
* License is Apache v2, see: https://github.com/giantswarm/net-exporter/blob/v1.10.3/LICENSE

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
