### PR TITLE
[stable/net-exporter] Flexible resource name, labels and selector to fit our use case

### DIFF
--- a/stable/net-exporter/Chart.yaml
+++ b/stable/net-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v1"
 name: net-exporter
 description: "Helm chart for net-exporter."
 home: "https://github.com/giantswarm/net-exporter"
-version: "1.10.3"
+version: "1.10.3-deliveryhero.1"
 appVersion: "1.10.3"
 annotations:
   config.giantswarm.io/version: 1.x.x

--- a/stable/net-exporter/Chart.yaml
+++ b/stable/net-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v1"
 name: net-exporter
 description: "Helm chart for net-exporter."
 home: "https://github.com/giantswarm/net-exporter"
-version: "1.10.3-deliveryhero.1"
+version: "1.10.4"
 appVersion: "1.10.3"
 annotations:
   config.giantswarm.io/version: 1.x.x

--- a/stable/net-exporter/README.md
+++ b/stable/net-exporter/README.md
@@ -45,6 +45,7 @@ helm install my-release deliveryhero/net-exporter -f values.yaml
 | NetExporter.DNSCheck.TCP.Disabled | bool | `false` |  |
 | NetExporter.Hosts | string | `""` |  |
 | NetExporter.NTPServers | string | `""` |  |
+| additionalLabels | object | `{}` |  |
 | controlPlaneSubnets | list | `[]` |  |
 | daemonset.priorityClassName | string | `"system-node-critical"` |  |
 | dns.label | string | `"coredns"` |  |
@@ -60,6 +61,7 @@ helm install my-release deliveryhero/net-exporter -f values.yaml
 | kubectl.image.tag | string | `"1.18.8"` |  |
 | name | string | `"net-exporter"` |  |
 | port | int | `8000` |  |
+| selector.app | string | `"net-exporter"` |  |
 | serviceType | string | `"managed"` |  |
 | timeout | string | `"5s"` |  |
 | userID | int | `1000` |  |

--- a/stable/net-exporter/README.md
+++ b/stable/net-exporter/README.md
@@ -1,6 +1,6 @@
 # net-exporter
 
-![Version: 1.10.3](https://img.shields.io/badge/Version-1.10.3-informational?style=flat-square) ![AppVersion: 1.10.3](https://img.shields.io/badge/AppVersion-1.10.3-informational?style=flat-square)
+![Version: 1.10.4](https://img.shields.io/badge/Version-1.10.4-informational?style=flat-square) ![AppVersion: 1.10.3](https://img.shields.io/badge/AppVersion-1.10.3-informational?style=flat-square)
 
 Helm chart for net-exporter.
 

--- a/stable/net-exporter/templates/_helpers.tpl
+++ b/stable/net-exporter/templates/_helpers.tpl
@@ -9,18 +9,24 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "labels.common" -}}
-{{ include "labels.selector" . }}
+{{- include "labels.selector" . -}}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/name: {{ .Values.name | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 giantswarm.io/service-type: "{{ .Values.serviceType }}"
 helm.sh/chart: {{ include "chart" . | quote }}
+{{- if hasKey .Values "additionalLabels" }}
+{{- range $key, $value := .Values.additionalLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 {{/*
 Selector labels
 */}}
 {{- define "labels.selector" -}}
-app: {{ .Values.name | quote }}
+{{- range $key, $value := .Values.selector }}{{ $key }}: {{ $value | quote }}
+{{ end }}
 {{- end -}}

--- a/stable/net-exporter/templates/daemonset.yaml
+++ b/stable/net-exporter/templates/daemonset.yaml
@@ -1,7 +1,7 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: net-exporter
+  name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -38,7 +38,7 @@ spec:
       ## In the TC, net-exporter runs on kube-system and so this is fine
       priorityClassName: {{ .Values.daemonset.priorityClassName }}
       containers:
-      - name: net-exporter
+      - name: {{ .Values.name }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         args:
           - "-namespace={{ .Release.Namespace }}"
@@ -73,7 +73,7 @@ spec:
             memory: 75Mi
           limits:
             memory: 150Mi
-      serviceAccountName: net-exporter
+      serviceAccountName: {{ .Values.name }}
       securityContext:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.groupID }}

--- a/stable/net-exporter/templates/rbac.yaml
+++ b/stable/net-exporter/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: net-exporter
+  name: {{ .Values.name }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 rules:
@@ -11,7 +11,7 @@ rules:
   - services
   - endpoints
   resourceNames:
-  - net-exporter
+  - {{ .Values.name }}
   - {{ .Values.dns.service }}
   verbs:
   - get
@@ -44,14 +44,14 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: net-exporter
+  name: {{ .Values.name }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: net-exporter
+  name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: net-exporter
+  name: {{ .Values.name }}
   apiGroup: rbac.authorization.k8s.io

--- a/stable/net-exporter/templates/service-account.yaml
+++ b/stable/net-exporter/templates/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: net-exporter
+  name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/stable/net-exporter/templates/service.yaml
+++ b/stable/net-exporter/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: net-exporter
+  name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/stable/net-exporter/values.yaml
+++ b/stable/net-exporter/values.yaml
@@ -38,3 +38,8 @@ NetExporter:
   DNSCheck:
     TCP:
       Disabled: false
+
+selector:
+  app: net-exporter
+
+additionalLabels: {}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

* Minor change: flexible resource name, labels and selector to fit our use case

Example:

```yaml
- name: {{ $cluster.region }}-{{ $cluster.env }}-net-exporter
  chart: deliveryhero/net-exporter
  kubeContext: {{ $cluster.cluster }}
  labels:
    app: net-exporter
    cluster: {{ $cluster.cluster }}
    type: infra
  values:
    - name: {{ $cluster.region }}-{{ $cluster.env }}-net-exporter
    - timeout: 5s
    - selector:
        app: net-exporter
        rps_region: {{ $cluster.region }}
        env: {{ $cluster.env }}
    - additionalLabels:
        team: infra
        grafana: aVhTzk5Wz
        dh_region: {{ $cluster.region }}
        dh_env: {{ $cluster.env }}
        dh_app: net-exporter
        dh_tribe: RPS
        dh_squad: infra
```

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
