### PR TITLE
[stable/locust] Pass --tags/--exclude-tags through the locust master

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.23.0"
+version: "0.24.0"
 appVersion: 2.1.0
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -60,6 +60,12 @@ spec:
 {{- if .Values.master.auth.enabled }}
           - --web-auth={{ .Values.master.auth.username }}:{{ .Values.master.auth.password }}
 {{- end }}
+{{- if .Values.loadtest.tags }}
+          - --tags {{ .Values.loadtest.tags }}
+{{- end }}
+{{- if .Values.loadtest.excludeTags }}
+          - --exclude-tags {{ .Values.loadtest.excludeTags }}
+{{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
 {{ toYaml .Values.master.resources | indent 10 }}

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -54,12 +54,6 @@ spec:
 {{- if .Values.worker.args }}
           {{- toYaml .Values.worker.args | nindent 10 }}
 {{- end }}
-{{- if .Values.loadtest.tags }}
-          - --tags {{ .Values.loadtest.tags }}
-{{- end }}
-{{- if .Values.loadtest.excludeTags }}
-          - --exclude-tags {{ .Values.loadtest.excludeTags }}
-{{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}


### PR DESCRIPTION

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

As per https://github.com/locustio/locust/pull/1976 the --tags/--exclude-tags are now passed through the master locust node.  The master will then pass them through to the workers.  I moved these arguments from the worker deployment to the master deployment.

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
