### PR TITLE
[stable/locust] be able to choose the path of Locustfile and library.

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.25.0"
+version: "0.26.0"
 appVersion: 2.1.0
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.26.0](https://img.shields.io/badge/Version-0.26.0-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -84,9 +84,10 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |
 | loadtest.locustCmd | string | `"/usr/local/bin/locust"` | The command to run Locust |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |
-| loadtest.locust_lib_configmap | string | `""` | name of a configmap containing your lib |
+| loadtest.locust_lib_configmap | string | `"example"` | name of a configmap containing your lib (default uses the example lib) |
 | loadtest.locust_locustfile | string | `"main.py"` | the name of the locustfile |
-| loadtest.locust_locustfile_configmap | string | `""` | name of a configmap containing your locustfile |
+| loadtest.locust_locustfile_configmap | string | `"example"` | name of a configmap containing your locustfile (default uses the example locustfile) |
+| loadtest.locust_locustfile_path | string | `"/mnt/locust"` | the path of the locustfile (without trailing backslash) |
 | loadtest.mount_external_secret | object | `{}` | additional mount used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `mountPath: yourMountLocation, files: { secret_name: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY] }` |
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -84,9 +84,9 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |
 | loadtest.locustCmd | string | `"/usr/local/bin/locust"` | The command to run Locust |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |
-| loadtest.locust_lib_configmap | string | `"example"` | name of a configmap containing your lib (default uses the example lib) |
+| loadtest.locust_lib_configmap | string | `"example-lib"` | name of a configmap containing your lib (default uses the example lib) |
 | loadtest.locust_locustfile | string | `"main.py"` | the name of the locustfile |
-| loadtest.locust_locustfile_configmap | string | `"example"` | name of a configmap containing your locustfile (default uses the example locustfile) |
+| loadtest.locust_locustfile_configmap | string | `"example-locustfile"` | name of a configmap containing your locustfile (default uses the example locustfile) |
 | loadtest.locust_locustfile_path | string | `"/mnt/locust"` | the path of the locustfile (without trailing backslash) |
 | loadtest.mount_external_secret | object | `{}` | additional mount used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `mountPath: yourMountLocation, files: { secret_name: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY] }` |
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |

--- a/stable/locust/templates/configmap-locust-lib.yaml
+++ b/stable/locust/templates/configmap-locust-lib.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.loadtest.locust_lib_configmap "example" }}
+{{- if eq .Values.loadtest.locust_lib_configmap "example-lib" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/locust/templates/configmap-locust-lib.yaml
+++ b/stable/locust/templates/configmap-locust-lib.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.loadtest.locust_lib_configmap "" }}
+{{- if eq .Values.loadtest.locust_lib_configmap "example" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/locust/templates/configmap-locust-lib.yaml
+++ b/stable/locust/templates/configmap-locust-lib.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "locust.fullname" . }}-lib
+  name: {{ .Values.loadtest.locust_lib_configmap }}
   labels:
 {{ include "locust.labels" . | indent 4 }}
 data:

--- a/stable/locust/templates/configmap-locust-locustfile.yaml
+++ b/stable/locust/templates/configmap-locust-locustfile.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "locust.fullname" . }}-locustfile
+  name: {{ .Values.loadtest.locust_locustfile_configmap }}
   labels:
 {{ include "locust.labels" . | indent 4 }}
 data:

--- a/stable/locust/templates/configmap-locust-locustfile.yaml
+++ b/stable/locust/templates/configmap-locust-locustfile.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.loadtest.locust_locustfile_configmap "" }}
+{{- if eq .Values.loadtest.locust_locustfile_configmap "example" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/locust/templates/configmap-locust-locustfile.yaml
+++ b/stable/locust/templates/configmap-locust-locustfile.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.loadtest.locust_locustfile_configmap "example" }}
+{{- if eq .Values.loadtest.locust_locustfile_configmap "example-locustfile" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -157,12 +157,12 @@ spec:
         {{- if .Values.loadtest.locust_lib_configmap }}
         - name: lib
           configMap:
-            name: {{ template "locust.lib_configmap_name" . }}
+            name: {{ .Values.loadtest.locust_lib_configmap }}
         {{- end }}
-        {{- if .Values.loadtest.locust_locustfile_configmap}}
+        {{- if .Values.loadtest.locust_locustfile_configmap }}
         - name: locustfile
           configMap:
-            name: {{ template "locust.locustfile_configmap_name" . }}
+            name: {{ .Values.loadtest.locust_locustfile_configmap }}
         {{- end }}
         - name: config
           configMap:

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -70,10 +70,14 @@ spec:
         resources:
 {{ toYaml .Values.master.resources | indent 10 }}
         volumeMounts:
+          {{- if .Values.loadtest.locust_locustfile_configmap}}
           - name: locustfile
-            mountPath: /mnt/locust
+            mountPath: "{{ .Values.loadtest.locust_locustfile_path }}"
+          {{- end }}
+          {{- if .Values.loadtest.locust_lib_configmap }}
           - name: lib
-            mountPath: /mnt/locust/lib
+            mountPath: "{{ .Values.loadtest.locust_locustfile_path }}/lib"
+          {{- end }}
           - name: config
             mountPath: /config
 {{- if .Values.extraConfigMaps }}
@@ -93,7 +97,7 @@ spec:
           - name: LOCUST_LOGLEVEL
             value: "{{ .Values.master.logLevel }}"
           - name: LOCUST_LOCUSTFILE
-            value: "/mnt/locust/{{ .Values.loadtest.locust_locustfile }}"
+            value: "{{ .Values.loadtest.locust_locustfile_path }}/{{ .Values.loadtest.locust_locustfile }}"
 {{- end }}
 {{- range $key, $value := .Values.loadtest.environment }}
           - name: {{ $key }}
@@ -150,12 +154,16 @@ spec:
 {{- end }}
       restartPolicy: {{ .Values.master.restartPolicy }}
       volumes:
+        {{- if .Values.loadtest.locust_lib_configmap }}
         - name: lib
           configMap:
             name: {{ template "locust.lib_configmap_name" . }}
+        {{- end }}
+        {{- if .Values.loadtest.locust_locustfile_configmap}}
         - name: locustfile
           configMap:
             name: {{ template "locust.locustfile_configmap_name" . }}
+        {{- end }}
         - name: config
           configMap:
             name: {{ template "locust.fullname" . }}-config

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -58,10 +58,14 @@ spec:
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
         volumeMounts:
+          {{- if .Values.loadtest.locust_locustfile_configmap}}
           - name: locustfile
-            mountPath: /mnt/locust
+            mountPath: "{{ .Values.loadtest.locust_locustfile_path }}"
+          {{- end }}
+          {{- if .Values.loadtest.locust_lib_configmap }}
           - name: lib
-            mountPath: /mnt/locust/lib
+            mountPath: "{{ .Values.loadtest.locust_locustfile_path }}/lib"
+          {{- end }}
           - name: config
             mountPath: /config
 {{- if .Values.extraConfigMaps }}
@@ -85,7 +89,7 @@ spec:
           - name: LOCUST_LOGLEVEL
             value: "{{ .Values.worker.logLevel }}"
           - name: LOCUST_LOCUSTFILE
-            value: "/mnt/locust/{{ .Values.loadtest.locust_locustfile }}"
+            value: "{{ .Values.loadtest.locust_locustfile_path }}/{{ .Values.loadtest.locust_locustfile }}"
 {{- end }}
 {{- range $key, $value := .Values.worker.environment }}
           - name: {{ $key }}
@@ -114,12 +118,16 @@ spec:
 {{- end }}
       restartPolicy: {{ .Values.worker.restartPolicy }}
       volumes:
+        {{- if .Values.loadtest.locust_lib_configmap }}
         - name: lib
           configMap:
             name: {{ template "locust.lib_configmap_name" . }}
+        {{- end }}
+        {{- if .Values.loadtest.locust_locustfile_configmap}}
         - name: locustfile
           configMap:
             name: {{ template "locust.locustfile_configmap_name" . }}
+        {{- end }}
         - name: config
           configMap:
             name: {{ template "locust.fullname" . }}-config

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -121,12 +121,12 @@ spec:
         {{- if .Values.loadtest.locust_lib_configmap }}
         - name: lib
           configMap:
-            name: {{ template "locust.lib_configmap_name" . }}
+            name: {{ .Values.loadtest.locust_lib_configmap }}
         {{- end }}
-        {{- if .Values.loadtest.locust_locustfile_configmap}}
+        {{- if .Values.loadtest.locust_locustfile_configmap }}
         - name: locustfile
           configMap:
-            name: {{ template "locust.locustfile_configmap_name" . }}
+            name: {{ .Values.loadtest.locust_locustfile_configmap }}
         {{- end }}
         - name: config
           configMap:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -6,9 +6,9 @@ loadtest:
   # loadtest.locust_locustfile_path -- the path of the locustfile (without trailing backslash)
   locust_locustfile_path: "/mnt/locust"
   # loadtest.locust_locustfile_configmap -- name of a configmap containing your locustfile (default uses the example locustfile)
-  locust_locustfile_configmap: "example"
+  locust_locustfile_configmap: "example-locustfile"
   # loadtest.locust_lib_configmap -- name of a configmap containing your lib (default uses the example lib)
-  locust_lib_configmap: "example"
+  locust_lib_configmap: "example-lib"
   # loadtest.locust_host -- the host you will load test
   locust_host: https://www.google.com
   # loadtest.pip_packages -- a list of extra python pip packages to install

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -3,10 +3,12 @@ loadtest:
   name: example
   # loadtest.locust_locustfile -- the name of the locustfile
   locust_locustfile: main.py
-  # loadtest.locust_locustfile_configmap -- name of a configmap containing your locustfile
-  locust_locustfile_configmap: ""
-  # loadtest.locust_lib_configmap -- name of a configmap containing your lib
-  locust_lib_configmap: ""
+  # loadtest.locust_locustfile_path -- the path of the locustfile (without trailing backslash)
+  locust_locustfile_path: "/mnt/locust"
+  # loadtest.locust_locustfile_configmap -- name of a configmap containing your locustfile (default uses the example locustfile)
+  locust_locustfile_configmap: "example"
+  # loadtest.locust_lib_configmap -- name of a configmap containing your lib (default uses the example lib)
+  locust_lib_configmap: "example"
   # loadtest.locust_host -- the host you will load test
   locust_host: https://www.google.com
   # loadtest.pip_packages -- a list of extra python pip packages to install


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Allows to specify the path of the lib and the locustfile. 
I also made the use of the configmap optional if not needed.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
