### PR TITLE
[stable/locust] Don't set worker replicas when hpa is enabled

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.26.0"
+version: "0.26.1"
 appVersion: 2.1.0
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.26.0](https://img.shields.io/badge/Version-0.26.0-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.26.1](https://img.shields.io/badge/Version-0.26.1-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -14,7 +14,9 @@ spec:
     matchLabels:
       component: worker
       {{- include "locust.selectorLabels" . | nindent 6 }}
+{{- if not .Values.worker.hpa.enabled }}
   replicas: {{ .Values.worker.replicas }}
+{{- end }}
 {{- with .Values.worker.strategy }}
   strategy:
 {{ toYaml . | trim | indent 4 }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

In current locust chart, the worker `spec.replicas` is set even when `worker.hpa.enabled` is `true`, and it causes problem in GitOps tool [Argo CD](https://argo-cd.readthedocs.io/en/stable/).

By design, Argo CD constantly compares resource in Kubernetes against their definition in git. In this case, Argo CD will try to set `spec.replicas` to `1` to match resource definition in git, however, `HorizontalPodAutoscaling` will try to set `spec.replicas` to properly value according to current worker loading. This discrepancy makes worker unstable.

To fix the issue, locust chart shall not set `spec.replicas` when `worker.hpa.enabled` is `true`.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
