### PR TITLE
[stable/node-problem-detector] feat: allow service annotations

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.1.0"
+version: "2.2.0"
 appVersion: v0.8.10
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -64,6 +64,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |
 | logDir.pod | string | `""` | log directory in pod (volume mount), use logDir.host if empty |
 | maxUnavailable | int | `1` | The max pods unavailable during an update |
+| metrics.annotations | object | `{}` |  |
 | metrics.enabled | bool | `false` |  |
 | metrics.prometheusRule.additionalRules | list | `[]` |  |
 | metrics.prometheusRule.defaultRules.create | bool | `true` |  |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![AppVersion: v0.8.10](https://img.shields.io/badge/AppVersion-v0.8.10-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![AppVersion: v0.8.10](https://img.shields.io/badge/AppVersion-v0.8.10-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 

--- a/stable/node-problem-detector/templates/service.yaml
+++ b/stable/node-problem-detector/templates/service.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app: {{ include "node-problem-detector.name" . }}
+  {{- if .Values.metrics.annotations }}
+  annotations:
+    {{- toYaml .Values.metrics.annotations | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -98,6 +98,7 @@ nodeSelector: {}
 
 metrics:
   enabled: false
+  annotations: {}
   serviceMonitor:
     enabled: false
     additionalLabels: {}


### PR DESCRIPTION
## Description

Allows setting of service object annotations to allow promtheus scraping to work in custom k8s cluster. 

e.g 
```
apiVersion: v1
kind: Service
metadata:
  annotations:
    prometheus.io/port: "3300"
    prometheus.io/scrape: "true"
...
```

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
