### PR TITLE
[stable/cluster-overprovisioner] Add support for containerSecurityContext

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.7.7
+version: 0.7.8
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.7.7](https://img.shields.io/badge/Version-0.7.7-informational?style=flat-square) ![AppVersion: 3.6](https://img.shields.io/badge/AppVersion-3.6-informational?style=flat-square)
+![Version: 0.7.8](https://img.shields.io/badge/Version-0.7.8-informational?style=flat-square) ![AppVersion: 3.6](https://img.shields.io/badge/AppVersion-3.6-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -52,6 +52,7 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| containerSecurityContext | object | `{}` | Container security context object |
 | deployments | list | [] | Define optional additional deployments - A default deployment is included by default |
 | deployments[0].affinity | object | `{}` | Default Deployment - Map of node/pod affinities |
 | deployments[0].annotations | object | `{}` | Default Deployment - Annotations to add to the deployment |

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -7,6 +7,7 @@
 {{- $commonLabels :=  include "cluster-overprovisioner.labels" . -}}
 {{- $matchLabels :=  include "cluster-overprovisioner.matchLabels" . -}}
 {{- $chartName := .Chart.Name }}
+{{- $containerSecurityContext := .Values.containerSecurityContext }}
 {{- $podSecurityContext := .Values.podSecurityContext }}
 {{- $priorityClassName := .Values.priorityClassOverprovision.name }}
 {{- $repository := .Values.image.repository }}
@@ -61,6 +62,9 @@ spec:
         - name: {{ $chartName }}
           image: "{{ $repository }}:{{ $imageTag }}"
           imagePullPolicy: {{ $pullPolicy }}
+          {{- if $containerSecurityContext }}
+          securityContext: {{ toYaml $containerSecurityContext | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .resources | nindent 12 }}
           {{- with $imageCommand }}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -1,3 +1,7 @@
+# containerSecurityContext -- Container security context object
+containerSecurityContext: {}
+  # allowPrivilegeEscalation: false
+
 # podSecurityContext -- Pod security context object
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
podSecurityContext was already supported, this change adds support for container
security context for things like `allowPrivilegeEscalation=false`,
`readOnlyRootFilesystem=true`, `capabilities = DROP ALL`, etc

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
