### PR TITLE
[stable/node-problem-detector] add: additionalLabels for prometheusRules

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.2.0"
+version: "2.2.1"
 appVersion: v0.8.10
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![AppVersion: v0.8.10](https://img.shields.io/badge/AppVersion-v0.8.10-informational?style=flat-square)
+![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![AppVersion: v0.8.10](https://img.shields.io/badge/AppVersion-v0.8.10-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -66,6 +66,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | maxUnavailable | int | `1` | The max pods unavailable during an update |
 | metrics.annotations | object | `{}` |  |
 | metrics.enabled | bool | `false` |  |
+| metrics.prometheusRule.additionalLabels | object | `{}` |  |
 | metrics.prometheusRule.additionalRules | list | `[]` |  |
 | metrics.prometheusRule.defaultRules.create | bool | `true` |  |
 | metrics.prometheusRule.defaultRules.disabled | list | `[]` |  |

--- a/stable/node-problem-detector/templates/prometheusrule.yaml
+++ b/stable/node-problem-detector/templates/prometheusrule.yaml
@@ -8,6 +8,9 @@ metadata:
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.metrics.prometheusRule.additionalLabels }}
+    {{- toYaml .Values.metrics.prometheusRule.additionalLabels | nindent 4 }}
+    {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   groups:

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -107,6 +107,7 @@ metrics:
     defaultRules:
       create: true
       disabled: []
+    additionalLabels: {}
     additionalRules: []
 
 env:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Adds additional labels to prometheusRules. 


## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
