### PR TITLE
[stable/listmonk] Enable init-db and upgrade-db hooks by helm upgrade

### DIFF
--- a/stable/listmonk/Chart.yaml
+++ b/stable/listmonk/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/listmonk/README.md
+++ b/stable/listmonk/README.md
@@ -1,6 +1,6 @@
 # listmonk
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.0](https://img.shields.io/badge/AppVersion-v2.1.0-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.0](https://img.shields.io/badge/AppVersion-v2.1.0-informational?style=flat-square)
 
 A Helm chart for listmonk application
 

--- a/stable/listmonk/templates/init-db.yaml
+++ b/stable/listmonk/templates/init-db.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "listmonk.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:

--- a/stable/listmonk/templates/upgrade-db.yaml
+++ b/stable/listmonk/templates/upgrade-db.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "listmonk.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-weight": "6"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:

--- a/stable/listmonk/templates/upgrade-db.yaml
+++ b/stable/listmonk/templates/upgrade-db.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "listmonk.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Enable init-db and upgrade-db hooks to be triggered by helm upgrade and helm install

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
