### PR TITLE
[stable/prometheus-aws-limits-exporter] Update aws limits exporter chart

### DIFF
--- a/stable/prometheus-aws-limits-exporter/Chart.yaml
+++ b/stable/prometheus-aws-limits-exporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 
 appVersion: "0.6.0"
 

--- a/stable/prometheus-aws-limits-exporter/README.md
+++ b/stable/prometheus-aws-limits-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-aws-limits-exporter
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 This helmchart provides a Prometheus metrics endpoint that exposes AWS usage and limits as reported by the AWS Trusted Advisor API.
 
@@ -51,17 +51,22 @@ helm install my-release deliveryhero/prometheus-aws-limits-exporter -f values.ya
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| development_mode | bool | `true` |  |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"danielfm/aws-limits-exporter"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
+| livenessProbe.Enabled | bool | `true` |  |
+| livenessProbe.path | string | `"/-/healthy"` |  |
+| livenessProbe.port | int | `8080` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| readinessProbe.Enabled | bool | `true` |  |
+| readinessProbe.path | string | `"/-/healthy"` |  |
+| readinessProbe.port | int | `8080` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |

--- a/stable/prometheus-aws-limits-exporter/ci/ct-values.yaml
+++ b/stable/prometheus-aws-limits-exporter/ci/ct-values.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/stable/prometheus-aws-limits-exporter/templates/deployment.yaml
+++ b/stable/prometheus-aws-limits-exporter/templates/deployment.yaml
@@ -38,27 +38,25 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- if .Values.development_mode }}
-          command: [ "/bin/sh", "-c", "--" ]
-          args: [ "while true; do sleep 30; done;" ]
-          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
-          {{- if not .Values.development_mode }}
+        {{- if .Values.livenessProbe.Enabled}}
           livenessProbe:
             httpGet:
-              path: /-/healthy
-              port: 8080
-            timeoutSeconds: 10
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+            timeoutSeconds: 60
+        {{- end }}
+        {{- if .Values.readinessProbe.Enabled}}
           readinessProbe:
             httpGet:
-              path: /-/healthy
-              port: 8080
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
             timeoutSeconds: 10
-          {{- end }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/prometheus-aws-limits-exporter/values.yaml
+++ b/stable/prometheus-aws-limits-exporter/values.yaml
@@ -73,4 +73,12 @@ affinity: {}
 
 extraLabels: {}
 
-development_mode: true
+readinessProbe:
+  Enabled: true
+  path: /-/healthy
+  port: 8080
+
+livenessProbe:
+  Enabled: true
+  path: /-/healthy
+  port: 8080


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

- Add dynamic readiness and liveness probe
- Remove development mode
- Ignore deployment ci checks as it needs to collect aws trusted advisor metrics to get ready

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
