### PR TITLE
[stable/prometheus-aws-health-exporter] Add service account and pod annotations to aws health exporter chart

### DIFF
--- a/stable/prometheus-aws-health-exporter/Chart.yaml
+++ b/stable/prometheus-aws-health-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: AWS Health API Exporter for Prometheus
 name: prometheus-aws-health-exporter
-version: 0.1.3
+version: 0.1.4
 home: https://github.com/Jimdo/aws-health-exporter
 sources:
   - https://github.com/Jimdo/aws-health-exporter

--- a/stable/prometheus-aws-health-exporter/README.md
+++ b/stable/prometheus-aws-health-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-aws-health-exporter
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 AWS Health API Exporter for Prometheus
 
@@ -55,6 +55,7 @@ helm install my-release deliveryhero/prometheus-aws-health-exporter -f values.ya
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | string | `"100m"` |  |
@@ -64,6 +65,8 @@ helm install my-release deliveryhero/prometheus-aws-health-exporter -f values.ya
 | securityContext | object | `{}` |  |
 | service.port | int | `9383` |  |
 | service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
 | tolerations | list | `[]` |  |
 
 ## Maintainers

--- a/stable/prometheus-aws-health-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-aws-health-exporter/templates/_helpers.tpl
@@ -46,3 +46,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ toYaml .Values.extraLabels }}
 {{- end }}
 {{- end -}}
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prometheus-aws-health-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stable/prometheus-aws-health-exporter/templates/deployment.yaml
+++ b/stable/prometheus-aws-health-exporter/templates/deployment.yaml
@@ -12,6 +12,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "prometheus-aws-health-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -22,6 +26,7 @@ spec:
     {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/stable/prometheus-aws-health-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-aws-health-exporter/templates/serviceaccount.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "serviceAccountName" . }}
-  labels:
-    {{- include "labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/stable/prometheus-aws-health-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-aws-health-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "serviceAccountName" . }}
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/stable/prometheus-aws-health-exporter/values.yaml
+++ b/stable/prometheus-aws-health-exporter/values.yaml
@@ -42,3 +42,8 @@ tolerations: []
 
 affinity: {}
 extraLabels: {}
+
+podAnnotations: {}
+serviceAccount:
+  create: true
+  annotations: {}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

- Add serviceaccount to being able to attach it to Iam role
- Add podAnnotations to being able to add prometheus annotations to scrape automatically

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
