### PR TITLE
[stable/prometheus-aws-health-exporter] Add podLabels to aws health exporter chart

### DIFF
--- a/stable/prometheus-aws-health-exporter/Chart.yaml
+++ b/stable/prometheus-aws-health-exporter/Chart.yaml
@@ -2,10 +2,12 @@ apiVersion: v1
 appVersion: "1.0"
 description: AWS Health API Exporter for Prometheus
 name: prometheus-aws-health-exporter
-version: 0.1.4
+version: 0.1.5
 home: https://github.com/Jimdo/aws-health-exporter
 sources:
   - https://github.com/Jimdo/aws-health-exporter
 maintainers:
-- name: max-rocket-internet
-  email: no-reply@deliveryhero.com
+  - name: max-rocket-internet
+    email: no-reply@deliveryhero.com
+  - name: javad-hajiani
+    email: no-reply@deliveryhero.com

--- a/stable/prometheus-aws-health-exporter/README.md
+++ b/stable/prometheus-aws-health-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-aws-health-exporter
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 AWS Health API Exporter for Prometheus
 
@@ -56,6 +56,7 @@ helm install my-release deliveryhero/prometheus-aws-health-exporter -f values.ya
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | string | `"100m"` |  |
@@ -74,3 +75,4 @@ helm install my-release deliveryhero/prometheus-aws-health-exporter -f values.ya
 | Name | Email | Url |
 | ---- | ------ | --- |
 | max-rocket-internet | no-reply@deliveryhero.com |  |
+| javad-hajiani | no-reply@deliveryhero.com |  |

--- a/stable/prometheus-aws-health-exporter/templates/deployment.yaml
+++ b/stable/prometheus-aws-health-exporter/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "prometheus-aws-health-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+          {{ toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/prometheus-aws-health-exporter/values.yaml
+++ b/stable/prometheus-aws-health-exporter/values.yaml
@@ -47,3 +47,5 @@ podAnnotations: {}
 serviceAccount:
   create: true
   annotations: {}
+
+podLabels: {}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

- Add podLabels to exporter 

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
