### PR TITLE
[stable/node-local-dns] Adding the node-local-dns chart

### DIFF
--- a/stable/node-local-dns/.helmignore
+++ b/stable/node-local-dns/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: node-local-dns
+maintainers:
+- name: Gabriel Ferreira
+  email: no-reply@deliveryhero.com
+description: |
+ A chart to install node-local-dns.
+ NodeLocal DNSCache improves Cluster DNS performance by running a DNS caching agent on cluster nodes as a DaemonSet.
+ In today's architecture, Pods in 'ClusterFirst' DNS mode reach out to a kube-dns serviceIP for DNS queries.
+ This is translated to a kube-dns/CoreDNS endpoint via iptables rules added by kube-proxy.
+ With this new architecture, Pods will reach out to the DNS caching agent running on the same node, thereby avoiding iptables DNAT rules and connection tracking.
+ The local caching agent will query kube-dns service for cache misses of cluster hostnames ("cluster.local" suffix by default).[docs](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/)
+
+  ```console
+  helm install -n kube-system node-local-dns deliveryhero/node-local-dns
+  ```
+version: 0.1.0

--- a/stable/node-local-dns/templates/_helpers.tpl
+++ b/stable/node-local-dns/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "node-local-dns.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "node-local-dns.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "node-local-dns.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "node-local-dns.labels" -}}
+helm.sh/chart: {{ include "node-local-dns.chart" . }}
+{{ include "node-local-dns.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "node-local-dns.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "node-local-dns.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+k8s-app: {{ include "node-local-dns.fullname" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "node-local-dns.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "node-local-dns.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+data:
+  Corefile: |
+    {{ .Values.pillar_dns_domain }}:53 {
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
+        loop
+        bind {{ .Values.pillar_local_dns }} {{ .Values.pillar_dns_server }}
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        health {{ .Values.pillar_local_dns }}:8080
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind {{ .Values.pillar_local_dns }} {{ .Values.pillar_dns_server }}
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind {{ .Values.pillar_local_dns }} {{ .Values.pillar_dns_server }}
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind {{ .Values.pillar_local_dns }} {{ .Values.pillar_dns_server }}
+        forward . __PILLAR__UPSTREAM__SERVERS__
+        prometheus :9253
+        }

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}
+  namespace: kube-system
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: {{ include "node-local-dns.name" . }}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{ include "node-local-dns.name" . }}
+      annotations:
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: {{ include "node-local-dns.serviceAccountName" . }}
+      hostNetwork: true
+      dnsPolicy: Default  # Don't use cluster DNS.
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
+      containers:
+      - name: node-cache
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        resources:
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args: [ "-localip", "{{ .Values.pillar_local_dns }},{{ .Values.pillar_dns_server }}", "-conf", "/etc/Corefile", "-upstreamsvc", "{{ include "node-local-dns.fullname" . }}-upstream" ]
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9253
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            host: {{ .Values.pillar_local_dns }}
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - name: config-volume
+          mountPath: /etc/coredns
+        - name: kube-dns-config
+          mountPath: /etc/kube-dns
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: kube-dns-config
+        configMap:
+          name: {{ include "node-local-dns.fullname" . }}
+          optional: true
+      - name: config-volume
+        configMap:
+          name: {{ include "node-local-dns.fullname" . }}
+          items:
+            - key: Corefile
+              path: Corefile.base

--- a/stable/node-local-dns/templates/service_prometheus.yaml
+++ b/stable/node-local-dns/templates/service_prometheus.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}-prometheus
+  namespace: kube-system
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/port: "9253"
+    prometheus.io/scrape: "true"
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9253
+      targetPort: 9253
+  selector:
+    k8s-app: {{ include "node-local-dns.fullname" . }}

--- a/stable/node-local-dns/templates/service_upstream.yaml
+++ b/stable/node-local-dns/templates/service_upstream.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}-upstream
+  namespace: kube-system
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns

--- a/stable/node-local-dns/templates/serviceaccount.yaml
+++ b/stable/node-local-dns/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "node-local-dns.serviceAccountName" . }}
+  namespace: kube-system  
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -1,0 +1,27 @@
+image:
+  repository: k8s.gcr.io/dns/k8s-dns-node-cache
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "1.21.1"
+
+#Internal k8s internal domain
+pillar_dns_domain: "cluster.local"
+
+# Main coredns service (kube-dns) ip, used on iptables-mode.
+pillar_dns_server: "172.20.0.10"
+
+# Virtual IP to be used by ipvs mode, to be used as --cluster-dns, must not collide.
+pillar_local_dns: "169.254.20.25"
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+podAnnotations: {}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Creating a new chart to node-local-dns, following main instructions 

https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
