### PR TITLE
[stable/locust] Bump locust to version 2.8.6

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.26.1"
+version: "0.27.0"
 appVersion: 2.8.6
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: locust
 version: "0.26.1"
-appVersion: 2.1.0
+appVersion: 2.8.6
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png
 maintainers:

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.26.1](https://img.shields.io/badge/Version-0.26.1-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![AppVersion: 2.8.6](https://img.shields.io/badge/AppVersion-2.8.6-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -68,7 +68,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"locustio/locust"` |  |
-| image.tag | string | `"2.4.0"` |  |
+| image.tag | string | `"2.8.6"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -82,7 +82,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.environment_secret | object | `{}` | environment variables used in the load test for both master and workers, stored as secrets |
 | loadtest.excludeTags | string | `""` | whether to run locust with `--exclude-tags [TAG [TAG ...]]` options, so only tasks with no matching tags will be executed |
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |
-| loadtest.locustCmd | string | `"/usr/local/bin/locust"` | The command to run Locust |
+| loadtest.locustCmd | string | `"/opt/venv/bin/locust"` | The command to run Locust |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |
 | loadtest.locust_lib_configmap | string | `"example-lib"` | name of a configmap containing your lib (default uses the example lib) |
 | loadtest.locust_locustfile | string | `"main.py"` | the name of the locustfile |

--- a/stable/locust/templates/configmap-config.yaml
+++ b/stable/locust/templates/configmap-config.yaml
@@ -11,7 +11,7 @@ data:
     set -eu
 
     {{- if .Values.loadtest.pip_packages }}
-    pip install --user {{ range .Values.loadtest.pip_packages }}{{ . }} {{ end }}
+    pip install {{ range .Values.loadtest.pip_packages }}{{ . }} {{ end }}
     {{- end }}
 
     exec {{ .Values.loadtest.locustCmd }} $@

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -38,7 +38,7 @@ loadtest:
 
 image:
   repository: locustio/locust
-  tag: 2.4.0
+  tag: 2.8.6
   pullPolicy: IfNotPresent
 
 service:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -34,7 +34,7 @@ loadtest:
   # loadtest.excludeTags -- whether to run locust with `--exclude-tags [TAG [TAG ...]]` options, so only tasks with no matching tags will be executed
   excludeTags: ""
   # loadtest.locustCmd -- The command to run Locust
-  locustCmd: "/usr/local/bin/locust"
+  locustCmd: "/opt/venv/bin/locust"
 
 image:
   repository: locustio/locust


### PR DESCRIPTION
## Description

This pull request Bump locust to `2.8.6` version.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
