### PR TITLE
[stable/cloudhealth-collector] add existing secret values

### DIFF
--- a/stable/cloudhealth-collector/Chart.yaml
+++ b/stable/cloudhealth-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "957"
 name: cloudhealth-collector
-version: 0.1.1
+version: 0.1.2
 description: |
   Deploys a k8s pod to collect data and generate reports based or resources usages, costs and other possibilities. Please check more about it on: https://www.cloudhealthtech.com/solutions/containers
 

--- a/stable/cloudhealth-collector/README.md
+++ b/stable/cloudhealth-collector/README.md
@@ -1,6 +1,6 @@
 # cloudhealth-collector
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 957](https://img.shields.io/badge/AppVersion-957-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 957](https://img.shields.io/badge/AppVersion-957-informational?style=flat-square)
 
 Deploys a k8s pod to collect data and generate reports based or resources usages, costs and other possibilities. Please check more about it on: https://www.cloudhealthtech.com/solutions/containers
 
@@ -55,6 +55,8 @@ helm install my-release deliveryhero/cloudhealth-collector -f values.yaml
 | affinity | object | `{}` |  |
 | api_token | string | `"<change-me>"` |  |
 | cluster_name | string | `"your-cluster-name"` |  |
+| existingSecret.secretName | string | `""` |  |
+| existingSecret.tokenKey | string | `""` |  |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/stable/cloudhealth-collector/templates/clusterrole.yaml
+++ b/stable/cloudhealth-collector/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "cloudhealth-collector.fullname" . }}
   labels:

--- a/stable/cloudhealth-collector/templates/clusterrolebinding.yaml
+++ b/stable/cloudhealth-collector/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "cloudhealth-collector.fullname" . }}
   labels:

--- a/stable/cloudhealth-collector/templates/deployment.yaml
+++ b/stable/cloudhealth-collector/templates/deployment.yaml
@@ -41,8 +41,8 @@ spec:
         - name: CHT_API_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ include "cloudhealth-collector.fullname" . }}
-              key: api_token
+              name: {{ .Values.existingSecret.secretName | default (include "cloudhealth-collector.fullname" .) }}
+              key: {{ .Values.existingSecret.tokenKey |  default "api_key" }}
         - name: CHT_CLUSTER_NAME
           value: {{ .Values.cluster_name }}
         - name: CHT_INTERVAL

--- a/stable/cloudhealth-collector/templates/secret.yaml
+++ b/stable/cloudhealth-collector/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret.secretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
   api_token: {{ .Values.api_token | b64enc | quote }}
+{{- end }}

--- a/stable/cloudhealth-collector/values.yaml
+++ b/stable/cloudhealth-collector/values.yaml
@@ -1,4 +1,10 @@
 api_token: <change-me>
+  
+# `existingSecret` is an optional reference to an existing secret containing the api_token
+existingSecret:
+  secretName: ""
+  tokenKey: ""
+
 cluster_name: your-cluster-name
 
 replicaCount: 1

--- a/stable/cloudhealth-collector/values.yaml
+++ b/stable/cloudhealth-collector/values.yaml
@@ -1,5 +1,5 @@
 api_token: <change-me>
-  
+
 # `existingSecret` is an optional reference to an existing secret containing the api_token
 existingSecret:
   secretName: ""


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Adds values to use an existing secret for api_token.

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
