### PR TITLE
[stable/k8s-resources] allow secret type other than Opaque

### DIFF
--- a/stable/k8s-resources/Chart.yaml
+++ b/stable/k8s-resources/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.1
+version: 0.5.2
 appVersion: 0.0.1
 name: k8s-resources
 description: |

--- a/stable/k8s-resources/README.md
+++ b/stable/k8s-resources/README.md
@@ -1,6 +1,6 @@
 # k8s-resources
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Not an application but a Helm chart to create any and many resources in Kubernetes.
 

--- a/stable/k8s-resources/templates/secret.yaml
+++ b/stable/k8s-resources/templates/secret.yaml
@@ -2,7 +2,7 @@
 {{- range .Values.Secrets }}
 apiVersion: v1
 kind: Secret
-type: Opaque
+type: {{ if .type }}{{ .type }}{{ else }}Opaque{{ end }}
 metadata:
 {{- if .namespace }}
   namespace: {{ .namespace }}

--- a/stable/k8s-resources/values.yaml
+++ b/stable/k8s-resources/values.yaml
@@ -69,6 +69,13 @@ Secrets: []
   #     key2: value1
   #   keys:
   #     key3: dmFsdWUyCg==
+  # - name: container-registry
+  #   type: kubernetes.io/dockerconfigjson
+  #   fullnameOverride: ""
+  #   annotations: {}
+  #   extraLabels: {}
+  #   tplB64Keys:
+  #     .dockerconfigjson: '{{ printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .registry (printf "%s:%s" .username .password | b64enc) }}'
 
 # Services -- A list Service to create
 Services: []


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

I updated the heml template stable/k8s-resources/templates/secret.yaml to allow for a Secret type other than just Opaque.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
