### PR TITLE
[stable/k8s-event-logger] Update image tag to 1.6 for k8s-event-logger

### DIFF
--- a/stable/k8s-event-logger/Chart.yaml
+++ b/stable/k8s-event-logger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.5"
-version: "1.0"
+appVersion: "1.6"
+version: "1.1"
 description: |
   This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
 

--- a/stable/k8s-event-logger/README.md
+++ b/stable/k8s-event-logger/README.md
@@ -1,6 +1,6 @@
 # k8s-event-logger
 
-![Version: 1.0](https://img.shields.io/badge/Version-1.0-informational?style=flat-square) ![AppVersion: 1.5](https://img.shields.io/badge/AppVersion-1.5-informational?style=flat-square)
+![Version: 1.1](https://img.shields.io/badge/Version-1.1-informational?style=flat-square) ![AppVersion: 1.6](https://img.shields.io/badge/AppVersion-1.6-informational?style=flat-square)
 
 This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
 
@@ -63,7 +63,7 @@ helm install my-release deliveryhero/k8s-event-logger -f values.yaml
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"maxrocketinternet/k8s-event-logger"` |  |
-| image.tag | string | `"1.5"` |  |
+| image.tag | string | `"1.6"` |  |
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/stable/k8s-event-logger/templates/clusterrole.yaml
+++ b/stable/k8s-event-logger/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "k8s-event-logger.fullname" . }}
   labels:

--- a/stable/k8s-event-logger/values.yaml
+++ b/stable/k8s-event-logger/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: maxrocketinternet/k8s-event-logger
-  tag: "1.5"
+  tag: "1.6"
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

This PR updates the image tag of k8s-event-logger to 1.6. This version was released today 10th of June 2022 to address the vulnerabilities in the container.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
