### PR TITLE
Chore: move Python code away from configmap's yaml file in superset

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: superset
 description: A Helm chart for Apache Superset
 type: application
-version: 1.0.9
+version: 1.0.10
 home: https://superset.apache.org/
 appVersion: "latest"
 maintainers:

--- a/stable/superset/README.md
+++ b/stable/superset/README.md
@@ -1,6 +1,6 @@
 # superset
 
-![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.0.10](https://img.shields.io/badge/Version-1.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for Apache Superset
 
@@ -90,6 +90,7 @@ helm install my-release deliveryhero/superset -f values.yaml
 | superset.configMountPath | string | `"/app/pythonpath"` |  |
 | superset.containerPort | int | `8088` |  |
 | superset.database.create | bool | `false` |  |
+| superset.database.engine | string | `"postgresql+psycopg2"` |  |
 | superset.database.hostname | string | `""` |  |
 | superset.database.init | bool | `true` |  |
 | superset.database.instanceID | string | `""` |  |
@@ -105,7 +106,9 @@ helm install my-release deliveryhero/superset -f values.yaml
 | superset.podAnnotations | object | `{}` |  |
 | superset.redis.brokerDbIndex | int | `1` |  |
 | superset.redis.cacheDbIndex | int | `0` |  |
+| superset.redis.default_timeout | int | `300` |  |
 | superset.redis.hostname | string | `""` |  |
+| superset.redis.key_prefix | string | `"superset_"` |  |
 | superset.redis.password | string | `""` |  |
 | superset.redis.port | int | `6379` |  |
 | superset.replicas | int | `1` |  |

--- a/stable/superset/files/superset_config.py
+++ b/stable/superset/files/superset_config.py
@@ -1,0 +1,61 @@
+import os
+from cachelib.redis import RedisCache
+
+cache_default_timeout: int
+cache_key_prefix: str
+cache_redis_host: str
+cache_redis_port: int
+cache_redis_db: str
+cache_redis_url: str
+
+sqlalchemy_database_engine: str
+sqlalchemy_database_username: str
+sqlalchemy_database_password: str
+sqlalchemy_database_address: str
+sqlalchemy_database_uri: str
+
+celery_broker_url: str
+celery_result_backend: str
+
+results_backend_host: str
+results_backend_port: str
+results_backend_key_prefix: str
+
+MAPBOX_API_KEY = os.getenv("MAPBOX_API_KEY", "")
+
+CACHE_CONFIG = {
+    "CACHE_TYPE": "redis",
+    "CACHE_DEFAULT_TIMEOUT": cache_default_timeout,
+    "CACHE_KEY_PREFIX": cache_key_prefix,
+    "CACHE_REDIS_HOST": cache_redis_host,
+    "CACHE_REDIS_PORT": cache_redis_port,
+    "CACHE_REDIS_DB": cache_redis_db,
+    "CACHE_REDIS_URL": cache_redis_url,
+}
+
+DATA_CACHE_CONFIG = CACHE_CONFIG
+SQLALCHEMY_DATABASE_URI = sqlalchemy_database_uri
+SQLALCHEMY_TRACK_MODIFICATIONS = True
+SECRET_KEY = os.getenv("SECRET_KEY", "")
+# Flask-WTF flag for CSRF
+WTF_CSRF_ENABLED = True
+# Add endpoints that need to be exempt from CSRF protection
+WTF_CSRF_EXEMPT_LIST = []
+# A CSRF token that expires in 1 year
+WTF_CSRF_TIME_LIMIT = 60 * 60 * 24 * 365
+
+
+class CeleryConfig(object):
+    BROKER_URL = celery_broker_url
+    CELERY_IMPORTS = ("superset.sql_lab",)
+    CELERY_RESULT_BACKEND = celery_result_backend
+    CELERY_ANNOTATIONS = {"tasks.add": {"rate_limit": "10/s"}}
+
+
+CELERY_CONFIG = CeleryConfig
+
+RESULTS_BACKEND = RedisCache(
+    host=results_backend_host,
+    port=results_backend_port,
+    key_prefix=results_backend_key_prefix,
+)

--- a/stable/superset/templates/_helpers.tpl
+++ b/stable/superset/templates/_helpers.tpl
@@ -71,6 +71,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
-{{- define "superset.database.uri" -}}
+{{- define "superset.database.address" -}}
 {{- printf "%s:%v/%s" .Values.superset.database.hostname .Values.superset.database.port .Values.superset.database.name }}
 {{- end }}

--- a/stable/superset/templates/configmap.yaml
+++ b/stable/superset/templates/configmap.yaml
@@ -11,56 +11,14 @@ data:
   {{- end}}
 
   superset_config.py: |-
-    import os
-    from cachelib.redis import RedisCache
-  {{- if .Values.superset.oidc.enabled}}
-    {{ .Values.superset.oidc.imports | nindent 4 }}
-  {{- end }}
+    {{- include "superset_config_variables" . | nindent 4 }}
+    {{- .Files.Get "files/superset_config.py" | nindent 4  }}
+    {{- if .Values.superset.oidc.enabled }}
+      {{- .Values.superset.oidc.imports | nindent 4 }}
+      {{- .Values.superset.oidc.config | nindent 4 }}
+    {{ end }}
+    {{- .Values.superset.extraConfig | nindent 4 }}
 
-    def env(key, default=None):
-      return os.getenv(key, default)
-
-    MAPBOX_API_KEY = env('MAPBOX_API_KEY', '')
-
-    CACHE_CONFIG = {
-      'CACHE_TYPE': 'redis',
-      'CACHE_DEFAULT_TIMEOUT': 300,
-      'CACHE_KEY_PREFIX': 'superset_',
-      'CACHE_REDIS_HOST': {{ .Values.superset.redis.hostname | quote }},
-      'CACHE_REDIS_PORT': {{ .Values.superset.redis.port | quote}},
-      'CACHE_REDIS_DB': {{ .Values.superset.redis.cacheDbIndex | quote }},
-      'CACHE_REDIS_URL': f"redis://{{ include "superset.redis.uri" . }}/{{.Values.superset.redis.cacheDbIndex}}"
-    }
-
-    DATA_CACHE_CONFIG = CACHE_CONFIG
-    SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg2://{env('DB_USERNAME')}:{env('DB_PASSWORD')}@{{ include "superset.database.uri" . }}"
-    SQLALCHEMY_TRACK_MODIFICATIONS = True
-    SECRET_KEY = env('SECRET_KEY', '')
-    # Flask-WTF flag for CSRF
-    WTF_CSRF_ENABLED = True
-    # Add endpoints that need to be exempt from CSRF protection
-    WTF_CSRF_EXEMPT_LIST = []
-    # A CSRF token that expires in 1 year
-    WTF_CSRF_TIME_LIMIT = 60 * 60 * 24 * 365
-
-    class CeleryConfig(object):
-      BROKER_URL = f"redis://{{ include "superset.redis.uri" . }}/{{.Values.superset.redis.brokerDbIndex}}"
-      CELERY_IMPORTS = ('superset.sql_lab', )
-      CELERY_RESULT_BACKEND = f"redis://{{ include "superset.redis.uri" . }}/{{.Values.superset.redis.brokerDbIndex}}"
-      CELERY_ANNOTATIONS = {'tasks.add': {'rate_limit': '10/s'}}
-
-    CELERY_CONFIG = CeleryConfig
-
-    RESULTS_BACKEND = RedisCache(
-      host={{ .Values.superset.redis.hostname | quote }},
-      port={{ .Values.superset.redis.port | quote }},
-      key_prefix='superset_results'
-    )
-
-{{- if .Values.superset.oidc.enabled}}
-  {{ .Values.superset.oidc.config | nindent 4 }}
-{{- end }}
-{{ .Values.superset.extraConfig | nindent 4 }}
-{{- if .Values.extraConfigmapData}}
-{{- toYaml .Values.extraConfigmapData | nindent 2 }}
-{{- end }}
+  {{- if .Values.extraConfigmapData }}
+    {{- toYaml .Values.extraConfigmapData | nindent 2 }}
+  {{ end }}

--- a/stable/superset/templates/variables.py.tpl
+++ b/stable/superset/templates/variables.py.tpl
@@ -1,0 +1,23 @@
+{{- define "superset_config_variables" -}}
+import os
+
+cache_default_timeout = {{ .Values.superset.redis.default_timeout }}
+cache_key_prefix = {{ .Values.superset.redis.key_prefix | quote }}
+cache_redis_host = {{ .Values.superset.redis.hostname | quote }}
+cache_redis_port = {{ .Values.superset.redis.port }}
+cache_redis_db = {{ .Values.superset.redis.cacheDbIndex | quote }}
+cache_redis_url = f"redis://{cache_redis_host}:{cache_redis_port}/{cache_redis_db}"
+
+sqlalchemy_database_engine = {{ .Values.superset.database.engine | quote }}
+sqlalchemy_database_username = os.getenv("DB_USERNAME", "")
+sqlalchemy_database_password = os.getenv("DB_PASSWORD", "")
+sqlalchemy_database_address = {{ include "superset.database.address" . | quote }}
+sqlalchemy_database_uri = f"{sqlalchemy_database_engine}://{sqlalchemy_database_username}:{sqlalchemy_database_password}@{sqlalchemy_database_address}"
+
+celery_broker_url = f"redis://{cache_redis_host}:{cache_redis_port}/{{ .Values.superset.redis.brokerDbIndex }}"
+celery_result_backend = f"redis://{cache_redis_host}:{cache_redis_port}/{{ .Values.superset.redis.brokerDbIndex }}"
+
+results_backend_host = cache_redis_host
+results_backend_port = cache_redis_port
+results_backend_key_prefix = "superset_results"
+{{ end }}

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -32,12 +32,15 @@ superset:
     imports: ""
   replicas: 1
   redis:
+    default_timeout: 300
+    key_prefix: superset_
     password: ""
     hostname: ""
     port: 6379
     brokerDbIndex: 1
     cacheDbIndex: 0
   database:
+    engine: "postgresql+psycopg2"
     init: true
     create: false
     instanceID: ""


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

* Improved readability by moving Python code away from configmap's yaml file in superset
* Python variables are set in a separate template file `variables.py.tpl`

### Example diff in ConfigMap

```txt
    superset_config.py: |-
+     import os
+     
+     cache_default_timeout = 300
+     cache_key_prefix = "superset_"
+     cache_redis_host = "REDACTED"
+     cache_redis_port = 6379
+     cache_redis_db = "0"
+     cache_redis_url = f"redis://{cache_redis_host}:{cache_redis_port}/{cache_redis_db}"
+     
+     sqlalchemy_database_engine = "postgresql+psycopg2"
+     sqlalchemy_database_username = os.getenv("DB_USERNAME", "")
+     sqlalchemy_database_password = os.getenv("DB_PASSWORD", "")
+     sqlalchemy_database_address = "REDACTED"
+     sqlalchemy_database_uri = f"{sqlalchemy_database_engine}://{sqlalchemy_database_username}:{sqlalchemy_database_password}@{sqlalchemy_database_address}"
+     
+     celery_broker_url = f"redis://{cache_redis_host}:{cache_redis_port}/1"
+     celery_result_backend = f"redis://{cache_redis_host}:{cache_redis_port}/1"
+     
+     results_backend_host = cache_redis_host
+     results_backend_port = cache_redis_port
+     results_backend_key_prefix = "superset_results"
+     
      import os
      from cachelib.redis import RedisCache
+     
+     cache_default_timeout: int
+     cache_key_prefix: str
+     cache_redis_host: str
+     cache_redis_port: int
+     cache_redis_db: str
+     cache_redis_url: str
+     
+     sqlalchemy_database_engine: str
+     sqlalchemy_database_username: str
+     sqlalchemy_database_password: str
+     sqlalchemy_database_address: str
+     sqlalchemy_database_uri: str
+     
+     celery_broker_url: str
+     celery_result_backend: str
+     
+     results_backend_host: str
+     results_backend_port: str
+     results_backend_key_prefix: str
      
      def env(key, default=None):
        return os.getenv(key, default)
- 
+     
      MAPBOX_API_KEY = env('MAPBOX_API_KEY', '')
- 
+     
      CACHE_CONFIG = {
        'CACHE_TYPE': 'redis',
-       'CACHE_DEFAULT_TIMEOUT': 300,
-       'CACHE_KEY_PREFIX': 'superset_',
-       'CACHE_REDIS_HOST': "REDACTED",
-       'CACHE_REDIS_PORT': "6379",
-       'CACHE_REDIS_DB': "0",
-       'CACHE_REDIS_URL': f"REDACTED"
+       'CACHE_DEFAULT_TIMEOUT': cache_default_timeout,
+       'CACHE_KEY_PREFIX': cache_key_prefix,
+       'CACHE_REDIS_HOST': cache_redis_host,
+       'CACHE_REDIS_PORT': cache_redis_port,
+       'CACHE_REDIS_DB': cache_redis_db,
+       'CACHE_REDIS_URL': cache_redis_url,
      }
- 
+     
      DATA_CACHE_CONFIG = CACHE_CONFIG
-     SQLALCHEMY_DATABASE_URI = "REDACTED"
+     SQLALCHEMY_DATABASE_URI = sqlalchemy_database_uri
      SQLALCHEMY_TRACK_MODIFICATIONS = True
      SECRET_KEY = env('SECRET_KEY', '')
      # Flask-WTF flag for CSRF
      WTF_CSRF_ENABLED = True
      # Add endpoints that need to be exempt from CSRF protection
      WTF_CSRF_EXEMPT_LIST = []
      # A CSRF token that expires in 1 year
      WTF_CSRF_TIME_LIMIT = 60 * 60 * 24 * 365
- 
+     
      class CeleryConfig(object):
-       BROKER_URL = "REDACTED"
-       CELERY_IMPORTS = ('superset.sql_lab', )
-       CELERY_RESULT_BACKEND = "REDACTED"
+       BROKER_URL = celery_broker_url
+       CELERY_IMPORTS = ('superset.sql_lab',)
+       CELERY_RESULT_BACKEND = celery_result_backend
        CELERY_ANNOTATIONS = {'tasks.add': {'rate_limit': '10/s'}}
- 
+     
      CELERY_CONFIG = CeleryConfig
- 
+     
      RESULTS_BACKEND = RedisCache(
-       host="REDACTED",
-       port="6379",
-       key_prefix='superset_results'
+       host=results_backend_host,
+       port=results_backend_port,
+       key_prefix=results_backend_key_prefix,
      )
```

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
