### PR TITLE
[stable/locust] Master nodeSelector, affinity, and tolerations

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.27.0"
+version: "0.27.1"
 appVersion: 2.8.6
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -92,7 +92,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |
 | loadtest.tags | string | `""` | whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed |
-| master.affinity | object | `{}` |  |
+| master.affinity | object | `{}` | Overwrites affinity from global |
 | master.args | list | `[]` | Any extra command args for the master |
 | master.auth.enabled | bool | `false` | When enabled, UI basic auth will be enforced with the given username and password |
 | master.auth.password | string | `""` |  |
@@ -104,13 +104,13 @@ helm install my-release deliveryhero/locust -f values.yaml
 | master.envs_include_default | bool | `true` | Whether to include default environment variables |
 | master.image | string | `""` | A custom docker image including tag |
 | master.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
-| master.nodeSelector | object | `{}` |  |
+| master.nodeSelector | object | `{}` | Overwrites nodeSelector from global |
 | master.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the master pod |
 | master.resources | object | `{}` | resources for the locust master |
 | master.restartPolicy | string | `"Always"` | master pod's restartPolicy. Can be Always, OnFailure, or Never. |
 | master.serviceAccountAnnotations | object | `{}` |  |
 | master.strategy.type | string | `"RollingUpdate"` |  |
-| master.tolerations | list | `[]` |  |
+| master.tolerations | list | `[]` | Overwrites tolerations from global |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -92,6 +92,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |
 | loadtest.tags | string | `""` | whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed |
+| master.affinity | object | `{}` | Overwrites affinity from global |
 | master.args | list | `[]` | Any extra command args for the master |
 | master.auth.enabled | bool | `false` | When enabled, UI basic auth will be enforced with the given username and password |
 | master.auth.password | string | `""` |  |
@@ -103,11 +104,13 @@ helm install my-release deliveryhero/locust -f values.yaml
 | master.envs_include_default | bool | `true` | Whether to include default environment variables |
 | master.image | string | `""` | A custom docker image including tag |
 | master.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
+| master.nodeSelector | object | `{}` | Overwrites nodeSelector from global |
 | master.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the master pod |
 | master.resources | object | `{}` | resources for the locust master |
 | master.restartPolicy | string | `"Always"` | master pod's restartPolicy. Can be Always, OnFailure, or Never. |
 | master.serviceAccountAnnotations | object | `{}` |  |
 | master.strategy.type | string | `"RollingUpdate"` |  |
+| master.tolerations | list | `[]` | Overwrites tolerations from global |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![AppVersion: 2.8.6](https://img.shields.io/badge/AppVersion-2.8.6-informational?style=flat-square)
+![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.1-informational?style=flat-square) ![AppVersion: 2.8.6](https://img.shields.io/badge/AppVersion-2.8.6-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -92,7 +92,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |
 | loadtest.tags | string | `""` | whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed |
-| master.affinity | object | `{}` | Overwrites affinity from global |
+| master.affinity | object | `{}` |  |
 | master.args | list | `[]` | Any extra command args for the master |
 | master.auth.enabled | bool | `false` | When enabled, UI basic auth will be enforced with the given username and password |
 | master.auth.password | string | `""` |  |
@@ -104,13 +104,13 @@ helm install my-release deliveryhero/locust -f values.yaml
 | master.envs_include_default | bool | `true` | Whether to include default environment variables |
 | master.image | string | `""` | A custom docker image including tag |
 | master.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
-| master.nodeSelector | object | `{}` | Overwrites nodeSelector from global |
+| master.nodeSelector | object | `{}` |  |
 | master.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the master pod |
 | master.resources | object | `{}` | resources for the locust master |
 | master.restartPolicy | string | `"Always"` | master pod's restartPolicy. Can be Always, OnFailure, or Never. |
 | master.serviceAccountAnnotations | object | `{}` |  |
 | master.strategy.type | string | `"RollingUpdate"` |  |
-| master.tolerations | list | `[]` | Overwrites tolerations from global |
+| master.tolerations | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-      {{- with .Values.master.deploymentAnnotations }}
+      {{- with .Values.master.annotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
         checksum/config-locust-lib: {{ include (print $.Template.BasePath "/configmap-locust-lib.yaml") . | sha256sum }}

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-      {{- with .Values.master.annotations }}
+      {{- with .Values.master.deploymentAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
         checksum/config-locust-lib: {{ include (print $.Template.BasePath "/configmap-locust-lib.yaml") . | sha256sum }}
@@ -177,15 +177,36 @@ spec:
 {{- if .Values.loadtest.mount_external_secret }}
 {{- include "locust.external_secret.volume" . | nindent 8 }}
 {{- end }}
+{{- if .Values.master.nodeSelector }}
+      {{- with .Values.master.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{ else if .Values.nodeSelector }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{ end }}
+{{- if .Values.master.affinity }}
+      {{- with .Values.master.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{ else if .Values.affinity }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{ end }}
+{{- if .Values.master.tolerations }}
+      {{- with .Values.master.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{ else if .Values.tolerations }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{ end }}

--- a/stable/locust/test.yaml
+++ b/stable/locust/test.yaml
@@ -1,7 +1,0 @@
-master:
-  nodeSelector:
-    role: fake-services
-  tolerations: []
-  affinity: {}
-nodeSelector:
-  role: locust

--- a/stable/locust/test.yaml
+++ b/stable/locust/test.yaml
@@ -1,0 +1,7 @@
+master:
+  nodeSelector:
+    role: fake-services
+  tolerations: []
+  affinity: {}
+nodeSelector:
+  role: locust

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -83,8 +83,11 @@ master:
     password: ""
   # master.restartPolicy -- master pod's restartPolicy. Can be Always, OnFailure, or Never.
   restartPolicy: Always
+  # master.nodeSelector -- Overwrites nodeSelector from global
   nodeSelector: {}
+  # master.tolerations -- Overwrites tolerations from global
   tolerations: []
+  # master.affinity -- Overwrites affinity from global
   affinity: {}
 
 worker:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -83,6 +83,9 @@ master:
     password: ""
   # master.restartPolicy -- master pod's restartPolicy. Can be Always, OnFailure, or Never.
   restartPolicy: Always
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 worker:
   # worker.image -- A custom docker image including tag


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Adds the ability to assign master to a different node, backwards compatible with global assignments

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
