### PR TITLE
[stable/superset] Chore: Superset chart supports Oauth2 with Okta now

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: superset
 description: A Helm chart for Apache Superset
 type: application
-version: 1.0.10
+version: 1.0.11
 home: https://superset.apache.org/
 appVersion: "latest"
 maintainers:

--- a/stable/superset/README.md
+++ b/stable/superset/README.md
@@ -1,6 +1,6 @@
 # superset
 
-![Version: 1.0.10](https://img.shields.io/badge/Version-1.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.0.11](https://img.shields.io/badge/Version-1.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for Apache Superset
 
@@ -100,6 +100,10 @@ helm install my-release deliveryhero/superset -f values.yaml
 | superset.database.username | string | `""` |  |
 | superset.extraConfig | string | `""` |  |
 | superset.nodeSelector | object | `{}` |  |
+| superset.oauth2.okta.default_admin_emails | list | `[]` |  |
+| superset.oauth2.okta.default_self_registration_role | string | `"Gamma"` |  |
+| superset.oauth2.okta.enabled | bool | `false` |  |
+| superset.oauth2.okta.token_key_name | string | `"access_token"` |  |
 | superset.oidc.config | string | `""` |  |
 | superset.oidc.enabled | bool | `false` |  |
 | superset.oidc.imports | string | `""` |  |

--- a/stable/superset/files/okta.py
+++ b/stable/superset/files/okta.py
@@ -1,0 +1,60 @@
+import os
+
+from superset.security import SupersetSecurityManager
+from flask_appbuilder.security.manager import AUTH_OAUTH
+
+default_self_registration_role: str
+provider_token_key_name: str
+default_admin_emails: list[str]
+
+AUTH_TYPE = AUTH_OAUTH
+AUTH_USER_REGISTRATION = True
+
+AUTH_DEFAULT_ADMIN_EMAILS = default_admin_emails
+AUTH_USER_REGISTRATION_ROLE = default_self_registration_role
+
+OKTA_BASE_URL = os.environ["OKTA_BASE_URL"]
+OKTA_CLIENT_ID = os.environ["OKTA_CLIENT_ID"]
+OKTA_CLIENT_SECRET = os.environ["OKTA_CLIENT_SECRET"]
+OKTA_METADATA_URL = os.environ["OKTA_METADATA_URL"]
+
+
+OAUTH_PROVIDERS = [
+    {
+        "name": "okta",
+        "token_key": provider_token_key_name,
+        "icon": "fa-sign-in",
+        "remote_app": {
+            "client_id": OKTA_CLIENT_ID,
+            "client_secret": OKTA_CLIENT_SECRET,
+            "server_metadata_url": OKTA_METADATA_URL,
+            "api_base_url": OKTA_BASE_URL,
+            "client_kwargs": {
+                "scope": "openid profile email groups",
+            },
+        },
+    }
+]
+
+
+class CustomSsoSecurityManager(SupersetSecurityManager):
+    def oauth_user_info(self, provider, response=None):
+        if provider == "okta":
+            user: dict[str, str] = (
+                self.appbuilder.sm.oauth_remotes[provider].get("userinfo").json()
+            )
+            return {
+                "username": user["preferred_username"],
+                "name": user["name"],
+                "email": user["email"],
+                "first_name": user["given_name"],
+                "last_name": user["family_name"],
+                "roles": [
+                    "Admin"
+                    if user["email"] in AUTH_DEFAULT_ADMIN_EMAILS
+                    else AUTH_USER_REGISTRATION_ROLE
+                ],
+            }
+
+
+CUSTOM_SECURITY_MANAGER = CustomSsoSecurityManager

--- a/stable/superset/templates/configmap.yaml
+++ b/stable/superset/templates/configmap.yaml
@@ -16,6 +16,9 @@ data:
     {{- if .Values.superset.oidc.enabled }}
       {{- .Values.superset.oidc.imports | nindent 4 }}
       {{- .Values.superset.oidc.config | nindent 4 }}
+    {{- else if .Values.superset.oauth2.okta.enabled }}
+      {{- include "okta_variables" . | nindent 4 }}
+      {{- .Files.Get "files/okta.py" | nindent 4 }}
     {{ end }}
     {{- .Values.superset.extraConfig | nindent 4 }}
 

--- a/stable/superset/templates/variables.py.tpl
+++ b/stable/superset/templates/variables.py.tpl
@@ -21,3 +21,12 @@ results_backend_host = cache_redis_host
 results_backend_port = cache_redis_port
 results_backend_key_prefix = "superset_results"
 {{ end }}
+
+
+{{- define "okta_variables" -}}
+import os
+
+default_self_registration_role = {{ .Values.superset.oauth2.okta.default_self_registration_role | quote }}
+provider_token_key_name = {{ .Values.superset.oauth2.okta.token_key_name | quote }}
+default_admin_emails = {{ toPrettyJson .Values.superset.oauth2.okta.default_admin_emails }}
+{{ end }}

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -30,6 +30,12 @@ superset:
     enabled: false
     config: ""
     imports: ""
+  oauth2:
+    okta:
+      enabled: false
+      default_self_registration_role: Gamma
+      token_key_name: access_token
+      default_admin_emails: []
   replicas: 1
   redis:
     default_timeout: 300


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

* deliveryhero/superset chart supports Oauth2 with Okta

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
