### PR TITLE
[stable/superset] Fix: configureable https reverse proxy + flexible assignment of roles after authn

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: superset
 description: A Helm chart for Apache Superset
 type: application
-version: 1.0.12
+version: 1.0.13
 home: https://superset.apache.org/
 appVersion: "latest"
 maintainers:

--- a/stable/superset/README.md
+++ b/stable/superset/README.md
@@ -1,6 +1,6 @@
 # superset
 
-![Version: 1.0.12](https://img.shields.io/badge/Version-1.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.0.13](https://img.shields.io/badge/Version-1.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for Apache Superset
 
@@ -98,10 +98,10 @@ helm install my-release deliveryhero/superset -f values.yaml
 | superset.database.password | string | `""` |  |
 | superset.database.port | int | `5432` |  |
 | superset.database.username | string | `""` |  |
+| superset.enable_proxy_fix | bool | `true` |  |
 | superset.extraConfig | string | `""` |  |
 | superset.nodeSelector | object | `{}` |  |
 | superset.oauth2.okta.default_admin_emails | list | `[]` |  |
-| superset.oauth2.okta.default_self_registration_role | string | `"Gamma"` |  |
 | superset.oauth2.okta.enabled | bool | `false` |  |
 | superset.oauth2.okta.token_key_name | string | `"access_token"` |  |
 | superset.oidc.config | string | `""` |  |

--- a/stable/superset/files/okta.py
+++ b/stable/superset/files/okta.py
@@ -4,7 +4,6 @@ from typing import List
 from superset.security import SupersetSecurityManager
 from flask_appbuilder.security.manager import AUTH_OAUTH
 
-default_self_registration_role: str
 provider_token_key_name: str
 default_admin_emails: List[str]
 
@@ -12,7 +11,16 @@ AUTH_TYPE = AUTH_OAUTH
 AUTH_USER_REGISTRATION = True
 
 AUTH_DEFAULT_ADMIN_EMAILS = default_admin_emails
-AUTH_USER_REGISTRATION_ROLE = default_self_registration_role
+# See all available roles in https://superset.apache.org/docs/security
+AUTH_DEFAULT_ADMIN_ROLE = "Admin"
+AUTH_DEFAULT_NON_ADMIN_ROLE = "Gamma"
+
+# See: https://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-oauth
+AUTH_ROLES_MAPPING = {
+    # NOTE: A little bit inflexible for now, but should do the work
+    AUTH_DEFAULT_ADMIN_ROLE: [AUTH_DEFAULT_ADMIN_ROLE],
+    AUTH_DEFAULT_NON_ADMIN_ROLE: [AUTH_DEFAULT_NON_ADMIN_ROLE],
+}
 
 OKTA_BASE_URL = os.environ["OKTA_BASE_URL"]
 OKTA_CLIENT_ID = os.environ["OKTA_CLIENT_ID"]
@@ -46,14 +54,13 @@ class CustomSsoSecurityManager(SupersetSecurityManager):
             )
             return {
                 "username": user["preferred_username"],
-                "name": user["name"],
                 "email": user["email"],
                 "first_name": user["given_name"],
                 "last_name": user["family_name"],
-                "roles": [
-                    "Admin"
+                "role_keys": [
+                    AUTH_DEFAULT_ADMIN_ROLE
                     if user["email"] in AUTH_DEFAULT_ADMIN_EMAILS
-                    else AUTH_USER_REGISTRATION_ROLE
+                    else AUTH_DEFAULT_NON_ADMIN_ROLE
                 ],
             }
 

--- a/stable/superset/templates/variables.py.tpl
+++ b/stable/superset/templates/variables.py.tpl
@@ -1,5 +1,6 @@
 {{- define "superset_config_variables" -}}
 import os
+import json
 
 cache_default_timeout = {{ .Values.superset.redis.default_timeout }}
 cache_key_prefix = {{ .Values.superset.redis.key_prefix | quote }}
@@ -20,11 +21,12 @@ celery_result_backend = f"redis://{cache_redis_host}:{cache_redis_port}/{{ .Valu
 results_backend_host = cache_redis_host
 results_backend_port = cache_redis_port
 results_backend_key_prefix = "superset_results"
+
+ENABLE_PROXY_FIX = json.loads({{ .Values.superset.enable_proxy_fix | quote }})
 {{ end }}
 
 
 {{- define "okta_variables" -}}
-default_self_registration_role = {{ .Values.superset.oauth2.okta.default_self_registration_role | quote }}
 provider_token_key_name = {{ .Values.superset.oauth2.okta.token_key_name | quote }}
 default_admin_emails = {{ toPrettyJson .Values.superset.oauth2.okta.default_admin_emails }}
 {{ end }}

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -26,6 +26,10 @@ ingress:
   tls: []
 
 superset:
+  # Is it behind a reverse proxy that serves https?
+  # Strictly accepts true or false, not yes or no.
+  # See: https://superset.apache.org/docs/installation/configuring-superset/#configuration-behind-a-load-balancer
+  enable_proxy_fix: true
   oidc:
     enabled: false
     config: ""
@@ -33,7 +37,6 @@ superset:
   oauth2:
     okta:
       enabled: false
-      default_self_registration_role: Gamma
       token_key_name: access_token
       default_admin_emails: []
   replicas: 1


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

* Configureable https reverse proxy
* Flexible assignment of roles after authn

![Screenshot 2022-07-05 at 12 16 37](https://user-images.githubusercontent.com/7668385/177306792-c6bda1e8-a495-4b25-b12b-43b4b67157e9.png)

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
