### PR TITLE
[stable/kube-bench] Allows creation of service account

### DIFF
--- a/stable/kube-bench/Chart.yaml
+++ b/stable/kube-bench/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: "Helm chart to deploy run kube-bench as a cronjob on gke or eks."
 name: kube-bench
-version: 0.1.3
+version: 0.1.4
 home: https://github.com/aquasecurity/kube-bench
 icon: https://raw.githubusercontent.com/aquasecurity/kube-bench/master/images/kube-bench.png
 sources:

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -1,6 +1,6 @@
 # kube-bench
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square)
 
 Helm chart to deploy run kube-bench as a cronjob on gke or eks.
 
@@ -56,6 +56,8 @@ helm install my-release deliveryhero/kube-bench -f values.yaml
 | nodeSelector | object | `{}` |  |
 | provider | string | `"eks"` |  |
 | resources | object | `{}` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `false` |  |
 | tolerations | list | `[]` |  |
 
 ## Maintainers

--- a/stable/kube-bench/templates/cron.yaml
+++ b/stable/kube-bench/templates/cron.yaml
@@ -9,6 +9,9 @@ spec:
     spec:
       template:
         spec:
+          {{- if .Values.serviceAccount.create }}
+          serviceAccountName: kube-bench
+          {{- end }}
           hostPID: true
           restartPolicy: Never
           containers:

--- a/stable/kube-bench/templates/serviceaccount.yaml
+++ b/stable/kube-bench/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-bench
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/stable/kube-bench/values.yaml
+++ b/stable/kube-bench/values.yaml
@@ -9,6 +9,12 @@ image:
   tag: 0.4.0
   pullPolicy: IfNotPresent
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
This update allows the creation of a service account. 
## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
