### PR TITLE
[stable/kube-downscaler] add missing `securityContext` into templates

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.5"
+version: "0.5.1"
 appVersion: 22.2.0
 description: Scale down Kubernetes deployments after work hours
 keywords:

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.5](https://img.shields.io/badge/Version-0.5-informational?style=flat-square) ![AppVersion: 22.2.0](https://img.shields.io/badge/AppVersion-22.2.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![AppVersion: 22.2.0](https://img.shields.io/badge/AppVersion-22.2.0-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 
@@ -76,9 +76,7 @@ helm install my-release deliveryhero/kube-downscaler -f values.yaml
 | resources.limits.memory | string | `"200Mi"` |  |
 | resources.requests.cpu | string | `"50m"` |  |
 | resources.requests.memory | string | `"200Mi"` |  |
-| securityContext.readOnlyRootFilesystem | bool | `true` |  |
-| securityContext.runAsNonRoot | bool | `true` |  |
-| securityContext.runAsUser | int | `1000` |  |
+| securityContext | object | `{}` |  |
 | tolerations | list | `[]` |  |
 
 ## Maintainers

--- a/stable/kube-downscaler/templates/deployment.yaml
+++ b/stable/kube-downscaler/templates/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-downscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/stable/kube-downscaler/values.yaml
+++ b/stable/kube-downscaler/values.yaml
@@ -37,10 +37,10 @@ resources:
     cpu: 50m
     memory: 200Mi
 
-securityContext:
-  readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 1000
+securityContext: {}
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
 
 extraLabels: {}
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

Previously `Values.securityContext` was not used in templates, this PR adds it and keeps it empty by default.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
