### PR TITLE
[stable/node-problem-detector] Update Version to v0.8.11

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.2.2"
-appVersion: v0.8.10
+version: "2.2.3"
+appVersion: v0.8.11
 home: https://github.com/kubernetes/node-problem-detector
 description: |
   This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.2.2](https://img.shields.io/badge/Version-2.2.2-informational?style=flat-square) ![AppVersion: v0.8.10](https://img.shields.io/badge/AppVersion-v0.8.10-informational?style=flat-square)
+![Version: 2.2.3](https://img.shields.io/badge/Version-2.2.3-informational?style=flat-square) ![AppVersion: v0.8.11](https://img.shields.io/badge/AppVersion-v0.8.11-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -58,7 +58,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | hostPID | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"k8s.gcr.io/node-problem-detector/node-problem-detector"` |  |
-| image.tag | string | `"v0.8.10"` |  |
+| image.tag | string | `"v0.8.11"` |  |
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -52,7 +52,7 @@ logDir:
 
 image:
   repository: k8s.gcr.io/node-problem-detector/node-problem-detector
-  tag: v0.8.10
+  tag: v0.8.11
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
A new version of node-problem-detector has been released after a very long delay: https://github.com/kubernetes/node-problem-detector/releases/tag/v0.8.11. This PR updates the version to the latest, 0.8.11. I ran checks locally and they all passed.

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. ``)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
