### PR TITLE
[stable/kube-downscaler]: match image.tag with appVersion

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.5.1"
+version: "0.5.2"
 appVersion: 22.2.0
 description: Scale down Kubernetes deployments after work hours
 keywords:

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![AppVersion: 22.2.0](https://img.shields.io/badge/AppVersion-22.2.0-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![AppVersion: 22.2.0](https://img.shields.io/badge/AppVersion-22.2.0-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 
@@ -56,7 +56,7 @@ helm install my-release deliveryhero/kube-downscaler -f values.yaml
 | image.args | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"hjacobs/kube-downscaler"` |  |
-| image.tag | string | `"21.2.0"` |  |
+| image.tag | string | `"22.2.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | interval | int | `60` |  |
 | nameOverride | string | `""` |  |

--- a/stable/kube-downscaler/values.yaml
+++ b/stable/kube-downscaler/values.yaml
@@ -24,7 +24,7 @@ rbac:
 
 image:
   repository: hjacobs/kube-downscaler
-  tag: 21.2.0
+  tag: "22.2.0"
   pullPolicy: IfNotPresent
   args: []
     # - --include-resources=deployments,cronjobs


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

The appVersion in kube-downscaler was updated in #293 but the `image.tag` value still deploys the `21.2.0` version. This updates `image.tag` to match `appVersion`.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing

## Additional Notes

It might be preferable to use the `default` hack from `helm create` so we only need to set the `appVersion`. I can prepare such a PR if that should be preferred.

There is also a newer version 22.7.1 on codeberg, in the spirit of atmic changes, this only fixes releasing the current `appVersion` but i'll prepare a PR to bump downscaler as well once this is fixed.