### PR TITLE
stable/kube-downscaler: update from 22.2.0 to 22.7.1

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,7 +1,7 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.5.3"
-appVersion: 22.2.0
+version: "0.5.4"
+appVersion: 22.7.1
 description: Scale down Kubernetes deployments after work hours
 keywords:
 - k8s pods scheduler

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![AppVersion: 22.2.0](https://img.shields.io/badge/AppVersion-22.2.0-informational?style=flat-square)
+![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![AppVersion: 22.7.1](https://img.shields.io/badge/AppVersion-22.7.1-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

As promised, here is the update to the latest version of kube-downscaler. I did some cursory testing on a kind environment and it scaled down my workloads as expected.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
