### PR TITLE
[stable/kube-downscaler] Move securityContext to container level

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.5.4"
+version: "0.5.5"
 appVersion: 22.7.1
 description: Scale down Kubernetes deployments after work hours
 keywords:

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![AppVersion: 22.7.1](https://img.shields.io/badge/AppVersion-22.7.1-informational?style=flat-square)
+![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![AppVersion: 22.7.1](https://img.shields.io/badge/AppVersion-22.7.1-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 

--- a/stable/kube-downscaler/templates/deployment.yaml
+++ b/stable/kube-downscaler/templates/deployment.yaml
@@ -20,8 +20,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-downscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
-      securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -29,6 +27,8 @@ spec:
       containers:
       - name: {{ template "kube-downscaler.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         env:
 {{- range $key, $value := .Values.deployment.environment }}
          {{- if $value }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
Currently `securityContext` has been placed under `Deployment.spec.template.spec`. But the `securityContext.readOnlyRootFilesystem` is field of container [securityContext
](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#securitycontext-v1-core)

Enabling these values:
```
securityContext: 
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  runAsUser: 1000
```
and deploying the chart throws an error:

```
"Error: unable to build kubernetes objects from release manifest: error validating \"\": error validating data: ValidationError(Deployment.spec.template.spec.securityContext): unknown field \"readOnlyRootFilesystem\" in io.k8s.api.core.v1.PodSecurityContext\n"
```
Looking at the [deployment manifest](https://codeberg.org/hjacobs/kube-downscaler/src/branch/main/deploy/deployment.yaml#L38) in the maintainer repo, the `securityContext` should be part of the container 
<!--- Describe your changes in detail -->

## Checklist

- [ x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
