### PR TITLE
[stable/locust] Bump Locust version to 2.11.0

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: locust
-version: "0.27.1"
-appVersion: 2.8.6
+version: "0.28.0"
+appVersion: 2.11.0
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png
 maintainers:

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.1-informational?style=flat-square) ![AppVersion: 2.8.6](https://img.shields.io/badge/AppVersion-2.8.6-informational?style=flat-square)
+![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![AppVersion: 2.11.0](https://img.shields.io/badge/AppVersion-2.11.0-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -68,7 +68,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"locustio/locust"` |  |
-| image.tag | string | `"2.8.6"` |  |
+| image.tag | string | `"2.11.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -38,7 +38,7 @@ loadtest:
 
 image:
   repository: locustio/locust
-  tag: 2.8.6
+  tag: 2.11.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Updates Locust to 2.11.0

I was unable to run the GH actions in my fork, but I'm guessing they will run when I make this PR...