### PR TITLE
[stable/cloudhealth-collector] add deploymentAnnotations

### DIFF
--- a/stable/cloudhealth-collector/Chart.yaml
+++ b/stable/cloudhealth-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "957"
 name: cloudhealth-collector
-version: 0.1.2
+version: 0.1.3
 description: |
   Deploys a k8s pod to collect data and generate reports based or resources usages, costs and other possibilities. Please check more about it on: https://www.cloudhealthtech.com/solutions/containers
 

--- a/stable/cloudhealth-collector/README.md
+++ b/stable/cloudhealth-collector/README.md
@@ -1,6 +1,6 @@
 # cloudhealth-collector
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 957](https://img.shields.io/badge/AppVersion-957-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 957](https://img.shields.io/badge/AppVersion-957-informational?style=flat-square)
 
 Deploys a k8s pod to collect data and generate reports based or resources usages, costs and other possibilities. Please check more about it on: https://www.cloudhealthtech.com/solutions/containers
 
@@ -55,6 +55,7 @@ helm install my-release deliveryhero/cloudhealth-collector -f values.yaml
 | affinity | object | `{}` |  |
 | api_token | string | `"<change-me>"` |  |
 | cluster_name | string | `"your-cluster-name"` |  |
+| deploymentAnnotations | object | `{}` |  |
 | existingSecret.secretName | string | `""` |  |
 | existingSecret.tokenKey | string | `""` |  |
 | extraLabels | object | `{}` |  |

--- a/stable/cloudhealth-collector/templates/deployment.yaml
+++ b/stable/cloudhealth-collector/templates/deployment.yaml
@@ -4,6 +4,11 @@ metadata:
   name: {{ include "cloudhealth-collector.fullname" . }}
   labels:
     {{- include "cloudhealth-collector.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/stable/cloudhealth-collector/values.yaml
+++ b/stable/cloudhealth-collector/values.yaml
@@ -27,6 +27,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+deploymentAnnotations: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

I need to run the cloudhealth-collector with annotations on the Deployment.
Currently only pod annotations are supported.

This change adds deployment annotations to the helm chart via
`.Values.deploymentAnnotations`.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
