### PR TITLE
[stable/cloudhealth-collector] Fix indentation in deployment annotations

### DIFF
--- a/stable/cloudhealth-collector/templates/deployment.yaml
+++ b/stable/cloudhealth-collector/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     {{- include "cloudhealth-collector.labels" . | nindent 4 }}
   {{- with .Values.deploymentAnnotations }}
-    annotations:
-      {{- toYaml . | nindent 6 }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 
 spec:


### PR DESCRIPTION

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

When I tested this I found out that the chart wasn't working with the
deploymentAnnotations because of indentation errors. This change should fix
that.

Keeping the version the same because the current release of that version is
broken.

<!--- Describe your changes in detail -->

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
