### PR TITLE
[stable/kube-downscaler] Add support for pod custom labels

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.5.5"
+version: "0.5.6"
 appVersion: 22.7.1
 description: Scale down Kubernetes deployments after work hours
 keywords:

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![AppVersion: 22.7.1](https://img.shields.io/badge/AppVersion-22.7.1-informational?style=flat-square)
+![Version: 0.5.6](https://img.shields.io/badge/Version-0.5.6-informational?style=flat-square) ![AppVersion: 22.7.1](https://img.shields.io/badge/AppVersion-22.7.1-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 

--- a/stable/kube-downscaler/templates/deployment.yaml
+++ b/stable/kube-downscaler/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "kube-downscaler.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.extraLabels }}
+          {{- toYaml .Values.extraLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-downscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
     {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
PR adds support for pod custom labels.
One of the use cases is running downscaler in EKS on fargate where a pod label selector is used to determine a workload to be scheduled on fargate.
<!--- Describe your changes in detail -->

## Checklist

- [+] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [+] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [+] Github actions are passing
