### PR TITLE
[stable/node-problem-detector] Remove deprecated critical-pod annotation

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.2.3"
+version: "2.2.4"
 appVersion: v0.8.11
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.2.3](https://img.shields.io/badge/Version-2.2.3-informational?style=flat-square) ![AppVersion: v0.8.11](https://img.shields.io/badge/AppVersion-v0.8.11-informational?style=flat-square)
+![Version: 2.2.4](https://img.shields.io/badge/Version-2.2.4-informational?style=flat-square) ![AppVersion: v0.8.11](https://img.shields.io/badge/AppVersion-v0.8.11-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -75,7 +75,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | metrics.serviceMonitor.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
-| priorityClassName | string | `""` |  |
+| priorityClassName | string | `"system-node-critical"` |  |
 | rbac.create | bool | `true` |  |
 | rbac.pspEnabled | bool | `false` |  |
 | resources | object | `{}` |  |

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
         {{- end}}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/custom-config-configmap.yaml") . | sha256sum }}
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         {{- if .Values.annotations }}
         {{- toYaml .Values.annotations | nindent 8 }}
         {{- end }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -70,7 +70,7 @@ rbac:
 hostNetwork: false
 hostPID: false
 
-priorityClassName: ""
+priorityClassName: system-node-critical
 
 securityContext:
   privileged: true


### PR DESCRIPTION
And set `system-node-critical` as a default priorityClass

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

In kubernetes v1.16 `scheduler.alpha.kubernetes.io/critical-pod` annotation was deprecated and `priorityClassName` is supposed to be used instead.

Fixes https://github.com/deliveryhero/helm-charts/issues/373

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
