### PR TITLE
[stable/k8s-resources] Ingress API version networking.k8s.io/v1 support, add Namespaces

### DIFF
--- a/stable/k8s-resources/Chart.yaml
+++ b/stable/k8s-resources/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.5
+version: 0.6.0
 appVersion: 0.0.1
 name: k8s-resources
 description: |

--- a/stable/k8s-resources/Chart.yaml
+++ b/stable/k8s-resources/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.0.1
 name: k8s-resources
 description: |
@@ -12,6 +12,7 @@ description: |
   - Custom resources from CustomResourceDefinition
   - HorizontalPodAutoscaler
   - Ingress
+  - Namespace
   - Secret
   - Service
   - ServiceAccount

--- a/stable/k8s-resources/README.md
+++ b/stable/k8s-resources/README.md
@@ -1,6 +1,6 @@
 # k8s-resources
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Not an application but a Helm chart to create any and many resources in Kubernetes.
 
@@ -11,6 +11,7 @@ Currently supports:
 - Custom resources from CustomResourceDefinition
 - HorizontalPodAutoscaler
 - Ingress
+- Namespace
 - Secret
 - Service
 - ServiceAccount
@@ -60,6 +61,7 @@ helm install my-release deliveryhero/k8s-resources -f values.yaml
 | CustomResources | list | `[]` | A list resources to create that are completely custom |
 | HorizontalPodAutoscalers | list | `[]` | A list HorizontalPodAutoscaler to create |
 | Ingresses | list | `[]` | A list Ingress to create |
+| Namespaces | list | `[]` | A list Namespaces to create |
 | PriorityClasses | list | `[]` | A list PriorityClasses to create |
 | Secrets | list | `[]` | A list Secret to create |
 | ServiceAccounts | list | `[]` | A list ServiceAccount to create |

--- a/stable/k8s-resources/README.md
+++ b/stable/k8s-resources/README.md
@@ -1,6 +1,6 @@
 # k8s-resources
 
-![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Not an application but a Helm chart to create any and many resources in Kubernetes.
 

--- a/stable/k8s-resources/ci/ct-values.yaml
+++ b/stable/k8s-resources/ci/ct-values.yaml
@@ -30,12 +30,17 @@ Ingresses:
     fullnameOverride: ""
     annotations: {}
     extraLabels: {}
-    hosts:
+    rules:
       - host: chart-example.local
-        paths:
-          - path: /api
-            serviceName: example-service
-            servicePort: 8080
+        http:
+          paths:
+            - path: /api
+              pathType: Prefix
+              backend:
+                service:
+                  name: example-service
+                  port:
+                    number: 8080
 
 Secrets:
   - name: example-secret

--- a/stable/k8s-resources/ci/ct-values.yaml
+++ b/stable/k8s-resources/ci/ct-values.yaml
@@ -110,3 +110,9 @@ HorizontalPodAutoscalers:
       apiVersion: apps/v1
       kind: Deployment
       name: my-deployment
+
+Namespaces:
+  - name: production
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels: {}

--- a/stable/k8s-resources/templates/ingress.yaml
+++ b/stable/k8s-resources/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.Ingresses -}}
 {{- range .Values.Ingresses }}
-apiVersion: {{ default "networking.k8s.io/v1beta1" .apiVersion }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- if .namespace }}
@@ -17,6 +17,13 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .defaultBackend }}
+  defaultBackend:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .ingressClassName }}
+  ingressClassName: {{ .ingressClassName }}
+  {{- end }}
   {{- if .tls }}
   tls:
   {{- range .tls }}
@@ -24,20 +31,12 @@ spec:
     {{- range .hosts }}
     - {{ . | quote }}
     {{- end }}
-  secretName: {{ .secretName }}
+    secretName: {{ .secretName }}
   {{- end }}
   {{- end }}
+  {{- with .rules }}
   rules:
-  {{- range .hosts }}
-  - host: {{ .host | quote }}
-    http:
-      paths:
-      {{- range .paths }}
-      - path: {{ .path }}
-        backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
-      {{- end }}
+    {{- toYaml . | nindent 2 }}
   {{- end }}
 ---
 {{- end }}

--- a/stable/k8s-resources/templates/namespace.yaml
+++ b/stable/k8s-resources/templates/namespace.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.Namespaces -}}
+{{- range .Values.Namespaces }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ if .fullnameOverride }}{{ .fullnameOverride }}{{ else }}{{ include "k8s-resources.fullname" $ }}-{{ .name }}{{ end }}
+  labels:
+    {{- include "k8s-resources.labels" $ | nindent 4 }}
+  {{- with .extraLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/stable/k8s-resources/values.yaml
+++ b/stable/k8s-resources/values.yaml
@@ -46,12 +46,19 @@ Ingresses: []
   #   fullnameOverride: ""
   #   annotations: {}
   #   extraLabels: {}
-  #   hosts:
+  #   defaultBackend: {}
+  #   ingressClassName: ""
+  #   rules:
   #     - host: chart-example.local
-  #       paths:
-  #         - path: /api
-  #           serviceName: example-service
-  #           servicePort: 8080
+  #       http:
+  #         paths:
+  #           - path: /api
+  #             pathType: Prefix
+  #             backend:
+  #               service:
+  #                 name: example-service
+  #                 port:
+  #                   name: http
   #   tls:
   #      - secretName: chart-example-tls
   #        hosts:

--- a/stable/k8s-resources/values.yaml
+++ b/stable/k8s-resources/values.yaml
@@ -127,3 +127,10 @@ PriorityClasses: []
   #   value: 1000
   #   description: "Priority for system critical"
   #   globalDefault: false
+
+# Namespaces -- A list Namespaces to create
+Namespaces: []
+  # - name: "production"
+  #   fullnameOverride: ""
+  #   annotations: {}
+  #   extraLabels: {}


### PR DESCRIPTION
Fixes #377.

Add `defaultBackend` and `ingressClassName` values.

Switch from `hosts` values to `rules`. Rule can be defined without host and
also it better matches Ingress spec.

Also fix `secretName` indentation, it should be nested in `.spec.tls`.

Add ability to create Namespaces.

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
