### PR TITLE
stable/node-problem-detector allow extra args on command line

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.2.5"
+version: "2.2.6"
 appVersion: v0.8.12
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -84,6 +84,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | serviceAccount.name | string | `nil` |  |
 | settings.custom_monitor_definitions | object | `{}` | Custom plugin monitor config files |
 | settings.custom_plugin_monitors | list | `[]` |  |
+| settings.extraArgs | list | `[]` |  |
 | settings.heartBeatPeriod | string | `"5m0s"` | Syncing interval with API server |
 | settings.log_monitors | list | `["/config/kernel-monitor.json","/config/docker-monitor.json"]` | User-specified custom monitor definitions |
 | settings.prometheus_address | string | `"0.0.0.0"` | Prometheus exporter address |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.2.5](https://img.shields.io/badge/Version-2.2.5-informational?style=flat-square) ![AppVersion: v0.8.12](https://img.shields.io/badge/AppVersion-v0.8.12-informational?style=flat-square)
+![Version: 2.2.6](https://img.shields.io/badge/Version-2.2.6-informational?style=flat-square) ![AppVersion: v0.8.12](https://img.shields.io/badge/AppVersion-v0.8.12-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 

--- a/stable/node-problem-detector/templates/_helpers.tpl
+++ b/stable/node-problem-detector/templates/_helpers.tpl
@@ -67,7 +67,7 @@ Return the appropriate apiVersion for podSecurityPolicy.
   Concat npd.config.* to make node-problem-detector CLI args more readable
 */}}
 {{- define "npd.cli.args" -}}
-{{ include "npd.config.systemLogMonitor" . }} {{ include "npd.config.customPluginMonitor" . }} {{ include "npd.config.prometheus" . }} {{ include "npd.config.k8sExporter" . }}
+{{ include "npd.config.systemLogMonitor" . }} {{ include "npd.config.customPluginMonitor" . }} {{ include "npd.config.prometheus" . }} {{ include "npd.config.k8sExporter" . }}  {{ include "npd.config.extraArgs" . }}
 {{- end -}}
 
 {{- define "npd.config.systemLogMonitor" -}}
@@ -94,4 +94,12 @@ Return the appropriate apiVersion for podSecurityPolicy.
 
 {{- define "npd.config.k8sExporter" -}}
 --k8s-exporter-heartbeat-period={{ .Values.settings.heartBeatPeriod }}
+{{- end -}}
+
+{{- define "npd.config.extraArgs" -}}
+{{- if .Values.settings.extraArgs -}}
+{{- range $index, $arg := .Values.settings.extraArgs -}}
+  {{- $arg -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -35,6 +35,10 @@ settings:
     # - /custom-config/docker-monitor-filelog.json
   custom_plugin_monitors: []
 
+  # Any extra arguments to append to node-problem-detector command
+  # - "--port 20526"
+  extraArgs: []
+
   # settings.prometheus_address -- Prometheus exporter address
   prometheus_address: 0.0.0.0
   # settings.prometheus_port -- Prometheus exporter port


### PR DESCRIPTION
## Description

Allow setting extra arguments node-problem-detector's command line

## Note

To run `ci/helm-conftest.sh` I had to use `bash`, `sh` complained:
```
$ sh ci/helm-conftest.sh
ci/helm-conftest.sh: line 29: syntax error near unexpected token `<'
```

This did result in these deleted files (which I didn't commit):

```
➭ git st
On branch node-problem-detector-command-vars
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        deleted:    stable/cachet/requirements.yaml
        deleted:    stable/listmonk/requirements.yaml
        deleted:    stable/weblate/requirements.yaml
```


## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
