### PR TITLE
[stable/metabase] Add extraEnv to metabase chart to set environment variables

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions and learn from data.
 name: metabase
-version: 0.13.3
+version: 0.13.4
 appVersion: v0.43
 home: http://www.metabase.com/
 icon: http://www.metabase.com/images/logo.svg

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -1,6 +1,6 @@
 # metabase
 
-![Version: 0.13.3](https://img.shields.io/badge/Version-0.13.3-informational?style=flat-square) ![AppVersion: v0.43](https://img.shields.io/badge/AppVersion-v0.43-informational?style=flat-square)
+![Version: 0.13.4](https://img.shields.io/badge/Version-0.13.4-informational?style=flat-square) ![AppVersion: v0.43](https://img.shields.io/badge/AppVersion-v0.43-informational?style=flat-square)
 
 The easy, open source way for everyone in your company to ask questions and learn from data.
 
@@ -49,6 +49,7 @@ helm install my-release deliveryhero/metabase -f values.yaml
 | affinity | object | `{}` |  |
 | database.type | string | `"h2"` |  |
 | emojiLogging | bool | `true` |  |
+| extraEnv | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"metabase/metabase"` |  |
 | image.tag | string | `"v0.36.3"` |  |

--- a/stable/metabase/templates/deployment.yaml
+++ b/stable/metabase/templates/deployment.yaml
@@ -124,6 +124,12 @@ spec:
           - name: MB_SESSION_COOKIES
             value: {{ .Values.session.sessionCookies | quote }}
           {{- end }}
+          {{- if .Values.extraEnv }}
+          {{- range $key, $value := .Values.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value }}
+          {{- end }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -113,6 +113,10 @@ ingress:
 #
 # log4jProperties:
 
+extraEnv: {}
+  # Used to set extra environment variables in the metabase container
+  # MB_DB_CONNECTION_TIMEOUT_MS: 120000
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Add extraEnv to metabase chart to set environment variables in metabase container.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
