### PR TITLE
[stable/node-local-dns] Add support for configurable resource requests and limts

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 0.1.1
+version: 0.2.0
 appVersion: 1.21.1
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -46,22 +46,25 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| fullnameOverride | string | `""` |  |
-| image.repository | string | `"k8s.gcr.io/dns/k8s-dns-node-cache"` |  |
-| image.tag | string | `"1.21.1"` |  |
-| nameOverride | string | `""` |  |
-| pillar_dns_domain | string | `"cluster.local"` |  |
-| pillar_dns_server | string | `"172.20.0.10"` |  |
-| pillar_local_dns | string | `"169.254.20.25"` |  |
-| podAnnotations | object | `{}` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
+| Key                        | Type   | Default                               | Description |
+| -------------------------- | ------ | ------------------------------------- | ----------- |
+| fullnameOverride           | string | `""`                                  |             |
+| image.repository           | string | `"k8s.gcr.io/dns/k8s-dns-node-cache"` |             |
+| image.tag                  | string | `"1.21.1"`                            |             |
+| nameOverride               | string | `""`                                  |             |
+| resources.requests.cpu     | string | `"25m"`                               |             |
+| resources.requests.memory  | string | `"5Mi"`                               |             |
+| resources.limits           | object | `{}`                                  |             |
+| pillar_dns_domain          | string | `"cluster.local"`                     |             |
+| pillar_dns_server          | string | `"172.20.0.10"`                       |             |
+| pillar_local_dns           | string | `"169.254.20.25"`                     |             |
+| podAnnotations             | object | `{}`                                  |             |
+| serviceAccount.annotations | object | `{}`                                  |             |
+| serviceAccount.create      | bool   | `true`                                |             |
+| serviceAccount.name        | string | `""`                                  |             |
 
 ## Maintainers
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| gabrieladt | <no-reply@deliveryhero.com> |  |
+| Name       | Email                       | Url |
+| ---------- | --------------------------- | --- |
+| gabrieladt | <no-reply@deliveryhero.com> |     |

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 1.21.1](https://img.shields.io/badge/AppVersion-1.21.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 1.21.1](https://img.shields.io/badge/AppVersion-1.21.1-informational?style=flat-square)
 
 A chart to install node-local-dns.
 

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -46,25 +46,25 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 
 ## Values
 
-| Key                        | Type   | Default                               | Description |
-| -------------------------- | ------ | ------------------------------------- | ----------- |
-| fullnameOverride           | string | `""`                                  |             |
-| image.repository           | string | `"k8s.gcr.io/dns/k8s-dns-node-cache"` |             |
-| image.tag                  | string | `"1.21.1"`                            |             |
-| nameOverride               | string | `""`                                  |             |
-| resources.requests.cpu     | string | `"25m"`                               |             |
-| resources.requests.memory  | string | `"5Mi"`                               |             |
-| resources.limits           | object | `{}`                                  |             |
-| pillar_dns_domain          | string | `"cluster.local"`                     |             |
-| pillar_dns_server          | string | `"172.20.0.10"`                       |             |
-| pillar_local_dns           | string | `"169.254.20.25"`                     |             |
-| podAnnotations             | object | `{}`                                  |             |
-| serviceAccount.annotations | object | `{}`                                  |             |
-| serviceAccount.create      | bool   | `true`                                |             |
-| serviceAccount.name        | string | `""`                                  |             |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| fullnameOverride | string | `""` |  |
+| image.repository | string | `"k8s.gcr.io/dns/k8s-dns-node-cache"` |  |
+| image.tag | string | `"1.21.1"` |  |
+| nameOverride | string | `""` |  |
+| pillar_dns_domain | string | `"cluster.local"` |  |
+| pillar_dns_server | string | `"172.20.0.10"` |  |
+| pillar_local_dns | string | `"169.254.20.25"` |  |
+| podAnnotations | object | `{}` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests.cpu | string | `"25m"` |  |
+| resources.requests.memory | string | `"5Mi"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
 
 ## Maintainers
 
-| Name       | Email                       | Url |
-| ---------- | --------------------------- | --- |
-| gabrieladt | <no-reply@deliveryhero.com> |     |
+| Name | Email | Url |
+| ---- | ------ | --- |
+| gabrieladt | <no-reply@deliveryhero.com> |  |

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -34,10 +34,10 @@ spec:
       containers:
       - name: node-cache
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        {{- with .Values.resources }}
         resources:
-          requests:
-            cpu: 25m
-            memory: 5Mi
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         args: [ "-localip", "{{ .Values.pillar_local_dns }},{{ .Values.pillar_dns_server }}", "-conf", "/etc/Corefile", "-upstreamsvc", "{{ include "node-local-dns.fullname" . }}-upstream" ]
         securityContext:
           privileged: true

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -25,3 +25,9 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 5Mi
+  limits: {}


### PR DESCRIPTION
## Description

This PR updates the node-local-dns chart to make the resource requests and limits configurable. The resource requests default to `25m` and `5Mi`, which is unchanged from the previous hard-coded values.

Limits is set to an empty object so by default the limits will not be set. Users can choose to set just the cpu, memory, or both.

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
