### PR TITLE
[stable/kube-downscaler] Add support for priorityClassName

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.5.7"
+version: "0.5.8"
 appVersion: 22.7.1
 description: Scale down Kubernetes deployments after work hours
 keywords:

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.5.7](https://img.shields.io/badge/Version-0.5.7-informational?style=flat-square) ![AppVersion: 22.7.1](https://img.shields.io/badge/AppVersion-22.7.1-informational?style=flat-square)
+![Version: 0.5.8](https://img.shields.io/badge/Version-0.5.8-informational?style=flat-square) ![AppVersion: 22.7.1](https://img.shields.io/badge/AppVersion-22.7.1-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 
@@ -61,6 +61,7 @@ helm install my-release deliveryhero/kube-downscaler -f values.yaml
 | interval | int | `60` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| priorityClassName | string | `""` |  |
 | rbac.create | bool | `true` |  |
 | rbac.extraRules | list | `[]` |  |
 | rbac.serviceAccountName | string | `"default"` |  |

--- a/stable/kube-downscaler/templates/deployment.yaml
+++ b/stable/kube-downscaler/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
           {{- toYaml .Values.extraLabels | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-downscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/kube-downscaler/values.yaml
+++ b/stable/kube-downscaler/values.yaml
@@ -84,3 +84,4 @@ fullnameOverride: ""
 nodeSelector: {}
 tolerations: []
 affinity: {}
+priorityClassName: ""


### PR DESCRIPTION
## Description
PR to add support for `priorityClassName`. 

It's important that the `kube-downscaler` has the right priority, especially when it's running in an environment with the `cluster-autoscaler` enabled because, in the event of a cluster downscale (i.e the cluster-autoscaler reduces the number of running instances), the `kube-downscaler` must be placed in any node **with the first priority**.

## Checklist

- [+] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [+] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [+] Github actions are passing
