### PR TITLE
Facing issue while pod creation.

### DIFF
--- a/stable/cloudhealth-collector/templates/deployment.yaml
+++ b/stable/cloudhealth-collector/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ .Values.existingSecret.secretName | default (include "cloudhealth-collector.fullname" .) }}
-              key: {{ .Values.existingSecret.tokenKey |  default "api_key" }}
+              key: {{ .Values.existingSecret.tokenKey |  default "api_token" }}
         - name: CHT_CLUSTER_NAME
           value: {{ .Values.cluster_name }}
         - name: CHT_INTERVAL


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Secret having api_token as a key, but in deployment.yaml we are looking api_key.
Wrong call of token, due to this is pod not coming up.

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
