### PR TITLE
[stable/cloudhealth-collector] Add arbitrary environment variable functionality

### DIFF
--- a/stable/cloudhealth-collector/Chart.yaml
+++ b/stable/cloudhealth-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "957"
 name: cloudhealth-collector
-version: 0.1.4
+version: 0.1.5
 description: |
   Deploys a k8s pod to collect data and generate reports based or resources usages, costs and other possibilities. Please check more about it on: https://www.cloudhealthtech.com/solutions/containers
 
@@ -14,5 +14,5 @@ home: https://github.com/deliveryhero/helm-charts
 sources:
   - https://s3.amazonaws.com/cloudhealth-public/containers/kubernetes-collector-pod-template.yaml
 maintainers:
-- name: max-rocket-internet
-  email: no-reply@deliveryhero.com
+  - name: max-rocket-internet
+    email: no-reply@deliveryhero.com

--- a/stable/cloudhealth-collector/README.md
+++ b/stable/cloudhealth-collector/README.md
@@ -1,6 +1,6 @@
 # cloudhealth-collector
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 957](https://img.shields.io/badge/AppVersion-957-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: 957](https://img.shields.io/badge/AppVersion-957-informational?style=flat-square)
 
 Deploys a k8s pod to collect data and generate reports based or resources usages, costs and other possibilities. Please check more about it on: https://www.cloudhealthtech.com/solutions/containers
 
@@ -50,38 +50,38 @@ helm install my-release deliveryhero/cloudhealth-collector -f values.yaml
 
 ## Values
 
-| Key                        | Type   | Default                             | Description |
-| -------------------------- | ------ | ----------------------------------- | ----------- |
-| affinity                   | object | `{}`                                |             |
-| api_token                  | string | `"<change-me>"`                     |             |
-| cluster_name               | string | `"your-cluster-name"`               |             |
-| deploymentAnnotations      | object | `{}`                                |             |
-| existingSecret.secretName  | string | `""`                                |             |
-| existingSecret.tokenKey    | string | `""`                                |             |
-| extraLabels                | object | `{}`                                |             |
-| fullnameOverride           | string | `""`                                |             |
-| image.pullPolicy           | string | `"IfNotPresent"`                    |             |
-| image.repository           | string | `"cloudhealth/container-collector"` |             |
-| image.tag                  | int    | `957`                               |             |
-| imagePullSecrets           | list   | `[]`                                |             |
-| nameOverride               | string | `""`                                |             |
-| nodeSelector               | object | `{}`                                |             |
-| podAnnotations             | object | `{}`                                |             |
-| podSecurityContext         | object | `{}`                                |             |
-| replicaCount               | int    | `1`                                 |             |
-| resources.limits.cpu       | string | `"1000m"`                           |             |
-| resources.limits.memory    | string | `"512Mi"`                           |             |
-| resources.requests.cpu     | string | `"500m"`                            |             |
-| resources.requests.memory  | string | `"512Mi"`                           |             |
-| securityContext            | object | `{}`                                |             |
-| serviceAccount.annotations | object | `{}`                                |             |
-| serviceAccount.create      | bool   | `true`                              |             |
-| serviceAccount.name        | string | `""`                                |             |
-| tolerations                | list   | `[]`                                |             |
-| extraEnv                   | list   | `[]`                                |             |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| api_token | string | `"<change-me>"` |  |
+| cluster_name | string | `"your-cluster-name"` |  |
+| deploymentAnnotations | object | `{}` |  |
+| existingSecret.secretName | string | `""` |  |
+| existingSecret.tokenKey | string | `""` |  |
+| extraEnv | list | `[]` |  |
+| extraLabels | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"cloudhealth/container-collector"` |  |
+| image.tag | int | `957` |  |
+| imagePullSecrets | list | `[]` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `1` |  |
+| resources.limits.cpu | string | `"1000m"` |  |
+| resources.limits.memory | string | `"512Mi"` |  |
+| resources.requests.cpu | string | `"500m"` |  |
+| resources.requests.memory | string | `"512Mi"` |  |
+| securityContext | object | `{}` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |
 
 ## Maintainers
 
-| Name                | Email                       | Url |
-| ------------------- | --------------------------- | --- |
-| max-rocket-internet | <no-reply@deliveryhero.com> |     |
+| Name | Email | Url |
+| ---- | ------ | --- |
+| max-rocket-internet | <no-reply@deliveryhero.com> |  |

--- a/stable/cloudhealth-collector/README.md
+++ b/stable/cloudhealth-collector/README.md
@@ -50,37 +50,38 @@ helm install my-release deliveryhero/cloudhealth-collector -f values.yaml
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| api_token | string | `"<change-me>"` |  |
-| cluster_name | string | `"your-cluster-name"` |  |
-| deploymentAnnotations | object | `{}` |  |
-| existingSecret.secretName | string | `""` |  |
-| existingSecret.tokenKey | string | `""` |  |
-| extraLabels | object | `{}` |  |
-| fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"cloudhealth/container-collector"` |  |
-| image.tag | int | `957` |  |
-| imagePullSecrets | list | `[]` |  |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podSecurityContext | object | `{}` |  |
-| replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"1000m"` |  |
-| resources.limits.memory | string | `"512Mi"` |  |
-| resources.requests.cpu | string | `"500m"` |  |
-| resources.requests.memory | string | `"512Mi"` |  |
-| securityContext | object | `{}` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| tolerations | list | `[]` |  |
+| Key                        | Type   | Default                             | Description |
+| -------------------------- | ------ | ----------------------------------- | ----------- |
+| affinity                   | object | `{}`                                |             |
+| api_token                  | string | `"<change-me>"`                     |             |
+| cluster_name               | string | `"your-cluster-name"`               |             |
+| deploymentAnnotations      | object | `{}`                                |             |
+| existingSecret.secretName  | string | `""`                                |             |
+| existingSecret.tokenKey    | string | `""`                                |             |
+| extraLabels                | object | `{}`                                |             |
+| fullnameOverride           | string | `""`                                |             |
+| image.pullPolicy           | string | `"IfNotPresent"`                    |             |
+| image.repository           | string | `"cloudhealth/container-collector"` |             |
+| image.tag                  | int    | `957`                               |             |
+| imagePullSecrets           | list   | `[]`                                |             |
+| nameOverride               | string | `""`                                |             |
+| nodeSelector               | object | `{}`                                |             |
+| podAnnotations             | object | `{}`                                |             |
+| podSecurityContext         | object | `{}`                                |             |
+| replicaCount               | int    | `1`                                 |             |
+| resources.limits.cpu       | string | `"1000m"`                           |             |
+| resources.limits.memory    | string | `"512Mi"`                           |             |
+| resources.requests.cpu     | string | `"500m"`                            |             |
+| resources.requests.memory  | string | `"512Mi"`                           |             |
+| securityContext            | object | `{}`                                |             |
+| serviceAccount.annotations | object | `{}`                                |             |
+| serviceAccount.create      | bool   | `true`                              |             |
+| serviceAccount.name        | string | `""`                                |             |
+| tolerations                | list   | `[]`                                |             |
+| extraEnv                   | list   | `[]`                                |             |
 
 ## Maintainers
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| max-rocket-internet | <no-reply@deliveryhero.com> |  |
+| Name                | Email                       | Url |
+| ------------------- | --------------------------- | --- |
+| max-rocket-internet | <no-reply@deliveryhero.com> |     |

--- a/stable/cloudhealth-collector/templates/deployment.yaml
+++ b/stable/cloudhealth-collector/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
           value: "900"
         - name: CHT_JVM_MEM
           value: "-Xmx891M"
+        {{- with .Values.extraEnv }}
+          {{toYaml . | nindent 8 }}
+        {{- end }}          
       restartPolicy: Always
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/cloudhealth-collector/values.yaml
+++ b/stable/cloudhealth-collector/values.yaml
@@ -31,10 +31,12 @@ deploymentAnnotations: {}
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -57,3 +59,5 @@ tolerations: []
 affinity: {}
 
 extraLabels: {}
+
+extraEnv: []


### PR DESCRIPTION
## Description

It's nice to have the option to arbitrary environment variables to containers. This PR adds a `list` variable to the cloudhealth-collector chart, which are templated into the deployment.yaml file.

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
