### PR TITLE
[stable/cluster-overprovisioner] Add arbitrary environment variable functionality

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,20 +8,20 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.7.9
+version: 0.7.10
 maintainers:
-- name: max-rocket-internet
-  email: max.williams@deliveryhero.com
-- name: mmingorance-dh
-  email: miguel.mingorance@deliveryhero.com
+  - name: max-rocket-internet
+    email: max.williams@deliveryhero.com
+  - name: mmingorance-dh
+    email: miguel.mingorance@deliveryhero.com
 engine: gotpl
 icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
 keywords:
-- cluster
-- autoscaling
-- overprovision
-- cluster-autoscaler
+  - cluster
+  - autoscaling
+  - overprovision
+  - cluster-autoscaler
 sources:
-- https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler
-- https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-- https://github.com/kubernetes/kubernetes/tree/master/build/pause
+  - https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler
+  - https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
+  - https://github.com/kubernetes/kubernetes/tree/master/build/pause

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.7.9](https://img.shields.io/badge/Version-0.7.9-informational?style=flat-square) ![AppVersion: 3.6](https://img.shields.io/badge/AppVersion-3.6-informational?style=flat-square)
+![Version: 0.7.10](https://img.shields.io/badge/Version-0.7.10-informational?style=flat-square) ![AppVersion: 3.6](https://img.shields.io/badge/AppVersion-3.6-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -50,47 +50,46 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 
 ## Values
 
-| Key                                         | Type   | Default              | Description                                                                                                                                          |
-| ------------------------------------------- | ------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| containerSecurityContext                    | object | `{}`                 | Container security context object                                                                                                                    |
-| deployments                                 | list   | []                   | Define optional additional deployments - A default deployment is included by default                                                                 |
-| deployments[0].affinity                     | object | `{}`                 | Default Deployment - Map of node/pod affinities                                                                                                      |
-| deployments[0].annotations                  | object | `{}`                 | Default Deployment - Annotations to add to the deployment                                                                                            |
-| deployments[0].extraEnv                     | list   | `[]`                 | Default Deployment - Optional environment variables to add to the deployment                                                                         |
-| deployments[0].labels                       | object | `{}`                 | Default Deployment - Optional labels tolerations                                                                                                     |
-| deployments[0].name                         | string | `"default"`          | Default Deployment - Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) |
-| deployments[0].nodeSelector                 | object | `{}`                 | Default Deployment - Node labels for pod assignment                                                                                                  |
-| deployments[0].pdb                          | object | `{}`                 | Default Deployment - Optional PodDisruptionBudget                                                                                                    |
-| deployments[0].podAnnotations               | object | `{}`                 | Default Deployment - Annotations to add to the pods                                                                                                  |
-| deployments[0].replicaCount                 | int    | `3`                  | Default Deployment - Number of replicas                                                                                                              |
-| deployments[0].resources.limits.cpu         | string | `"1000m"`            | Default Deployment - CPU limit for the overprovision pods                                                                                            |
-| deployments[0].resources.limits.memory      | string | `"1000Mi"`           | Default Deployment - Memory limit for the overprovision pods                                                                                         |
-| deployments[0].resources.requests.cpu       | string | `"1000m"`            | Default Deployment - CPU requested for the overprovision pods                                                                                        |
-| deployments[0].resources.requests.memory    | string | `"1000Mi"`           | Default Deployment - Memory requested for the overprovision pods                                                                                     |
-| deployments[0].schedulerName                | string | `""`                 | Default Deployment - Override the scheduler for overprovision pods                                                                                   |
-| deployments[0].tolerations                  | list   | `[]`                 | Default Deployment - Optional deployment tolerations                                                                                                 |
-| deployments[0].topologySpreadConstraints    | list   | `[]`                 | Default Deployment - Optional topology spread constraints                                                                                            |
-| fullnameOverride                            | string | `""`                 | Override the fullname of the chart                                                                                                                   |
-| image.args                                  | list   | `[]`                 | Override container args                                                                                                                              |
-| image.command                               | list   | `[]`                 | Override container command                                                                                                                           |
-| image.pullPolicy                            | string | `"IfNotPresent"`     | Container pull policy                                                                                                                                |
-| image.repository                            | string | `"k8s.gcr.io/pause"` | Image repository                                                                                                                                     |
-| image.tag                                   | string | `.Chart.AppVersion`  | Image tag                                                                                                                                            |
-| nameOverride                                | string | `""`                 | Override the name of the chart                                                                                                                       |
-| podSecurityContext                          | object | `{}`                 | Pod security context object                                                                                                                          |
-| priorityClassDefault.enabled                | bool   | `true`               | If true, enable default priorityClass                                                                                                                |
-| priorityClassDefault.name                   | string | `"default"`          | Name of the default priorityClass                                                                                                                    |
-| priorityClassDefault.value                  | int    | `0`                  | Priority value of the default priorityClass                                                                                                          |
-| priorityClassOverprovision.name             | string | `"overprovisioning"` | Name of the overprovision priorityClass                                                                                                              |
-| priorityClassOverprovision.value            | int    | `-1`                 | Priority value of the overprovision priorityClass                                                                                                    |
-| serviceAccount.annotations                  | object | `{}`                 | Additional Service Account annotations                                                                                                               |
-| serviceAccount.automountServiceAccountToken | bool   | `true`               | Automount API credentials for a Service Account                                                                                                      |
-| serviceAccount.create                       | bool   | `true`               | Determine whether a Service Account should be created or it should reuse an exiting one                                                              |
-| serviceAccount.name                         | string | `nil`                | The name of the ServiceAccount to use. If not set and create is `true`, a name is generated using the fullname template                              |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| containerSecurityContext | object | `{}` | Container security context object |
+| deployments | list | [] | Define optional additional deployments - A default deployment is included by default |
+| deployments[0].affinity | object | `{}` | Default Deployment - Map of node/pod affinities |
+| deployments[0].annotations | object | `{}` | Default Deployment - Annotations to add to the deployment |
+| deployments[0].labels | object | `{}` | Default Deployment - Optional labels tolerations |
+| deployments[0].name | string | `"default"` | Default Deployment - Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) |
+| deployments[0].nodeSelector | object | `{}` | Default Deployment - Node labels for pod assignment |
+| deployments[0].pdb | object | `{}` | Default Deployment - Optional PodDisruptionBudget |
+| deployments[0].podAnnotations | object | `{}` | Default Deployment - Annotations to add to the pods |
+| deployments[0].replicaCount | int | `3` | Default Deployment - Number of replicas |
+| deployments[0].resources.limits.cpu | string | `"1000m"` | Default Deployment - CPU limit for the overprovision pods |
+| deployments[0].resources.limits.memory | string | `"1000Mi"` | Default Deployment - Memory limit for the overprovision pods |
+| deployments[0].resources.requests.cpu | string | `"1000m"` | Default Deployment - CPU requested for the overprovision pods |
+| deployments[0].resources.requests.memory | string | `"1000Mi"` | Default Deployment - Memory requested for the overprovision pods |
+| deployments[0].schedulerName | string | `""` | Default Deployment - Override the scheduler for overprovision pods |
+| deployments[0].tolerations | list | `[]` | Default Deployment - Optional deployment tolerations |
+| deployments[0].topologySpreadConstraints | list | `[]` | Default Deployment - Optional topology spread constraints |
+| fullnameOverride | string | `""` | Override the fullname of the chart |
+| image.args | list | `[]` | Override container args |
+| image.command | list | `[]` | Override container command |
+| image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| image.repository | string | `"k8s.gcr.io/pause"` | Image repository |
+| image.tag | string | `.Chart.AppVersion` | Image tag |
+| nameOverride | string | `""` | Override the name of the chart |
+| podSecurityContext | object | `{}` | Pod security context object |
+| priorityClassDefault.enabled | bool | `true` | If true, enable default priorityClass |
+| priorityClassDefault.name | string | `"default"` | Name of the default priorityClass |
+| priorityClassDefault.value | int | `0` | Priority value of the default priorityClass |
+| priorityClassOverprovision.name | string | `"overprovisioning"` | Name of the overprovision priorityClass |
+| priorityClassOverprovision.value | int | `-1` | Priority value of the overprovision priorityClass |
+| serviceAccount.annotations | object | `{}` | Additional Service Account annotations |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for a Service Account |
+| serviceAccount.create | bool | `true` | Determine whether a Service Account should be created or it should reuse an exiting one |
+| serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is `true`, a name is generated using the fullname template |
 
 ## Maintainers
 
-| Name                | Email                                | Url |
-| ------------------- | ------------------------------------ | --- |
-| max-rocket-internet | <max.williams@deliveryhero.com>      |     |
-| mmingorance-dh      | <miguel.mingorance@deliveryhero.com> |     |
+| Name | Email | Url |
+| ---- | ------ | --- |
+| max-rocket-internet | <max.williams@deliveryhero.com> |  |
+| mmingorance-dh | <miguel.mingorance@deliveryhero.com> |  |

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -50,46 +50,47 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| containerSecurityContext | object | `{}` | Container security context object |
-| deployments | list | [] | Define optional additional deployments - A default deployment is included by default |
-| deployments[0].affinity | object | `{}` | Default Deployment - Map of node/pod affinities |
-| deployments[0].annotations | object | `{}` | Default Deployment - Annotations to add to the deployment |
-| deployments[0].labels | object | `{}` | Default Deployment - Optional labels tolerations |
-| deployments[0].name | string | `"default"` | Default Deployment - Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) |
-| deployments[0].nodeSelector | object | `{}` | Default Deployment - Node labels for pod assignment |
-| deployments[0].pdb | object | `{}` | Default Deployment - Optional PodDisruptionBudget |
-| deployments[0].podAnnotations | object | `{}` | Default Deployment - Annotations to add to the pods |
-| deployments[0].replicaCount | int | `3` | Default Deployment - Number of replicas |
-| deployments[0].resources.limits.cpu | string | `"1000m"` | Default Deployment - CPU limit for the overprovision pods |
-| deployments[0].resources.limits.memory | string | `"1000Mi"` | Default Deployment - Memory limit for the overprovision pods |
-| deployments[0].resources.requests.cpu | string | `"1000m"` | Default Deployment - CPU requested for the overprovision pods |
-| deployments[0].resources.requests.memory | string | `"1000Mi"` | Default Deployment - Memory requested for the overprovision pods |
-| deployments[0].schedulerName | string | `""` | Default Deployment - Override the scheduler for overprovision pods |
-| deployments[0].tolerations | list | `[]` | Default Deployment - Optional deployment tolerations |
-| deployments[0].topologySpreadConstraints | list | `[]` | Default Deployment - Optional topology spread constraints |
-| fullnameOverride | string | `""` | Override the fullname of the chart |
-| image.args | list | `[]` | Override container args |
-| image.command | list | `[]` | Override container command |
-| image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
-| image.repository | string | `"k8s.gcr.io/pause"` | Image repository |
-| image.tag | string | `.Chart.AppVersion` | Image tag |
-| nameOverride | string | `""` | Override the name of the chart |
-| podSecurityContext | object | `{}` | Pod security context object |
-| priorityClassDefault.enabled | bool | `true` | If true, enable default priorityClass |
-| priorityClassDefault.name | string | `"default"` | Name of the default priorityClass |
-| priorityClassDefault.value | int | `0` | Priority value of the default priorityClass |
-| priorityClassOverprovision.name | string | `"overprovisioning"` | Name of the overprovision priorityClass |
-| priorityClassOverprovision.value | int | `-1` | Priority value of the overprovision priorityClass |
-| serviceAccount.annotations | object | `{}` | Additional Service Account annotations |
-| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for a Service Account |
-| serviceAccount.create | bool | `true` | Determine whether a Service Account should be created or it should reuse an exiting one |
-| serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is `true`, a name is generated using the fullname template |
+| Key                                         | Type   | Default              | Description                                                                                                                                          |
+| ------------------------------------------- | ------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| containerSecurityContext                    | object | `{}`                 | Container security context object                                                                                                                    |
+| deployments                                 | list   | []                   | Define optional additional deployments - A default deployment is included by default                                                                 |
+| deployments[0].affinity                     | object | `{}`                 | Default Deployment - Map of node/pod affinities                                                                                                      |
+| deployments[0].annotations                  | object | `{}`                 | Default Deployment - Annotations to add to the deployment                                                                                            |
+| deployments[0].extraEnv                     | list   | `[]`                 | Default Deployment - Optional environment variables to add to the deployment                                                                         |
+| deployments[0].labels                       | object | `{}`                 | Default Deployment - Optional labels tolerations                                                                                                     |
+| deployments[0].name                         | string | `"default"`          | Default Deployment - Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) |
+| deployments[0].nodeSelector                 | object | `{}`                 | Default Deployment - Node labels for pod assignment                                                                                                  |
+| deployments[0].pdb                          | object | `{}`                 | Default Deployment - Optional PodDisruptionBudget                                                                                                    |
+| deployments[0].podAnnotations               | object | `{}`                 | Default Deployment - Annotations to add to the pods                                                                                                  |
+| deployments[0].replicaCount                 | int    | `3`                  | Default Deployment - Number of replicas                                                                                                              |
+| deployments[0].resources.limits.cpu         | string | `"1000m"`            | Default Deployment - CPU limit for the overprovision pods                                                                                            |
+| deployments[0].resources.limits.memory      | string | `"1000Mi"`           | Default Deployment - Memory limit for the overprovision pods                                                                                         |
+| deployments[0].resources.requests.cpu       | string | `"1000m"`            | Default Deployment - CPU requested for the overprovision pods                                                                                        |
+| deployments[0].resources.requests.memory    | string | `"1000Mi"`           | Default Deployment - Memory requested for the overprovision pods                                                                                     |
+| deployments[0].schedulerName                | string | `""`                 | Default Deployment - Override the scheduler for overprovision pods                                                                                   |
+| deployments[0].tolerations                  | list   | `[]`                 | Default Deployment - Optional deployment tolerations                                                                                                 |
+| deployments[0].topologySpreadConstraints    | list   | `[]`                 | Default Deployment - Optional topology spread constraints                                                                                            |
+| fullnameOverride                            | string | `""`                 | Override the fullname of the chart                                                                                                                   |
+| image.args                                  | list   | `[]`                 | Override container args                                                                                                                              |
+| image.command                               | list   | `[]`                 | Override container command                                                                                                                           |
+| image.pullPolicy                            | string | `"IfNotPresent"`     | Container pull policy                                                                                                                                |
+| image.repository                            | string | `"k8s.gcr.io/pause"` | Image repository                                                                                                                                     |
+| image.tag                                   | string | `.Chart.AppVersion`  | Image tag                                                                                                                                            |
+| nameOverride                                | string | `""`                 | Override the name of the chart                                                                                                                       |
+| podSecurityContext                          | object | `{}`                 | Pod security context object                                                                                                                          |
+| priorityClassDefault.enabled                | bool   | `true`               | If true, enable default priorityClass                                                                                                                |
+| priorityClassDefault.name                   | string | `"default"`          | Name of the default priorityClass                                                                                                                    |
+| priorityClassDefault.value                  | int    | `0`                  | Priority value of the default priorityClass                                                                                                          |
+| priorityClassOverprovision.name             | string | `"overprovisioning"` | Name of the overprovision priorityClass                                                                                                              |
+| priorityClassOverprovision.value            | int    | `-1`                 | Priority value of the overprovision priorityClass                                                                                                    |
+| serviceAccount.annotations                  | object | `{}`                 | Additional Service Account annotations                                                                                                               |
+| serviceAccount.automountServiceAccountToken | bool   | `true`               | Automount API credentials for a Service Account                                                                                                      |
+| serviceAccount.create                       | bool   | `true`               | Determine whether a Service Account should be created or it should reuse an exiting one                                                              |
+| serviceAccount.name                         | string | `nil`                | The name of the ServiceAccount to use. If not set and create is `true`, a name is generated using the fullname template                              |
 
 ## Maintainers
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| max-rocket-internet | <max.williams@deliveryhero.com> |  |
-| mmingorance-dh | <miguel.mingorance@deliveryhero.com> |  |
+| Name                | Email                                | Url |
+| ------------------- | ------------------------------------ | --- |
+| max-rocket-internet | <max.williams@deliveryhero.com>      |     |
+| mmingorance-dh      | <miguel.mingorance@deliveryhero.com> |     |

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -73,6 +73,10 @@ spec:
           {{- with $imageArgs }}
           args: {{ $imageArgs }}
           {{- end }}
+          {{- with .extraEnv }}
+          env:
+            {{toYaml . | nindent 12 }}
+          {{- end }}   
     {{- if $imagePullSecrets }}
       imagePullSecrets:
       {{- range $imagePullSecrets }}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -1,11 +1,11 @@
 # containerSecurityContext -- Container security context object
 containerSecurityContext: {}
-  # allowPrivilegeEscalation: false
+# allowPrivilegeEscalation: false
 
 # podSecurityContext -- Pod security context object
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
-
 
 priorityClassOverprovision:
   # priorityClassOverprovision.name -- Name of the overprovision priorityClass
@@ -54,8 +54,9 @@ deployments:
   # deployments[0].name -- Default Deployment - Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules)
   - name: default
     # deployments[0].annotations -- Default Deployment - Annotations to add to the deployment
-    annotations: {}
-     # deployments[0].podAnnotations -- Default Deployment - Annotations to add to the pods
+    annotations:
+      {}
+      # deployments[0].podAnnotations -- Default Deployment - Annotations to add to the pods
     podAnnotations: {}
     # deployments[0].replicaCount -- Default Deployment - Number of replicas
     replicaCount: 3
@@ -79,7 +80,8 @@ deployments:
     # deployments[0].labels -- Default Deployment - Optional labels tolerations
     labels: {}
     # deployments[0].topologySpreadConstraints -- Default Deployment - Optional topology spread constraints
-    topologySpreadConstraints: []
+    topologySpreadConstraints:
+      []
       # - maxSkew: 1
       #   topologyKey: failure-domain.beta.kubernetes.io/zone
       #   whenUnsatisfiable: DoNotSchedule
@@ -90,6 +92,7 @@ deployments:
     pdb: {}
     # deployments[0].schedulerName -- Default Deployment - Override the scheduler for overprovision pods
     schedulerName: ""
+    extraEnv: []
 
 serviceAccount:
   # serviceAccount.create -- Determine whether a Service Account should be created or it should reuse an exiting one


### PR DESCRIPTION
## Description

It's nice to have the option to arbitrary environment variables to containers. This PR adds a list variable to the cluster-overprovisioner chart, which is templated into the deployment.yaml file.

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
