### PR TITLE
[stable/chachet] remove DB_DRIVER duplication in configmap

### DIFF
--- a/stable/cachet/Chart.yaml
+++ b/stable/cachet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.3.15"
 description: The open source status page system
 name: cachet
-version: 1.3.1
+version: 1.3.2
 home: https://cachethq.io/
 sources:
   - https://github.com/CachetHQ/Docker

--- a/stable/cachet/README.md
+++ b/stable/cachet/README.md
@@ -67,7 +67,6 @@ helm install my-release deliveryhero/cachet -f values.yaml
 | env.public.CACHET_BEACON | bool | `false` |  |
 | env.public.CACHET_EMOJI | bool | `false` |  |
 | env.public.CACHE_DRIVER | string | `"database"` |  |
-| env.public.DB_DRIVER | string | `"pgsql"` |  |
 | env.public.DOCKER | bool | `true` |  |
 | env.public.MAIL_ADDRESS | string | `""` |  |
 | env.public.MAIL_DRIVER | string | `"smtp"` |  |

--- a/stable/cachet/values.yaml
+++ b/stable/cachet/values.yaml
@@ -53,7 +53,6 @@ env:
     # Application environments
     APP_DEBUG: false
     APP_LOG: errorlog
-    DB_DRIVER: pgsql
     DOCKER: true
     CACHE_DRIVER: database
     SESSION_DRIVER: database


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->
Since the variable is already defined at `database.driver` it causes duplication error in the configmap

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
