### PR TITLE
[stable/cloudhealth-collector] Use correct `secretKeyRef.key` for API Token secret

### DIFF
--- a/stable/cloudhealth-collector/templates/secret.yaml
+++ b/stable/cloudhealth-collector/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "cloudhealth-collector.labels" . | nindent 4 }}
 type: Opaque
 data:
-  api_token: {{ .Values.api_token | b64enc | quote }}
+  api_key: {{ .Values.api_token | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

* If a user installs this chart and sets the [`api_token` value](https://github.com/deliveryhero/helm-charts/blob/master/stable/cloudhealth-collector/values.yaml#L1), the cloudhealth-colllector pod will fail to start due to the deployment config using the wrong secret key: 
* https://github.com/deliveryhero/helm-charts/blob/master/stable/cloudhealth-collector/templates/deployment.yaml#L50
* https://github.com/deliveryhero/helm-charts/blob/master/stable/cloudhealth-collector/templates/secret.yaml#L10

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
