### PR TITLE
node-problem-detector: Populate default Prometheus labels when metrics are enabled

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.2.6"
+version: "2.3.0"
 appVersion: v0.8.12
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.2.6](https://img.shields.io/badge/Version-2.2.6-informational?style=flat-square) ![AppVersion: v0.8.12](https://img.shields.io/badge/AppVersion-v0.8.12-informational?style=flat-square)
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![AppVersion: v0.8.12](https://img.shields.io/badge/AppVersion-v0.8.12-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -64,8 +64,8 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |
 | logDir.pod | string | `""` | log directory in pod (volume mount), use logDir.host if empty |
 | maxUnavailable | int | `1` | The max pods unavailable during an update |
-| metrics.annotations | object | `{}` |  |
-| metrics.enabled | bool | `false` |  |
+| metrics.annotations | object | `{}` | Override all default annotations when `metrics.enabled=true` with specified values. |
+| metrics.enabled | bool | `false` | Expose metrics in Prometheus format with default configuration. |
 | metrics.prometheusRule.additionalLabels | object | `{}` |  |
 | metrics.prometheusRule.additionalRules | list | `[]` |  |
 | metrics.prometheusRule.defaultRules.create | bool | `true` |  |

--- a/stable/node-problem-detector/templates/service.yaml
+++ b/stable/node-problem-detector/templates/service.yaml
@@ -9,9 +9,14 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app: {{ include "node-problem-detector.name" . }}
-  {{- if .Values.metrics.annotations }}
   annotations:
+  {{- if .Values.metrics.annotations }}
     {{- toYaml .Values.metrics.annotations | nindent 4 }}
+  {{- else }}
+    prometheus.io/scrape: "true"
+    prometheus.io/scheme: http
+    prometheus.io/port: "{{ .Values.settings.prometheus_port }}"
+    prometheus.io/path: /metrics
   {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -101,7 +101,9 @@ affinity: {}
 nodeSelector: {}
 
 metrics:
+  # metrics.enabled -- Expose metrics in Prometheus format with default configuration.
   enabled: false
+  # metrics.annotations -- Override all default annotations when `metrics.enabled=true` with specified values.
   annotations: {}
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

In chart `node-problem-detector` exposing metrics in Prometheus format can be enabled with `metrics.enabled=true`. It creates a K8s Service that exposes metrics on the below endpoint
```sh
node-problem-detector:20257/metrics
```
but does not attach required annotations to the Service. To install and enable scrapping variable `metrics.annotations` has to be used so installation is needlessly verbose.
```sh
helm install node-problem-detector deliveryhero/node-problem-detector -n node-problem-detector --create-namespace \
--set metrics.enabled=true \
--set-string 'metrics.annotations.prometheus\.io/scrape=true' --set-string 'metrics.annotations.prometheus\.io/scheme=http'  --set-string 'metrics.annotations.prometheus\.io/port=20257' --set-string 'metrics.annotations.prometheus\.io/path=/metrics'
```
My change populates default annotations when `metrics.enabled=true`
```yml
...
  annotations:
    prometheus.io/scrape: "true"
    prometheus.io/scheme: HTTP
    prometheus.io/port: "20257"
    prometheus.io/path: /metrics
...
```
 so metrics will be scrapped automatically. In the case of using `metrics.annotations` directly, annotations introduced in this PR aren't added. So this change doesn't introduce any breaking change, everything that used to work still works.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
