### PR TITLE
[stable/cachet] Add support of securityContext in cachet Deployment

### DIFF
--- a/stable/cachet/Chart.yaml
+++ b/stable/cachet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.3.15"
 description: The open source status page system
 name: cachet
-version: 1.3.1
+version: 1.3.2
 home: https://cachethq.io/
 sources:
   - https://github.com/CachetHQ/Docker

--- a/stable/cachet/README.md
+++ b/stable/cachet/README.md
@@ -1,6 +1,6 @@
 # cachet
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![AppVersion: 2.3.15](https://img.shields.io/badge/AppVersion-2.3.15-informational?style=flat-square)
+![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![AppVersion: 2.3.15](https://img.shields.io/badge/AppVersion-2.3.15-informational?style=flat-square)
 
 The open source status page system
 
@@ -90,11 +90,13 @@ helm install my-release deliveryhero/cachet -f values.yaml
 | ingress.path | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
+| podSecurityContext | list | `[]` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | string | `"100m"` |  |
 | resources.limits.memory | string | `"128Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |
+| securityContext | list | `[]` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
 | test.enabled | bool | `true` |  |

--- a/stable/cachet/templates/deployment.yaml
+++ b/stable/cachet/templates/deployment.yaml
@@ -49,3 +49,11 @@ spec:
                 name: {{ include "cachet.fullname" . }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}

--- a/stable/cachet/values.yaml
+++ b/stable/cachet/values.yaml
@@ -39,6 +39,17 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+podSecurityContext: []
+  # seccompProfile: RuntimeDefault
+
+securityContext: []
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: false
+  # runAsUser: 12345
+
 # creates cachet database via posgres-controller
 database:
   host: cachet-db.example.com


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

Adding values for podSecurityContext and securityContext for cachet Deployment

## Checklist

- [x ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
