### PR TITLE
[stable/cloudhealth-collector]: added extraVolumes + extraVolumeMounts options

### DIFF
--- a/stable/cloudhealth-collector/Chart.yaml
+++ b/stable/cloudhealth-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "957"
 name: cloudhealth-collector
-version: 0.1.5
+version: 0.1.6
 description: |
   Deploys a k8s pod to collect data and generate reports based or resources usages, costs and other possibilities. Please check more about it on: https://www.cloudhealthtech.com/solutions/containers
 

--- a/stable/cloudhealth-collector/README.md
+++ b/stable/cloudhealth-collector/README.md
@@ -60,6 +60,8 @@ helm install my-release deliveryhero/cloudhealth-collector -f values.yaml
 | existingSecret.tokenKey | string | `""` |  |
 | extraEnv | list | `[]` |  |
 | extraLabels | object | `{}` |  |
+| extraVolumes | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"cloudhealth/container-collector"` |  |

--- a/stable/cloudhealth-collector/README.md
+++ b/stable/cloudhealth-collector/README.md
@@ -1,6 +1,6 @@
 # cloudhealth-collector
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: 957](https://img.shields.io/badge/AppVersion-957-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![AppVersion: 957](https://img.shields.io/badge/AppVersion-957-informational?style=flat-square)
 
 Deploys a k8s pod to collect data and generate reports based or resources usages, costs and other possibilities. Please check more about it on: https://www.cloudhealthtech.com/solutions/containers
 
@@ -60,8 +60,8 @@ helm install my-release deliveryhero/cloudhealth-collector -f values.yaml
 | existingSecret.tokenKey | string | `""` |  |
 | extraEnv | list | `[]` |  |
 | extraLabels | object | `{}` |  |
-| extraVolumes | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"cloudhealth/container-collector"` |  |

--- a/stable/cloudhealth-collector/templates/deployment.yaml
+++ b/stable/cloudhealth-collector/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         args: ["upload_k8s_state", "--verbose"]
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.extraVolumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         env:
@@ -58,6 +62,10 @@ spec:
           {{toYaml . | nindent 8 }}
         {{- end }}          
       restartPolicy: Always
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/cloudhealth-collector/values.yaml
+++ b/stable/cloudhealth-collector/values.yaml
@@ -61,3 +61,7 @@ affinity: {}
 extraLabels: {}
 
 extraEnv: []
+
+extraVolumes: []
+
+extraVolumeMounts: []


### PR DESCRIPTION
## Description
I wanted to pass an `api-token` secret from the aws secrets provider. It requires that I mount the volume with the secret, but unfortunately `cloudhealth-collector` doesn't support `extraVolumes` and `extraVolumeMounts`. That's why I decided to add this functionality. 

P.S. IMHO I think it would be very helpful to have it on every other helm chart as well :)


## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
