### PR TITLE
[stable/killgrave] A helm chart to deploy an http mock server

### DIFF
--- a/stable/killgrave/.helmignore
+++ b/stable/killgrave/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/killgrave/Chart.yaml
+++ b/stable/killgrave/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: killgrave
+icon: https://avatars.githubusercontent.com/u/36798605?v=4&s=160
+
+type: application
+version: 1.0.0
+appVersion: 1.0.0
+maintainers:
+  - name: Marcelo Aplanalp
+    email: marcelo.aplanalp@deliveryhero.com
+description: |
+  A chart to install [killgrave](https://github.com/friendsofgo/killgrave), a simulator for HTTP-based APIs.
+
+  In its more basic setup, this chart requires a `configmap` including all _imposters_ (the definition of a request-response pair)

--- a/stable/killgrave/Chart.yaml
+++ b/stable/killgrave/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 version: 1.0.0
 appVersion: 1.0.0
 maintainers:
-  - name: Marcelo Aplanalp
+  - name: MarceloAplanalp
     email: marcelo.aplanalp@deliveryhero.com
 description: |
   A chart to install [killgrave](https://github.com/friendsofgo/killgrave), a simulator for HTTP-based APIs.

--- a/stable/killgrave/Chart.yaml
+++ b/stable/killgrave/Chart.yaml
@@ -4,7 +4,7 @@ icon: https://avatars.githubusercontent.com/u/36798605?v=4&s=160
 
 type: application
 version: 1.0.0
-appVersion: 1.0.0
+appVersion: 0.4.1
 maintainers:
   - name: MarceloAplanalp
     email: marcelo.aplanalp@deliveryhero.com

--- a/stable/killgrave/README.md
+++ b/stable/killgrave/README.md
@@ -1,0 +1,78 @@
+# killgrave
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+
+A chart to install [killgrave](https://github.com/friendsofgo/killgrave), a simulator for HTTP-based APIs.
+
+In its more basic setup, this chart requires a `configmap` including all _imposters_ (the definition of a request-response pair)
+
+## How to install this chart
+
+Add Delivery Hero public chart repo:
+
+```console
+helm repo add deliveryhero https://charts.deliveryhero.io/
+```
+
+A simple install with default values:
+
+```console
+helm install deliveryhero/killgrave
+```
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release deliveryhero/killgrave
+```
+
+To install with some set values:
+
+```console
+helm install my-release deliveryhero/killgrave --set values_key1=value1 --set values_key2=value2
+```
+
+To install with custom values file:
+
+```console
+helm install my-release deliveryhero/killgrave -f values.yaml
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| hpa.enabled | bool | `false` |  |
+| hpa.maxReplicas | int | `100` |  |
+| hpa.minReplicas | int | `1` |  |
+| hpa.targetCPUUtilizationPercentage | int | `80` |  |
+| hpa.targetMemoryUtilizationPercentage | bool | `false` | Set it to false in case you don't want to scale by memory consumption |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts | list | `[]` |  |
+| ingress.tls | list | `[]` |  |
+| labels | object | `{}` | Any extra label to apply to all resources |
+| mock.imposters.configmap | string | `"imposters"` | The name of the configmap containing all your imposters |
+| mock.imposters.path | string | `"/imposters"` | The mounting path for your imposters folder |
+| mock.killgrave.secure | bool | `false` | If killgrave server must be configured to run using TSL |
+| mock.killgrave.tag | string | `"latest"` | The image tag to use |
+| mock.schemas.configmap | string | `"http_mock_schemas"` | The name of the configmap containing your schemas folder. |
+| mock.schemas.path | string | `"/schemas"` | The mounting path for your schemas folder |
+| nameOverride | string | `""` | Set it in case you want to override the name of the deployment. By default it is set to `.Chart.Name` |
+| nodeSelector | object | `{}` |  |
+| replicaCount | int | `1` | Set the number of replicas in case hpa is not enabled |
+| resources.limits.cpu | string | `"512m"` |  |
+| resources.limits.memory | string | `"512Mi"` |  |
+| resources.requests.cpu | string | `"512m"` |  |
+| resources.requests.memory | string | `"256Mi"` |  |
+| service.targetPort | int | `8080` |  |
+| service.type | string | `"NodePort"` |  |
+| tolerations | list | `[]` |  |
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Marcelo Aplanalp | <marcelo.aplanalp@deliveryhero.com> |  |

--- a/stable/killgrave/README.md
+++ b/stable/killgrave/README.md
@@ -1,6 +1,6 @@
 # killgrave
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1](https://img.shields.io/badge/AppVersion-0.4.1-informational?style=flat-square)
 
 A chart to install [killgrave](https://github.com/friendsofgo/killgrave), a simulator for HTTP-based APIs.
 
@@ -57,7 +57,7 @@ helm install my-release deliveryhero/killgrave -f values.yaml
 | mock.imposters.configmap | string | `"example-imposters"` | The name of the configmap containing all your imposters |
 | mock.imposters.path | string | `"/imposters"` | The mounting path for your imposters folder |
 | mock.killgrave.secure | bool | `false` | If killgrave server must be configured to run using TSL |
-| mock.killgrave.tag | string | `"latest"` | The image tag to use |
+| mock.killgrave.tag | string | `"0.4.1"` | The image tag to use |
 | mock.schemas.configmap | string | `"example-schemas"` | The name of the configmap containing your schemas' folder. |
 | mock.schemas.path | string | `"/schemas"` | The mounting path for your schemas folder |
 | nameOverride | string | `""` | Set it in case you want to override the name of the deployment. By default it is set to `.Chart.Name` |

--- a/stable/killgrave/README.md
+++ b/stable/killgrave/README.md
@@ -63,10 +63,7 @@ helm install my-release deliveryhero/killgrave -f values.yaml
 | nameOverride | string | `""` | Set it in case you want to override the name of the deployment. By default it is set to `.Chart.Name` |
 | nodeSelector | object | `{}` |  |
 | replicaCount | int | `1` | Set the number of replicas in case hpa is not enabled |
-| resources.limits.cpu | string | `"512m"` |  |
-| resources.limits.memory | string | `"512Mi"` |  |
-| resources.requests.cpu | string | `"512m"` |  |
-| resources.requests.memory | string | `"256Mi"` |  |
+| resources | object | `{}` |  |
 | service.targetPort | int | `8080` |  |
 | service.type | string | `"NodePort"` |  |
 | tolerations | list | `[]` |  |
@@ -75,4 +72,4 @@ helm install my-release deliveryhero/killgrave -f values.yaml
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| Marcelo Aplanalp | <marcelo.aplanalp@deliveryhero.com> |  |
+| MarceloAplanalp | <marcelo.aplanalp@deliveryhero.com> |  |

--- a/stable/killgrave/README.md
+++ b/stable/killgrave/README.md
@@ -54,11 +54,11 @@ helm install my-release deliveryhero/killgrave -f values.yaml
 | ingress.hosts | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
 | labels | object | `{}` | Any extra label to apply to all resources |
-| mock.imposters.configmap | string | `"imposters"` | The name of the configmap containing all your imposters |
+| mock.imposters.configmap | string | `"example-imposters"` | The name of the configmap containing all your imposters |
 | mock.imposters.path | string | `"/imposters"` | The mounting path for your imposters folder |
 | mock.killgrave.secure | bool | `false` | If killgrave server must be configured to run using TSL |
 | mock.killgrave.tag | string | `"latest"` | The image tag to use |
-| mock.schemas.configmap | string | `"http_mock_schemas"` | The name of the configmap containing your schemas folder. |
+| mock.schemas.configmap | string | `"example-schemas"` | The name of the configmap containing your schemas' folder. |
 | mock.schemas.path | string | `"/schemas"` | The mounting path for your schemas folder |
 | nameOverride | string | `""` | Set it in case you want to override the name of the deployment. By default it is set to `.Chart.Name` |
 | nodeSelector | object | `{}` |  |

--- a/stable/killgrave/example/imposters/example.imp.json
+++ b/stable/killgrave/example/imposters/example.imp.json
@@ -1,0 +1,16 @@
+[
+  {
+    "request": {
+      "endpoint": "/ping",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "Content-Type": "text/plain"
+      },
+      "body": "pong",
+      "delay": "1ms"
+    }
+  }
+]

--- a/stable/killgrave/templates/NOTES.txt
+++ b/stable/killgrave/templates/NOTES.txt
@@ -6,16 +6,16 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "http_mock.name" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "killgrave.name" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "http_mock.name" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "http_mock.name" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "killgrave.name" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "killgrave.name" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:8080
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "http_mock.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "killgrave.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/stable/killgrave/templates/NOTES.txt
+++ b/stable/killgrave/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "http_mock.name" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "http_mock.name" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "http_mock.name" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:8080
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "http_mock.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/stable/killgrave/templates/_helpers.tpl
+++ b/stable/killgrave/templates/_helpers.tpl
@@ -37,6 +37,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Killgrave image */}}
 {{- define "killgrave.image" -}}
-{{- $tag := .Values.mock.killgrave.tag | default "latest" }}
+{{- $tag := .Values.mock.killgrave.tag | default "0.4.1" }}
 {{- printf "friendsofgo/killgrave:%s" $tag }}
 {{- end }}

--- a/stable/killgrave/templates/_helpers.tpl
+++ b/stable/killgrave/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/* Expand the name of the chart. */}}
+{{- define "http_mock.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "http_mock.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels */}}
+{{- define "http_mock.labels" -}}
+helm.sh/chart: {{ include "http_mock.chart" . }}
+{{ include "http_mock.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{- range $key, $value := .Values.labels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+{{/* Selector labels */}}
+{{- define "http_mock.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "http_mock.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Imposters mounting path */}}
+{{- define "http_mock.imposters_mouniting_path" -}}
+{{- printf .Values.mock.imposters.path | default "/imposters" }}
+{{- end }}
+
+{{/* Killgrave image */}}
+{{- define "http_mock.image" -}}
+{{- $tag := .Values.mock.killgrave.tag | default "latest" }}
+{{- printf "friendsofgo/killgrave:%s" $tag }}
+{{- end }}

--- a/stable/killgrave/templates/_helpers.tpl
+++ b/stable/killgrave/templates/_helpers.tpl
@@ -1,17 +1,17 @@
 {{/* Expand the name of the chart. */}}
-{{- define "http_mock.name" -}}
+{{- define "killgrave.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/* Create chart name and version as used by the chart label. */}}
-{{- define "http_mock.chart" -}}
+{{- define "killgrave.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/* Common labels */}}
-{{- define "http_mock.labels" -}}
-helm.sh/chart: {{ include "http_mock.chart" . }}
-{{ include "http_mock.selectorLabels" . }}
+{{- define "killgrave.labels" -}}
+helm.sh/chart: {{ include "killgrave.chart" . }}
+{{ include "killgrave.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -25,18 +25,18 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 
 {{/* Selector labels */}}
-{{- define "http_mock.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "http_mock.name" . }}
+{{- define "killgrave.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "killgrave.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/* Imposters mounting path */}}
-{{- define "http_mock.imposters_mouniting_path" -}}
+{{- define "killgrave.imposters_mouniting_path" -}}
 {{- printf .Values.mock.imposters.path | default "/imposters" }}
 {{- end }}
 
 {{/* Killgrave image */}}
-{{- define "http_mock.image" -}}
+{{- define "killgrave.image" -}}
 {{- $tag := .Values.mock.killgrave.tag | default "latest" }}
 {{- printf "friendsofgo/killgrave:%s" $tag }}
 {{- end }}

--- a/stable/killgrave/templates/configmap-imposters.yaml
+++ b/stable/killgrave/templates/configmap-imposters.yaml
@@ -1,0 +1,10 @@
+{{- if eq .Values.mock.imposters.configmap "example-imposters" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.mock.imposters.configmap }}
+  labels:
+{{ include "killgrave.labels" . | indent 4 }}
+data:
+{{ ($.Files.Glob "example/imposters/*").AsConfig | indent 2 }}
+{{- end }}

--- a/stable/killgrave/templates/configmap-schemas.yaml
+++ b/stable/killgrave/templates/configmap-schemas.yaml
@@ -1,0 +1,10 @@
+{{- if eq .Values.mock.schemas.configmap "example-schemas" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.mock.schemas.configmap }}
+  labels:
+{{ include "killgrave.labels" . | indent 4 }}
+data:
+{{ ($.Files.Glob "example/schemas/*").AsConfig | indent 2 }}
+{{- end }}

--- a/stable/killgrave/templates/deployment.yaml
+++ b/stable/killgrave/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "http_mock.name" . }}
+  labels:
+    {{- include "http_mock.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.hpa.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "http_mock.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "http_mock.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "http_mock.image" . }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: {{ include "http_mock.imposters_mouniting_path" . }}
+              name: imposters
+            {{- if .Values.mock.schemas }}
+            {{- if .Values.mock.schemas.configmap }}
+            - mountPath: {{ .Values.mock.schemas.path | default "/schemas" | quote }}
+              name: schemas
+            {{- end }}
+            {{- end }}
+          args:
+            - -host=0.0.0.0
+            - -imposters={{ include "http_mock.imposters_mouniting_path" . }}
+            - -secure={{ .Values.mock.killgrave.secure }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: imposters
+          configMap:
+            name: {{ .Values.mock.imposters.configmap }}
+        {{- if .Values.mock.schemas }}
+        {{- if .Values.mock.schemas.configmap }}
+        - name: schemas
+          configMap:
+            name: {{ .Values.mock.schemas.configmap }}
+        {{- end }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/stable/killgrave/templates/deployment.yaml
+++ b/stable/killgrave/templates/deployment.yaml
@@ -1,27 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "http_mock.name" . }}
+  name: {{ include "killgrave.name" . }}
   labels:
-    {{- include "http_mock.labels" . | nindent 4 }}
+    {{- include "killgrave.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.hpa.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "http_mock.selectorLabels" . | nindent 6 }}
+      {{- include "killgrave.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "http_mock.labels" . | nindent 8 }}
+        {{- include "killgrave.labels" . | nindent 8 }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ include "http_mock.image" . }}
+          image: {{ include "killgrave.image" . }}
           imagePullPolicy: IfNotPresent
           volumeMounts:
-            - mountPath: {{ include "http_mock.imposters_mouniting_path" . }}
+            - mountPath: {{ include "killgrave.imposters_mouniting_path" . }}
               name: imposters
             {{- if .Values.mock.schemas }}
             {{- if .Values.mock.schemas.configmap }}
@@ -31,7 +31,7 @@ spec:
             {{- end }}
           args:
             - -host=0.0.0.0
-            - -imposters={{ include "http_mock.imposters_mouniting_path" . }}
+            - -imposters={{ include "killgrave.imposters_mouniting_path" . }}
             - -secure={{ .Values.mock.killgrave.secure }}
           ports:
             - name: http

--- a/stable/killgrave/templates/hpa.yaml
+++ b/stable/killgrave/templates/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "http_mock.name" . }}
+  name: {{ include "killgrave.name" . }}
   labels:
-    {{- include "http_mock.labels" . | nindent 4 }}
+    {{- include "killgrave.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "http_mock.name" . }}
+    name: {{ include "killgrave.name" . }}
   minReplicas: {{ .Values.hpa.minReplicas | default 1 }}
   maxReplicas: {{ .Values.hpa.maxReplicas | default 100 }}
   metrics:

--- a/stable/killgrave/templates/hpa.yaml
+++ b/stable/killgrave/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "http_mock.name" . }}
+  labels:
+    {{- include "http_mock.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "http_mock.name" . }}
+  minReplicas: {{ .Values.hpa.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.hpa.maxReplicas | default 100 }}
+  metrics:
+    {{- if ne .Values.hpa.targetCPUUtilizationPercentage false }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage | default 80 }}
+    {{- end }}
+    {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/stable/killgrave/templates/ingress.yaml
+++ b/stable/killgrave/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "http_mock.name" . -}}
+{{- $fullName := include "killgrave.name" . -}}
 {{- $svcPort := 8080 -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
@@ -17,7 +17,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "http_mock.labels" . | nindent 4 }}
+    {{- include "killgrave.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/stable/killgrave/templates/ingress.yaml
+++ b/stable/killgrave/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "http_mock.name" . -}}
+{{- $svcPort := 8080 -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "http_mock.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/stable/killgrave/templates/service.yaml
+++ b/stable/killgrave/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "http_mock.name" . }}
+  labels:
+    {{- include "http_mock.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 3000
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "http_mock.selectorLabels" . | nindent 4 }}

--- a/stable/killgrave/templates/service.yaml
+++ b/stable/killgrave/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "http_mock.name" . }}
+  name: {{ include "killgrave.name" . }}
   labels:
-    {{- include "http_mock.labels" . | nindent 4 }}
+    {{- include "killgrave.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "http_mock.selectorLabels" . | nindent 4 }}
+    {{- include "killgrave.selectorLabels" . | nindent 4 }}

--- a/stable/killgrave/values.yaml
+++ b/stable/killgrave/values.yaml
@@ -19,12 +19,12 @@ resources: {}
 mock:
   imposters:
 #    mock.imposters.configmap -- The name of the configmap containing all your imposters
-    configmap: imposters
+    configmap: example-imposters
 #    mock.imposters.path -- The mounting path for your imposters folder
     path: /imposters
   schemas:
-#    mock.schemas.configmap -- The name of the configmap containing your schemas folder.
-    configmap: http_mock_schemas
+#    mock.schemas.configmap -- The name of the configmap containing your schemas' folder.
+    configmap: example-schemas
 #    mock.schemas.path -- The mounting path for your schemas folder
     path: /schemas
   killgrave:

--- a/stable/killgrave/values.yaml
+++ b/stable/killgrave/values.yaml
@@ -1,0 +1,61 @@
+# nameOverride -- Set it in case you want to override the name of the deployment. By default it is set to `.Chart.Name`
+nameOverride: ""
+# labels -- Any extra label to apply to all resources
+labels: {}
+# replicaCount -- Set the number of replicas in case hpa is not enabled
+replicaCount: 1
+
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+#  hpa.targetUtilizationPercentage -- Set it to false in case you don't want to scale by cpu consumption
+  targetCPUUtilizationPercentage: 80
+#  hpa.targetMemoryUtilizationPercentage -- Set it to false in case you don't want to scale by memory consumption
+  targetMemoryUtilizationPercentage: false
+
+resources:
+  limits:
+    cpu: 512m
+    memory: 512Mi
+  requests:
+    cpu: 512m
+    memory: 256Mi
+
+mock:
+  imposters:
+#    mock.imposters.configmap -- The name of the configmap containing all your imposters
+    configmap: imposters
+#    mock.imposters.path -- The mounting path for your imposters folder
+    path: /imposters
+  schemas:
+#    mock.schemas.configmap -- The name of the configmap containing your schemas folder.
+    configmap: http_mock_schemas
+#    mock.schemas.path -- The mounting path for your schemas folder
+    path: /schemas
+  killgrave:
+#    mock.killgrave.tag -- The image tag to use
+    tag: "latest"
+#    mock.killgrave.secure -- If killgrave server must be configured to run using TSL
+    secure: false
+
+affinity: {}
+tolerations: []
+nodeSelector: {}
+
+ingress:
+  enabled: false
+  className: ""
+  hosts: []
+#    - host: http-mock-example.local
+#      pathType: ImplementationSpecific
+#      paths:
+#        - path: /
+  tls: []
+#    - hosts: []
+#      secretName: chart-example-tsl
+  annotations: {}
+
+service:
+  type: NodePort
+  targetPort: 8080

--- a/stable/killgrave/values.yaml
+++ b/stable/killgrave/values.yaml
@@ -29,7 +29,7 @@ mock:
     path: /schemas
   killgrave:
 #    mock.killgrave.tag -- The image tag to use
-    tag: "latest"
+    tag: "0.4.1"
 #    mock.killgrave.secure -- If killgrave server must be configured to run using TSL
     secure: false
 

--- a/stable/killgrave/values.yaml
+++ b/stable/killgrave/values.yaml
@@ -14,13 +14,7 @@ hpa:
 #  hpa.targetMemoryUtilizationPercentage -- Set it to false in case you don't want to scale by memory consumption
   targetMemoryUtilizationPercentage: false
 
-resources:
-  limits:
-    cpu: 512m
-    memory: 512Mi
-  requests:
-    cpu: 512m
-    memory: 256Mi
+resources: {}
 
 mock:
   imposters:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

A chart to install [killgrave](https://github.com/friendsofgo/killgrave), a simulator for HTTP-based APIs.

Killgrave allows setting up a mock server with minimal preparation, this is especially useful when the actual implementation is not ready or in cases where you want to avoid hitting real services (ie. while load testing applications).

To mock endpoints, killgrave uses _imposters_ (a request-response pair). Imposters usually look like this:

```json
[
    {
        "request": {
            "method": "GET",
            "endpoint": "/gophers/01D8EMQ185CA8PRGE20DKZTGSR"            
        },
        "response": {
            "status": 200,
            "headers": {
                "Content-Type": "application/json"
            },
            "body": "{\"data\":{\"type\":\"gophers\",\"id\":\"01D8EMQ185CA8PRGE20DKZTGSR\",\"attributes\":{\"name\":\"Zebediah\",\"color\":\"Purples\",\"age\":55}}}"
        }
    }
]
```
You can find extra documentation about different imposter options in killgrave's own repo

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
