### PR TITLE
[stable/gripmock] GRPC mock server

### DIFF
--- a/stable/gripmock/.helmignore
+++ b/stable/gripmock/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/gripmock/Chart.yaml
+++ b/stable/gripmock/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: gripmock
+description: |
+  A chart to install [gripmock](https://github.com/tokopedia/gripmock). A mock server for GRPC services. It uses `.proto` file(s) to generate the implementation of gRPC service(s) for you.
+
+  > **Note:**
+  > <br />
+  > The latest version (v1.10 - default) of gripmock is requiring `go_package` declaration in the `.proto` file. This is due to the latest update of `protoc` plugin that being used by gripmock is making the `go_package` declaration mandatory.
+  >
+  > Version v1.11.1-beta release is available by overriding the `image.tag` in your `values.yaml` file. This version supports **NO** declaration of `go_package`.
+type: application
+version: 1.0.0
+appVersion: "1.10.1"
+maintainers:
+  - name: MarceloAplanalp
+    email: marcelo.aplanalp@deliveryhero.com

--- a/stable/gripmock/README.md
+++ b/stable/gripmock/README.md
@@ -1,0 +1,81 @@
+# gripmock
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.1](https://img.shields.io/badge/AppVersion-1.10.1-informational?style=flat-square)
+
+A chart to install [gripmock](https://github.com/tokopedia/gripmock). A mock server for GRPC services. It uses `.proto` file(s) to generate the implementation of gRPC service(s) for you.
+
+> **Note:**
+> <br />
+> The latest version (v1.10 - default) of gripmock is requiring `go_package` declaration in the `.proto` file. This is due to the latest update of `protoc` plugin that being used by gripmock is making the `go_package` declaration mandatory.
+>
+> Version v1.11.1-beta release is available by overriding the `image.tag` in your `values.yaml` file. This version supports **NO** declaration of `go_package`.
+
+## How to install this chart
+
+Add Delivery Hero public chart repo:
+
+```console
+helm repo add deliveryhero https://charts.deliveryhero.io/
+```
+
+A simple install with default values:
+
+```console
+helm install deliveryhero/gripmock
+```
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release deliveryhero/gripmock
+```
+
+To install with some set values:
+
+```console
+helm install my-release deliveryhero/gripmock --set values_key1=value1 --set values_key2=value2
+```
+
+To install with custom values file:
+
+```console
+helm install my-release deliveryhero/gripmock -f values.yaml
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
+| gripmock.mock | list | `["hello_service.proto"]` | A list of `.proto` files that will be mocked based on the stubs. |
+| gripmock.proto.configmap | string | `"example-protos"` | The name of the configmap containing all your `.proto` files |
+| gripmock.proto.path | string | `"/proto"` | The path where your configmap containing the proto files will be mounted |
+| gripmock.stubs.configmap | string | `"example-stubs"` | The name of the configmap containing all the response definitions |
+| gripmock.stubs.path | string | `"/stubs"` | The path where your stubs configmap will be mounted |
+| hpa.enabled | bool | `false` |  |
+| hpa.maxReplicas | int | `100` |  |
+| hpa.minReplicas | int | `1` |  |
+| hpa.targetCPUUtilizationPercentage | int | `80` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.tag | string | `"1.10.1"` | Overrides the image tag whose default is the chart appVersion. |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.tls | list | `[]` |  |
+| labels | object | `{}` | Any extra label to apply to all resources |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| replicaCount | int | `1` | Set the number of replicas in case hpa is not enabled |
+| resources | object | `{}` |  |
+| tolerations | list | `[]` |  |
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| MarceloAplanalp | <marcelo.aplanalp@deliveryhero.com> |  |

--- a/stable/gripmock/example/proto/hello_service.proto
+++ b/stable/gripmock/example/proto/hello_service.proto
@@ -1,0 +1,17 @@
+syntax = 'proto3';
+
+package com.deliveryhero.loadtest.examples.hello;
+
+option go_package = "com.deliveryhero/loadtest/examples/hello";
+
+service HelloService {
+  rpc sayHello(HelloRequest) returns (HelloResponse);
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloResponse {
+  string message = 1;
+}

--- a/stable/gripmock/example/stubs/hello_service.json
+++ b/stable/gripmock/example/stubs/hello_service.json
@@ -1,0 +1,14 @@
+{
+  "service":"HelloService",
+  "method":"SayHello",
+  "input":{
+    "matches":{
+      "name":"[\\s\\S]*"
+    }
+  },
+  "output":{
+    "data":{
+      "message":"Hello there!"
+    }
+  }
+}

--- a/stable/gripmock/templates/_helpers.tpl
+++ b/stable/gripmock/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* Expand the name of the chart. */}}
+{{- define "gripmock.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gripmock.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "gripmock.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels */}}
+{{- define "gripmock.labels" -}}
+helm.sh/chart: {{ include "gripmock.chart" . }}
+{{ include "gripmock.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{- range $key, $value := .Values.labels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Selector labels */}}
+{{- define "gripmock.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gripmock.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/stable/gripmock/templates/configmap-proto.yaml
+++ b/stable/gripmock/templates/configmap-proto.yaml
@@ -1,0 +1,10 @@
+{{- if eq .Values.gripmock.proto.configmap "example-protos" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.gripmock.proto.configmap }}
+  labels:
+{{ include "gripmock.labels" . | indent 4}}
+data:
+{{ (.Files.Glob "example/proto/*").AsConfig | indent 2 }}
+{{- end }}

--- a/stable/gripmock/templates/configmap-stubs.yaml
+++ b/stable/gripmock/templates/configmap-stubs.yaml
@@ -1,0 +1,10 @@
+{{- if eq .Values.gripmock.stubs.configmap "example-stubs" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.gripmock.stubs.configmap }}
+  labels:
+{{ include "gripmock.labels" . | indent 4}}
+data:
+{{ (.Files.Glob "example/stubs/*").AsConfig | indent 2 }}
+{{- end }}

--- a/stable/gripmock/templates/deployment.yaml
+++ b/stable/gripmock/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gripmock.fullname" . }}
+  labels:
+    {{- include "gripmock.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.hpa.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "gripmock.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "gripmock.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "tkpd/gripmock:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -imports={{ .Values.gripmock.proto.path }}
+            - -stub={{ .Values.gripmock.stubs.path }}
+            {{- range $proto := .Values.gripmock.mock }}
+            - {{ $.Values.gripmock.proto.path }}/{{ $proto }}
+            {{- end }}
+          volumeMounts:
+            - mountPath: {{ .Values.gripmock.proto.path }}
+              name: proto
+            - mountPath: {{ .Values.gripmock.stubs.path }}
+              name: stubs
+          ports:
+            - name: http
+              containerPort: 4771
+              protocol: TCP
+            - name: grpc
+              containerPort: 4770
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: proto
+          configMap:
+            name: {{ .Values.gripmock.proto.configmap }}
+        - name: stubs
+          configMap:
+            name: {{ .Values.gripmock.stubs.configmap }}

--- a/stable/gripmock/templates/hpa.yaml
+++ b/stable/gripmock/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: hpa/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "gripmock.fullname" . }}
+  labels:
+    {{- include "gripmock.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "gripmock.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/stable/gripmock/templates/ingress.yaml
+++ b/stable/gripmock/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "gripmock.fullname" . -}}
+{{- $svcPort := 4770 -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "gripmock.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/stable/gripmock/templates/service.yaml
+++ b/stable/gripmock/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gripmock.fullname" . }}
+  labels:
+    {{- include "gripmock.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4770
+      targetPort: 4770
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "gripmock.selectorLabels" . | nindent 4 }}

--- a/stable/gripmock/values.yaml
+++ b/stable/gripmock/values.yaml
@@ -1,0 +1,76 @@
+# Default values for gripmock.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# replicaCount -- Set the number of replicas in case hpa is not enabled
+replicaCount: 1
+
+# labels -- Any extra label to apply to all resources
+labels: {}
+
+image:
+  pullPolicy: IfNotPresent
+  # image.tag -- Overrides the image tag whose default is the chart appVersion.
+  tag: "1.10.1"
+
+gripmock:
+  proto:
+#   gripmock.proto.configmap -- The name of the configmap containing all your `.proto` files
+    configmap: example-protos
+#   gripmock.proto.path -- The path where your configmap containing the proto files will be mounted
+    path: /proto
+  stubs:
+#   gripmock.stubs.configmap -- The name of the configmap containing all the response definitions
+    configmap: example-stubs
+#   gripmock.stubs.path -- The path where your stubs configmap will be mounted
+    path: /stubs
+# gripmock.mock -- A list of `.proto` files that will be mocked based on the stubs.
+  mock:
+    - hello_service.proto
+
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

A chart to install [gripmock](https://github.com/tokopedia/gripmock). A mock server for GRPC services. It uses `.proto` file(s) to generate the implementation of gRPC service(s) for you.

  > **Note:**
  > <br />
  > The latest version (v1.10 - default) of gripmock is requiring `go_package` declaration in the `.proto` file. This is due to the latest update of `protoc` plugin that is used by gripmock is making the `go_package` declaration mandatory.
  >
  > Version v1.11.1-beta release is available by overriding the `image.tag` in your `values.yaml` file. This version supports **NO** declaration of `go_package`.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
