### PR TITLE
[stable/backstage] Missing ingressClassName parameter

### DIFF
--- a/stable/backstage/Chart.yaml
+++ b/stable/backstage/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/backstage/backstage
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.12
+version: 0.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/backstage/README.md
+++ b/stable/backstage/README.md
@@ -1,6 +1,6 @@
 # backstage
 
-![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1-alpha.23](https://img.shields.io/badge/AppVersion-v0.1.1--alpha.23-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1-alpha.23](https://img.shields.io/badge/AppVersion-v0.1.1--alpha.23-informational?style=flat-square)
 
 A Helm chart for Backstage
 
@@ -154,8 +154,8 @@ helm install my-release deliveryhero/backstage -f values.yaml
 | fullnameOverride | string | `""` |  |
 | global.postgresql.caFilename | string | `"ca.crt"` |  |
 | global.postgresql.postgresqlUsername | string | `"backend-user"` |  |
-| ingress.ingressClassName | string | `"nginx"` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/force-ssl-redirect" | string | `"false"` |  |
+| ingress.ingressClassName | string | `"nginx"` |  |
 | issuer.clusterIssuer | string | `"letsencrypt-staging"` |  |
 | issuer.email | string | `nil` |  |
 | lighthouse.containerPort | int | `3003` |  |

--- a/stable/backstage/README.md
+++ b/stable/backstage/README.md
@@ -154,6 +154,7 @@ helm install my-release deliveryhero/backstage -f values.yaml
 | fullnameOverride | string | `""` |  |
 | global.postgresql.caFilename | string | `"ca.crt"` |  |
 | global.postgresql.postgresqlUsername | string | `"backend-user"` |  |
+| ingress.ingressClassName | string | `"nginx"` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/force-ssl-redirect" | string | `"false"` |  |
 | issuer.clusterIssuer | string | `"letsencrypt-staging"` |  |
 | issuer.email | string | `nil` |  |

--- a/stable/backstage/templates/ingress.yaml
+++ b/stable/backstage/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- $frontendUrl := urlParse .Values.appConfig.app.baseUrl}}
 {{- $backendUrl := urlParse .Values.appConfig.backend.baseUrl}}
 {{- $lighthouseUrl := urlParse .Values.appConfig.lighthouse.baseUrl}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "backstage.fullname" . }}-ingress
@@ -30,24 +30,33 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ include "frontend.serviceName" . }}
-              servicePort: 80
+              service:
+                name: {{ include "frontend.serviceName" . }}
+                port:
+                  number: 80
           {{/* Route the backend inside the same hostname as the frontend when they are the same */}}
           {{- if eq $frontendUrl.host $backendUrl.host}}
           - path: /api
+            pathType: Prefix
             backend:
-              serviceName: {{ include "backend.serviceName" . }}
-              servicePort: 80
+              service:
+                name: {{ include "backend.serviceName" . }}
+                port:
+                  number: 80
           {{/* Route the backend through a different host */}}
           {{- else -}}
     - host: {{ $backendUrl.host }}
       http:
         paths:
           - path: {{ $backendUrl.path | default "/" }}
+            pathType: Prefix
             backend:
-              serviceName: {{ include "backend.serviceName" . }}
-              servicePort: 80
+              service:
+                name: {{ include "backend.serviceName" . }}
+                port:
+                  number: 80
          {{- end }}
 
 {{/* Route lighthouse through a different host */}}
@@ -56,13 +65,16 @@ spec:
       http:
         paths:
           - path: {{ $lighthouseUrl.path | default "/" }}
+            pathType: Prefix
             backend:
-              serviceName: {{ include "lighthouse.serviceName" . }}
-              servicePort: 80
+              service:
+                name: {{ include "lighthouse.serviceName" . }}
+                port:
+                  number: 80
 {{- else }}
 {{/* Route lighthouse by path with re-write rules when it is hosted under the same hostname */}}
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "backstage.fullname" . }}-ingress-lighthouse
@@ -87,7 +99,10 @@ spec:
       http:
         paths:
           - path: {{$lighthouseUrl.path}}(/|$)(.*)
+            pathType: Prefix
             backend:
-              serviceName: {{ include "lighthouse.serviceName" . }}
-              servicePort: 80
+              service:
+                name: {{ include "lighthouse.serviceName" . }}
+                port:
+                  number: 80
 {{- end }}

--- a/stable/backstage/templates/ingress.yaml
+++ b/stable/backstage/templates/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
       }
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   tls:
     - secretName: {{ include "backstage.fullname" . }}-tls
       hosts:

--- a/stable/backstage/values.yaml
+++ b/stable/backstage/values.yaml
@@ -58,6 +58,7 @@ nameOverride: ''
 fullnameOverride: ''
 
 ingress:
+  ingressClassName: nginx
   annotations:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
 


### PR DESCRIPTION
## Description

Currently, the parameter `ingressClassName` is missing.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [ ] Github actions are passing
