### PR TITLE
[stable/kube-downscaler] Do not override default config

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,7 +1,7 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.5.9"
-appVersion: 22.7.1
+version: "0.6.0"
+appVersion: 22.9.0
 description: Scale down Kubernetes deployments after work hours
 keywords:
 - k8s pods scheduler

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.5.9](https://img.shields.io/badge/Version-0.5.9-informational?style=flat-square) ![AppVersion: 22.7.1](https://img.shields.io/badge/AppVersion-22.7.1-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: 22.9.0](https://img.shields.io/badge/AppVersion-22.9.0-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 
@@ -49,7 +49,7 @@ helm install my-release deliveryhero/kube-downscaler -f values.yaml
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | debug.enable | bool | `false` |  |
-| deployment.environment.DEFAULT_UPTIME | string | `"Mon-Fri 07:00-20:00 Europe/Berlin"` |  |
+| deployment.environment | object | `{}` |  |
 | events.enable | bool | `true` |  |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |

--- a/stable/kube-downscaler/templates/deployment.yaml
+++ b/stable/kube-downscaler/templates/deployment.yaml
@@ -35,13 +35,15 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- with .Values.deployment.environment }}
+        {{- range $key, $value := . }}
         env:
-{{- range $key, $value := .Values.deployment.environment }}
-         {{- if $value }}
+          {{- if $value }}
           - name: {{ $key }}
             value: {{ $value | quote }}
-         {{- end }}
-{{- end }}
+          {{- end }}
+        {{- end }}
+        {{- end }}
         args:
         - --interval={{ .Values.interval }}
         {{- if .Values.namespace }}

--- a/stable/kube-downscaler/values.yaml
+++ b/stable/kube-downscaler/values.yaml
@@ -56,9 +56,12 @@ securityContext: {}
 
 extraLabels: {}
 
+# Set environment variables to override the default configuration
+# By default the uptime is "always"
+# More information here: https://codeberg.org/hjacobs/kube-downscaler#configuration
 deployment:
-  environment:
-    DEFAULT_UPTIME: "Mon-Fri 07:00-20:00 Europe/Berlin"
+  environment: {}
+    # DEFAULT_UPTIME: "Mon-Fri 07:00-20:00 Europe/Berlin"
 
 # This will periodically remove all annotations preventing downscaling
 # Sometimes people forget to remove the annotations and this can incur costs


### PR DESCRIPTION
## Description

Do not override the default settings of kube-downscaler by default through the environment variables. I made a bone headed mistake which caused the chart to get deployed without removing the `DEFAULT_UPTIME` value in production and want to avoid this happening for others (or future me...).

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#contributing), bumped chart version and regenerated the docs
- [x] Github actions are passing
