### PR TITLE
[stable/killgrave] Remove hardcoded port from ingress.yaml

### DIFF
--- a/stable/killgrave/Chart.yaml
+++ b/stable/killgrave/Chart.yaml
@@ -3,7 +3,7 @@ name: killgrave
 icon: https://avatars.githubusercontent.com/u/36798605?v=4&s=160
 
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.4.1
 maintainers:
   - name: MarceloAplanalp

--- a/stable/killgrave/README.md
+++ b/stable/killgrave/README.md
@@ -64,7 +64,7 @@ helm install my-release deliveryhero/killgrave -f values.yaml
 | nodeSelector | object | `{}` |  |
 | replicaCount | int | `1` | Set the number of replicas in case hpa is not enabled |
 | resources | object | `{}` |  |
-| service.targetPort | int | `8080` |  |
+| service.port | int | `8080` |  |
 | service.type | string | `"NodePort"` |  |
 | tolerations | list | `[]` |  |
 

--- a/stable/killgrave/README.md
+++ b/stable/killgrave/README.md
@@ -1,6 +1,6 @@
 # killgrave
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1](https://img.shields.io/badge/AppVersion-0.4.1-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1](https://img.shields.io/badge/AppVersion-0.4.1-informational?style=flat-square)
 
 A chart to install [killgrave](https://github.com/friendsofgo/killgrave), a simulator for HTTP-based APIs.
 

--- a/stable/killgrave/templates/deployment.yaml
+++ b/stable/killgrave/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
             {{- end }}
           args:
             - -host=0.0.0.0
+            - -port={{ .Values.service.port }}
             - -imposters={{ include "killgrave.imposters_mouniting_path" . }}
             - -secure={{ .Values.mock.killgrave.secure }}
           ports:

--- a/stable/killgrave/templates/hpa.yaml
+++ b/stable/killgrave/templates/hpa.yaml
@@ -13,7 +13,7 @@ spec:
   minReplicas: {{ .Values.hpa.minReplicas | default 1 }}
   maxReplicas: {{ .Values.hpa.maxReplicas | default 100 }}
   metrics:
-    {{- if ne .Values.hpa.targetCPUUtilizationPercentage false }}
+    {{- if .Values.hpa.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu

--- a/stable/killgrave/templates/ingress.yaml
+++ b/stable/killgrave/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "killgrave.name" . -}}
-{{- $svcPort := 8080 -}}
+{{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/stable/killgrave/templates/service.yaml
+++ b/stable/killgrave/templates/service.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: 3000
-      targetPort: {{ .Values.service.targetPort }}
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
       protocol: TCP
       name: http
   selector:

--- a/stable/killgrave/values.yaml
+++ b/stable/killgrave/values.yaml
@@ -52,4 +52,4 @@ ingress:
 
 service:
   type: NodePort
-  targetPort: 8080
+  port: 8080


### PR DESCRIPTION
## Description

Corrections to killgrave's helm chart:

- Remove hardcoded port in ingress
- Correct type error when HPA is enabled

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
