### PR TITLE
[stable/service-account]: fix chart to fit 1.23+ k8s version

### DIFF
--- a/stable/service-account/Chart.yaml
+++ b/stable/service-account/Chart.yaml
@@ -1,5 +1,5 @@
 name: service-account
-version: "1.0.2"
+version: "1.1.0"
 description: |
   Creates a ServiceAccount, ClusterRoleBinding and a ClusterRole with some provided rules.
 

--- a/stable/service-account/README.md
+++ b/stable/service-account/README.md
@@ -1,6 +1,6 @@
 # service-account
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square)
 
 Creates a ServiceAccount, ClusterRoleBinding and a ClusterRole with some provided rules.
 

--- a/stable/service-account/templates/clusterrole.yaml
+++ b/stable/service-account/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/stable/service-account/templates/clusterrolebinding.yaml
+++ b/stable/service-account/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Starting from 1.23 the RBAC APIs are no more in `beta`.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
