### PR TITLE
[stable/kube-downscaler] sync cluster role with upstream for keda support

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.6.0"
+version: "0.7.0"
 appVersion: 22.9.0
 description: Scale down Kubernetes deployments after work hours
 keywords:

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: 22.9.0](https://img.shields.io/badge/AppVersion-22.9.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: 22.9.0](https://img.shields.io/badge/AppVersion-22.9.0-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 

--- a/stable/kube-downscaler/templates/clusterrole.yaml
+++ b/stable/kube-downscaler/templates/clusterrole.yaml
@@ -66,7 +66,7 @@ rules:
   - list
   - update
   - patch
- - apiGroups:
+- apiGroups:
   - keda.sh
   resources:
   - scaledobjects

--- a/stable/kube-downscaler/templates/clusterrole.yaml
+++ b/stable/kube-downscaler/templates/clusterrole.yaml
@@ -66,6 +66,16 @@ rules:
   - list
   - update
   - patch
+ - apiGroups:
+  - keda.sh
+  resources:
+  - scaledobjects
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

added keda rules based on upstream project:
https://codeberg.org/hjacobs/kube-downscaler/src/branch/main/deploy/rbac.yaml

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
