### PR TITLE
[stable/k8s-event-logger] Added securityContext and podSecurityContext

### DIFF
--- a/stable/k8s-event-logger/Chart.yaml
+++ b/stable/k8s-event-logger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.6"
-version: "1.1"
+version: "1.1.1"
 description: |
   This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
 

--- a/stable/k8s-event-logger/README.md
+++ b/stable/k8s-event-logger/README.md
@@ -1,6 +1,6 @@
 # k8s-event-logger
 
-![Version: 1.1](https://img.shields.io/badge/Version-1.1-informational?style=flat-square) ![AppVersion: 1.6](https://img.shields.io/badge/AppVersion-1.6-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 1.6](https://img.shields.io/badge/AppVersion-1.6-informational?style=flat-square)
 
 This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
 
@@ -68,10 +68,13 @@ helm install my-release deliveryhero/k8s-event-logger -f values.yaml
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podLabels | object | `{}` |  |
+| podSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
+| podSecurityContext.runAsNonRoot | bool | `true` |  |
 | resources.limits.cpu | string | `"100m"` |  |
 | resources.limits.memory | string | `"128Mi"` |  |
 | resources.requests.cpu | string | `"10m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |
+| securityContext | object | `{}` |  |
 | tolerations | list | `[]` |  |
 
 ## Maintainers

--- a/stable/k8s-event-logger/templates/deployment.yaml
+++ b/stable/k8s-event-logger/templates/deployment.yaml
@@ -23,14 +23,19 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- if .Values.podSecurityContext }}
+      securityContext:
+{{- toYaml .Values.securityContext | nindent 8 }}
+{{- end }}
       serviceAccountName: {{ include "k8s-event-logger.fullname" . }}
       containers:
         - name: app
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.podSecurityContext }}
           securityContext:
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
+{{- toYaml .Values.podSecurityContext | nindent 12 }}
+{{- end }}
           env:
 {{- range $key, $value := .Values.env }}
           - name: {{ $key }}

--- a/stable/k8s-event-logger/values.yaml
+++ b/stable/k8s-event-logger/values.yaml
@@ -15,6 +15,11 @@ env:
   KUBERNETES_API_URL: https://172.20.0.1:443
   CA_FILE: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 
+securityContext: {}
+podSecurityContext:
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Added the ability to add securityContext and podSecurityContext to the deployment

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
