### PR TITLE
[stable/metabase] feat(metabase): add option to add extra containers

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions and learn from data.
 name: metabase
-version: 0.13.4
+version: 0.13.5
 appVersion: v0.43
 home: http://www.metabase.com/
 icon: http://www.metabase.com/images/logo.svg

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -1,6 +1,6 @@
 # metabase
 
-![Version: 0.13.4](https://img.shields.io/badge/Version-0.13.4-informational?style=flat-square) ![AppVersion: v0.43](https://img.shields.io/badge/AppVersion-v0.43-informational?style=flat-square)
+![Version: 0.13.5](https://img.shields.io/badge/Version-0.13.5-informational?style=flat-square) ![AppVersion: v0.43](https://img.shields.io/badge/AppVersion-v0.43-informational?style=flat-square)
 
 The easy, open source way for everyone in your company to ask questions and learn from data.
 
@@ -49,6 +49,7 @@ helm install my-release deliveryhero/metabase -f values.yaml
 | affinity | object | `{}` |  |
 | database.type | string | `"h2"` |  |
 | emojiLogging | bool | `true` |  |
+| extraContainers | list | `[]` |  |
 | extraEnv | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"metabase/metabase"` |  |

--- a/stable/metabase/templates/deployment.yaml
+++ b/stable/metabase/templates/deployment.yaml
@@ -153,6 +153,9 @@ spec:
           {{- end}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 8 }}
+{{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -68,6 +68,8 @@ session: {}
   # maxSessionAge:
   # sessionCookies:
 
+extraContainers: []
+
 livenessProbe:
   initialDelaySeconds: 120
   timeoutSeconds: 30


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

This allows metabase to be used with sidecars, i.e. using Google SQL Auth Proxy to connect to an instance managed by GCP

## Checklist

- [ x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ x] Github actions are passing
