### PR TITLE
[stable/locust] fix labels for PodDisruptionBudget and enable for worker

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.30.1"
+version: "0.31.0"
 appVersion: 2.13.1
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.30.1](https://img.shields.io/badge/Version-0.30.1-informational?style=flat-square) ![AppVersion: 2.13.1](https://img.shields.io/badge/AppVersion-2.13.1-informational?style=flat-square)
+![Version: 0.31.0](https://img.shields.io/badge/Version-0.31.0-informational?style=flat-square) ![AppVersion: 2.13.1](https://img.shields.io/badge/AppVersion-2.13.1-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -132,6 +132,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | worker.hpa.targetCPUUtilizationPercentage | int | `40` |  |
 | worker.image | string | `""` | A custom docker image including tag |
 | worker.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
+| worker.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the worker pods |
 | worker.replicas | int | `1` |  |
 | worker.resources | object | `{}` | resources for the locust worker |
 | worker.restartPolicy | string | `"Always"` | worker pod's restartPolicy. Can be Always, OnFailure, or Never. |

--- a/stable/locust/templates/worker-pdb.yaml
+++ b/stable/locust/templates/worker-pdb.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.master.pdb.enabled }}
+{{- if .Values.worker.pdb.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "locust.fullname" . }}-master
+  name: {{ template "locust.fullname" . }}-worker
   labels:
-    component: master
+    component: worker
 {{ include "locust.labels" . | indent 4 }}
 spec:
   maxUnavailable: 0
   selector:
     matchLabels:
       {{- include "locust.selectorLabels" . | nindent 6 }}
-      component: master
+      component: worker
 {{- end }}

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -98,6 +98,9 @@ worker:
   # worker.logLevel -- Log level. Can be INFO or DEBUG
   logLevel: INFO
   replicas: 1
+  # worker.pdb.enabled -- Whether to create a PodDisruptionBudget for the worker pods
+  pdb:
+    enabled: false
   hpa:
     enabled: false
     minReplicas: 1


### PR DESCRIPTION
The labels on the `PodDisruptionBudget` were incorrect and did not match the actual pods. This causes the `cluster-autoscaler` to move the pods on node scale down with events like `deleting pod for node scale down`. And this interrupts running load tests.