### PR TITLE
[stable/cluster-overprovisioner] pause 3.9

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "3.6"
+appVersion: "3.9"
 description: |
   This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.7.10
+version: 0.7.11
 maintainers:
   - name: max-rocket-internet
     email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.7.10](https://img.shields.io/badge/Version-0.7.10-informational?style=flat-square) ![AppVersion: 3.6](https://img.shields.io/badge/AppVersion-3.6-informational?style=flat-square)
+![Version: 0.7.11](https://img.shields.io/badge/Version-0.7.11-informational?style=flat-square) ![AppVersion: 3.9](https://img.shields.io/badge/AppVersion-3.9-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -73,7 +73,7 @@ helm install my-release deliveryhero/cluster-overprovisioner -f values.yaml
 | image.args | list | `[]` | Override container args |
 | image.command | list | `[]` | Override container command |
 | image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
-| image.repository | string | `"k8s.gcr.io/pause"` | Image repository |
+| image.repository | string | `"registry.k8s.io/pause"` | Image repository |
 | image.tag | string | `.Chart.AppVersion` | Image tag |
 | nameOverride | string | `""` | Override the name of the chart |
 | podSecurityContext | object | `{}` | Pod security context object |

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -76,7 +76,7 @@ spec:
           {{- with .extraEnv }}
           env:
             {{toYaml . | nindent 12 }}
-          {{- end }}   
+          {{- end }}
     {{- if $imagePullSecrets }}
       imagePullSecrets:
       {{- range $imagePullSecrets }}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -23,7 +23,7 @@ priorityClassDefault:
 
 image:
   # image.repository -- Image repository
-  repository: k8s.gcr.io/pause
+  repository: registry.k8s.io/pause
   # image.tag -- Image tag
   # @default -- `.Chart.AppVersion`
   tag: ""


### PR DESCRIPTION
## Description

Update 'pause' to latest version. Switch to new official kubernetes
registry: https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/

pause changelog at https://github.com/kubernetes/kubernetes/blob/v1.26.0/build/pause/CHANGELOG.md

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
