### PR TITLE
[stable/prometheus-k8s-events-exporter] Fix cluster role api version

### DIFF
--- a/stable/prometheus-k8s-events-exporter/templates/clusterrole.yaml
+++ b/stable/prometheus-k8s-events-exporter/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "prometheus-k8s-events-exporter.fullname" . }}
   labels:


### PR DESCRIPTION

## Description

cluster role should use api version rbac.authorization.k8s.io/v1

