### PR TITLE
[stable/k8s-cloudwatch-adapter] Make compatible with K8s v1.22+

### DIFF
--- a/stable/k8s-cloudwatch-adapter/Chart.yaml
+++ b/stable/k8s-cloudwatch-adapter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.9.0
 name: k8s-cloudwatch-adapter
 description: |
   An implementation of the Kubernetes Custom Metrics API and External Metrics API for AWS CloudWatch metrics. This adapter allows you to scale your Kubernetes deployment using the Horizontal Pod Autoscaler (HPA) with metrics from AWS CloudWatch.
-version: 0.1.4
+version: 0.2.0
 home: https://github.com/awslabs/k8s-cloudwatch-adapter
 sources:
   - https://github.com/awslabs/k8s-cloudwatch-adapter

--- a/stable/k8s-cloudwatch-adapter/README.md
+++ b/stable/k8s-cloudwatch-adapter/README.md
@@ -1,6 +1,6 @@
 # k8s-cloudwatch-adapter
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 An implementation of the Kubernetes Custom Metrics API and External Metrics API for AWS CloudWatch metrics. This adapter allows you to scale your Kubernetes deployment using the Horizontal Pod Autoscaler (HPA) with metrics from AWS CloudWatch.
 

--- a/stable/k8s-cloudwatch-adapter/templates/apiservice.yaml
+++ b/stable/k8s-cloudwatch-adapter/templates/apiservice.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "apiregistration.k8s.io/v1" }}
+apiVersion: apiregistration.k8s.io/v1
+{{- else }}
 apiVersion: apiregistration.k8s.io/v1beta1
+{{- end }}
 kind: APIService
 metadata:
   name: v1beta1.external.metrics.k8s.io

--- a/stable/k8s-cloudwatch-adapter/templates/crd.yaml
+++ b/stable/k8s-cloudwatch-adapter/templates/crd.yaml
@@ -1,10 +1,80 @@
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: externalmetrics.metrics.aws
 spec:
   group: metrics.aws
+  {{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" }}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            required:
+              - name
+              - queries
+            properties:
+              name:
+                type: string
+              roleArn:
+                type: string
+              region:
+                type: string
+              queries:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    expression:
+                      type: string
+                    id:
+                      type: string
+                    label:
+                      type: string
+                    metricStat:
+                      type: object
+                      properties:
+                        metric:
+                          type: object
+                          required:
+                            - metricName
+                          properties:
+                            dimensions:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                  - name
+                                  - value
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                            metricName:
+                              type: string
+                            namespace:
+                              type: string
+                        period:
+                          type: integer
+                        stat:
+                          type: string
+                        unit:
+                          type: string
+                    returnData:
+                      type: boolean
+  {{- else }}
   version: v1alpha1
+  {{- end }}
   names:
     kind: ExternalMetric
     plural: externalmetrics


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

Even though the cloudwatch-adapter is already deprecated and archived it still works on K8s v1.22+, but the API resources need to be updated. This PR does just that, with the schema manually crafted from the docs.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
