### PR TITLE
[stable/prometheus-k8s-events-exporter] Add compatibility with K8s v1.22+

### DIFF
--- a/stable/prometheus-k8s-events-exporter/Chart.yaml
+++ b/stable/prometheus-k8s-events-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.2.0
 description: Exporter for kubernetes events
 name: prometheus-k8s-events-exporter
-version: 0.1.3
+version: 0.2.0
 home: https://github.com/caicloud/event_exporter
 sources:
   - https://github.com/caicloud/event_exporter

--- a/stable/prometheus-k8s-events-exporter/README.md
+++ b/stable/prometheus-k8s-events-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-k8s-events-exporter
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 Exporter for kubernetes events
 

--- a/stable/prometheus-k8s-events-exporter/templates/clusterrole.yaml
+++ b/stable/prometheus-k8s-events-exporter/templates/clusterrole.yaml
@@ -1,5 +1,9 @@
 kind: ClusterRole
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 metadata:
   name: {{ include "prometheus-k8s-events-exporter.fullname" . }}
   labels:

--- a/stable/prometheus-k8s-events-exporter/templates/clusterrolebinding.yaml
+++ b/stable/prometheus-k8s-events-exporter/templates/clusterrolebinding.yaml
@@ -1,5 +1,9 @@
 kind: ClusterRoleBinding
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 metadata:
   name: {{ include "prometheus-k8s-events-exporter.fullname" . }}
   labels:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

The old RBAC API versions are removed, this makes sure the chart can handle both. ([ref](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22))

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
