### PR TITLE
[stable/superset] Update superset api version compatiblity with v1.22.0

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: superset
 description: A Helm chart for Apache Superset
 type: application
-version: 1.0.14
+version: 1.0.15
 home: https://superset.apache.org/
 appVersion: "latest"
 maintainers:

--- a/stable/superset/README.md
+++ b/stable/superset/README.md
@@ -133,4 +133,4 @@ helm install my-release deliveryhero/superset -f values.yaml
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| nyambati | thomas.nyambati@deliveryhero.com |  |
+| nyambati | <thomas.nyambati@deliveryhero.com> |  |

--- a/stable/superset/README.md
+++ b/stable/superset/README.md
@@ -1,6 +1,6 @@
 # superset
 
-![Version: 1.0.14](https://img.shields.io/badge/Version-1.0.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.0.15](https://img.shields.io/badge/Version-1.0.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for Apache Superset
 
@@ -133,4 +133,4 @@ helm install my-release deliveryhero/superset -f values.yaml
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| nyambati | <thomas.nyambati@deliveryhero.com> |  |
+| nyambati | thomas.nyambati@deliveryhero.com |  |

--- a/stable/superset/templates/ingress.yaml
+++ b/stable/superset/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{ if .Values.ingress.enabled -}}
 {{- $fullName := include "superset.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -28,8 +28,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

This pull request fixs removed API version from k8s v1.22.0.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
