### PR TITLE
[stable/metabase]: Make Metabase's ingress path type available as variable

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The easy, open source way for everyone in your company to ask questions and learn from data.
 name: metabase
-version: 0.14.0
+version: 0.14.1
 appVersion: v0.45.2
 home: http://www.metabase.com/
 icon: http://www.metabase.com/images/logo.svg

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -1,6 +1,6 @@
 # metabase
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![AppVersion: v0.45.2](https://img.shields.io/badge/AppVersion-v0.45.2-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![AppVersion: v0.45.2](https://img.shields.io/badge/AppVersion-v0.45.2-informational?style=flat-square)
 
 The easy, open source way for everyone in your company to ask questions and learn from data.
 
@@ -60,6 +60,7 @@ helm install my-release deliveryhero/metabase -f values.yaml
 | ingress.hosts | list | `[]` |  |
 | ingress.labels | object | `{}` |  |
 | ingress.path | string | `"/"` |  |
+| ingress.pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
 | jetty | object | `{}` |  |
 | listen.host | string | `"0.0.0.0"` |  |

--- a/stable/metabase/templates/ingress.yaml
+++ b/stable/metabase/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $serviceName := include "metabase.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -23,7 +24,7 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
-            pathType: Prefix
+            pathType: {{ $ingressPathType }}
             backend:
               service:
                 name: {{ $serviceName }}

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -104,6 +104,7 @@ ingress:
     # - metabase.domain.com
   # The ingress path. Useful to host metabase on a subpath, such as `/metabase`.
   path: /
+  pathType: ImplementationSpecific
   labels: {}
     # Used to add custom labels to the Ingress
     # Useful if for example you have multiple Ingress controllers and want your Ingress controllers to bind to specific Ingresses


### PR DESCRIPTION
## Description

* Make Metabase's ingress path type available as variable

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
