### PR TITLE
[stable/metabase] Missing ingressClassName parameter

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The easy, open source way for everyone in your company to ask questions and learn from data.
 name: metabase
-version: 0.14.1
+version: 0.14.2
 appVersion: v0.45.2
 home: http://www.metabase.com/
 icon: http://www.metabase.com/images/logo.svg

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -1,6 +1,6 @@
 # metabase
 
-![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![AppVersion: v0.45.2](https://img.shields.io/badge/AppVersion-v0.45.2-informational?style=flat-square)
+![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![AppVersion: v0.45.2](https://img.shields.io/badge/AppVersion-v0.45.2-informational?style=flat-square)
 
 The easy, open source way for everyone in your company to ask questions and learn from data.
 
@@ -58,6 +58,7 @@ helm install my-release deliveryhero/metabase -f values.yaml
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts | list | `[]` |  |
+| ingress.ingressClassName | string | `""` |  |
 | ingress.labels | object | `{}` |  |
 | ingress.path | string | `"/"` |  |
 | ingress.pathType | string | `"ImplementationSpecific"` |  |

--- a/stable/metabase/templates/ingress.yaml
+++ b/stable/metabase/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -100,6 +100,7 @@ service:
 ingress:
   enabled: false
   # Used to create Ingress record (should used with service.type: ClusterIP).
+  ingressClassName: ""
   hosts: []
     # - metabase.domain.com
   # The ingress path. Useful to host metabase on a subpath, such as `/metabase`.


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

The parameter `ingressClassName` is missing.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
