### PR TITLE
[stable/kube-downscaler] fix env variable injection

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.7.0"
+version: "0.7.1"
 appVersion: 22.9.0
 description: Scale down Kubernetes deployments after work hours
 keywords:

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: 22.9.0](https://img.shields.io/badge/AppVersion-22.9.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![AppVersion: 22.9.0](https://img.shields.io/badge/AppVersion-22.9.0-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 

--- a/stable/kube-downscaler/templates/deployment.yaml
+++ b/stable/kube-downscaler/templates/deployment.yaml
@@ -36,8 +36,8 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
         {{- with .Values.deployment.environment }}
-        {{- range $key, $value := . }}
         env:
+        {{- range $key, $value := . }}
           {{- if $value }}
           - name: {{ $key }}
             value: {{ $value | quote }}


### PR DESCRIPTION
## Description

Allow injecting more than one env variable into kube-downscaler environment variable. 

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [X] Github actions are passing
