### PR TITLE
[stable/k8s-cloudwatch-adapter] Fix APIService reference

### DIFF
--- a/stable/k8s-cloudwatch-adapter/Chart.yaml
+++ b/stable/k8s-cloudwatch-adapter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.9.0
 name: k8s-cloudwatch-adapter
 description: |
   An implementation of the Kubernetes Custom Metrics API and External Metrics API for AWS CloudWatch metrics. This adapter allows you to scale your Kubernetes deployment using the Horizontal Pod Autoscaler (HPA) with metrics from AWS CloudWatch.
-version: 0.2.0
+version: 0.2.1
 home: https://github.com/awslabs/k8s-cloudwatch-adapter
 sources:
   - https://github.com/awslabs/k8s-cloudwatch-adapter

--- a/stable/k8s-cloudwatch-adapter/README.md
+++ b/stable/k8s-cloudwatch-adapter/README.md
@@ -1,6 +1,6 @@
 # k8s-cloudwatch-adapter
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 An implementation of the Kubernetes Custom Metrics API and External Metrics API for AWS CloudWatch metrics. This adapter allows you to scale your Kubernetes deployment using the Horizontal Pod Autoscaler (HPA) with metrics from AWS CloudWatch.
 

--- a/stable/k8s-cloudwatch-adapter/templates/apiservice.yaml
+++ b/stable/k8s-cloudwatch-adapter/templates/apiservice.yaml
@@ -8,7 +8,7 @@ metadata:
   name: v1beta1.external.metrics.k8s.io
 spec:
   service:
-    name: "{{ .Release.Name }}"
+    name: {{ include "k8s-cloudwatch-adapter.fullname" . }}
     namespace: "{{ .Release.Namespace }}"
   group: external.metrics.k8s.io
   version: v1beta1


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

Release name is not always the same as the full name, but for the cross reference it is important that name used in the APIService spec is the same as the one used for the Service. Before this change, some configurations led to the metrics served by k8s-cloudwatch-adapter to not be available.

Refs: OGSYS-6125

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
