### PR TITLE
use named port for prom scape config

### DIFF
--- a/stable/aws-service-quotas-exporter/Chart.yaml
+++ b/stable/aws-service-quotas-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: aws-service-quotas-exporter
 description: This exporter exports AWS service quotas and usage as Prometheus metrics
 home: https://github.com/thought-machine/aws-service-quotas-exporter
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v1.3.2"
 maintainers:
   - name: nyambati

--- a/stable/aws-service-quotas-exporter/README.md
+++ b/stable/aws-service-quotas-exporter/README.md
@@ -1,6 +1,6 @@
 # aws-service-quotas-exporter
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.2](https://img.shields.io/badge/AppVersion-v1.3.2-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.2](https://img.shields.io/badge/AppVersion-v1.3.2-informational?style=flat-square)
 
 This exporter exports AWS service quotas and usage as Prometheus metrics
 
@@ -65,7 +65,7 @@ helm install my-release deliveryhero/aws-service-quotas-exporter -f values.yaml
 | resources.requests.memory | string | `"55Mi"` |  |
 | securityContext | object | `{}` |  |
 | service.annotations."prometheus.io/path" | string | `"/metrics"` |  |
-| service.annotations."prometheus.io/port" | string | `"80"` |  |
+| service.annotations."prometheus.io/port" | string | `"http"` |  |
 | service.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |

--- a/stable/aws-service-quotas-exporter/values.yaml
+++ b/stable/aws-service-quotas-exporter/values.yaml
@@ -39,7 +39,7 @@ service:
   port: 80
   annotations:
     prometheus.io/path: "/metrics"
-    prometheus.io/port: "80"
+    prometheus.io/port: "http"
     prometheus.io/scrape: "true"
 
 exporter:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
- use named port for prom scrape config
<!--- Describe your changes in detail -->

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
