### PR TITLE
[stable/kube-bench] use batch/v1 for cronjobs on kubernetes >= 1.21

### DIFF
--- a/stable/kube-bench/Chart.yaml
+++ b/stable/kube-bench/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: "Helm chart to deploy run kube-bench as a cronjob on gke or eks."
 name: kube-bench
-version: 0.1.5
+version: 0.1.6
 home: https://github.com/aquasecurity/kube-bench
 icon: https://raw.githubusercontent.com/aquasecurity/kube-bench/0d1bd2bbd95608957be024c12d03a0510325e5e2/docs/images/kube-bench.png
 sources:

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -1,6 +1,6 @@
 # kube-bench
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square)
 
 Helm chart to deploy run kube-bench as a cronjob on gke or eks.
 

--- a/stable/kube-bench/templates/_helpers.tpl
+++ b/stable/kube-bench/templates/_helpers.tpl
@@ -4,8 +4,10 @@ Return the appropriate apiVersion for cronjob APIs.
 {{- define "cronjob.apiVersion" -}}
 {{- if semverCompare "< 1.8-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "batch/v2alpha1" }}
-{{- else if semverCompare ">=1.8-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.8-0, <1.21-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "batch/v1beta1" }}
+{{- else if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "batch/v1" }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
fixes #452

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

* add support for batch/v1 for Kubernetes v1.21+

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
