### PR TITLE
[stable/kube-bench] Update kube-bench image, code cleanup, aks support

### DIFF
--- a/stable/kube-bench/Chart.yaml
+++ b/stable/kube-bench/Chart.yaml
@@ -1,7 +1,9 @@
-apiVersion: v1
-description: "Helm chart to deploy run kube-bench as a cronjob on gke or eks."
+---
+apiVersion: v2
+appVersion: 0.6.12
+description: "Helm chart to deploy run kube-bench as a cronjob on aks, gke or eks."
 name: kube-bench
-version: 0.1.6
+version: 0.1.7
 home: https://github.com/aquasecurity/kube-bench
 icon: https://raw.githubusercontent.com/aquasecurity/kube-bench/0d1bd2bbd95608957be024c12d03a0510325e5e2/docs/images/kube-bench.png
 sources:

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -1,8 +1,8 @@
 # kube-bench
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![AppVersion: 0.6.12](https://img.shields.io/badge/AppVersion-0.6.12-informational?style=flat-square)
 
-Helm chart to deploy run kube-bench as a cronjob on gke or eks.
+Helm chart to deploy run kube-bench as a cronjob on aks, gke or eks.
 
 **Homepage:** <https://github.com/aquasecurity/kube-bench>
 
@@ -50,15 +50,33 @@ helm install my-release deliveryhero/kube-bench -f values.yaml
 | concurrencyPolicy | string | `"Forbid"` |  |
 | cronjob.command | list | `[]` |  |
 | cronjob.schedule | string | `"0 0 1 * *"` |  |
+| extraLabels | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"aquasec/kube-bench"` |  |
-| image.tag | string | `"0.4.0"` |  |
+| image.tag | string | `"v0.6.12"` |  |
+| nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | provider | string | `"eks"` |  |
 | resources | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | tolerations | list | `[]` |  |
+| volumeMounts[0].mountPath | string | `"/var/lib/kubelet"` |  |
+| volumeMounts[0].name | string | `"var-lib-kubelet"` |  |
+| volumeMounts[0].readOnly | bool | `true` |  |
+| volumeMounts[1].mountPath | string | `"/etc/systemd"` |  |
+| volumeMounts[1].name | string | `"etc-systemd"` |  |
+| volumeMounts[1].readOnly | bool | `true` |  |
+| volumeMounts[2].mountPath | string | `"/etc/kubernetes"` |  |
+| volumeMounts[2].name | string | `"etc-kubernetes"` |  |
+| volumeMounts[2].readOnly | bool | `true` |  |
+| volumes[0].hostPath.path | string | `"/var/lib/kubelet"` |  |
+| volumes[0].name | string | `"var-lib-kubelet"` |  |
+| volumes[1].hostPath.path | string | `"/etc/systemd"` |  |
+| volumes[1].name | string | `"etc-systemd"` |  |
+| volumes[2].hostPath.path | string | `"/etc/kubernetes"` |  |
+| volumes[2].name | string | `"etc-kubernetes"` |  |
 
 ## Maintainers
 

--- a/stable/kube-bench/templates/_helpers.tpl
+++ b/stable/kube-bench/templates/_helpers.tpl
@@ -1,3 +1,53 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kube-bench.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kube-bench.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kube-bench.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kube-bench.labels" -}}
+app.kubernetes.io/name: {{ include "kube-bench.name" . }}
+helm.sh/chart: {{ include "kube-bench.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels }}
+{{- end }}
+{{- end -}}
+
+
 {{/*
 Return the appropriate apiVersion for cronjob APIs.
 */}}
@@ -15,13 +65,17 @@ Return the appropriate apiVersion for cronjob APIs.
 Return appropriate command given the provider
 */}}
 {{- define "cronjob.command" -}}
-{{- if hasKey .Values.cronjob "command" -}}
+{{- if ne (join "" .Values.cronjob.command) "" -}}
 {{ toJson .Values.cronjob.command }}
 {{- else -}}
 {{- if eq "gke" .Values.provider -}}
-["kube-bench", "--benchmark", "gke-1.0", "run", "--targets", "node,policies,managedservices"]
+["kube-bench", "--benchmark", "gke-1.2.0", "run", "--targets", "node,policies,managedservices"]
+{{- else if eq "aks" .Values.provider -}}
+["kube-bench", "--benchmark", "aks-1.0", "run", "--targets", "node"]
+{{- else if eq "eks" .Values.provider -}}
+["kube-bench", "--benchmark", "eks-1.1.0", "run", "--targets", "node"]
 {{- else -}}
-["kube-bench", "node", "--benchmark", "eks-1.0"]
+["kube-bench"]
 {{- end }}
 {{- end -}}
 {{- end -}}

--- a/stable/kube-bench/templates/cron.yaml
+++ b/stable/kube-bench/templates/cron.yaml
@@ -1,12 +1,15 @@
+---
 apiVersion: {{ template "cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
-  name: kube-bench
+  name: {{ template "kube-bench.fullname" . }}
+  labels: {{ include "kube-bench.labels" . | nindent 4 }}
 spec:
   schedule: {{ quote .Values.cronjob.schedule }}
   concurrencyPolicy: "{{ .Values.concurrencyPolicy }}"
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         spec:
           {{- if .Values.serviceAccount.create }}
@@ -15,41 +18,23 @@ spec:
           hostPID: true
           restartPolicy: Never
           containers:
-            - name: kube-bench
+            - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: {{ template "cronjob.command" . }}
-              resources:
-              {{ toYaml .Values.resources | indent 14 }}
-              volumeMounts:
-                - name: var-lib-kubelet
-                  mountPath: /var/lib/kubelet
-                  readOnly: true
-                - name: etc-systemd
-                  mountPath: /etc/systemd
-                  readOnly: true
-                - name: etc-kubernetes
-                  mountPath: /etc/kubernetes
-                  readOnly: true
-          volumes:
-            - name: var-lib-kubelet
-              hostPath:
-                path: "/var/lib/kubelet"
-            - name: etc-systemd
-              hostPath:
-                path: "/etc/systemd"
-            - name: etc-kubernetes
-              hostPath:
-                path: "/etc/kubernetes"
-    {{- with .Values.nodeSelector }}
-          nodeSelector:
-{{ toYaml . | indent 12 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-          affinity:
-{{ toYaml . | indent 12 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-          tolerations:
-{{ toYaml . | indent 12 }}
-    {{- end }}
+              resources: {{ toYaml .Values.resources | nindent 16 }}
+              {{- with .Values.volumeMounts }}
+              volumeMounts: {{ toYaml . | nindent 16 }}
+              {{- end }}
+          {{- with .Values.volumes }}
+          volumes: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations: {{ toYaml . | nindent 12 }}
+          {{- end }}

--- a/stable/kube-bench/templates/serviceaccount.yaml
+++ b/stable/kube-bench/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/stable/kube-bench/values.yaml
+++ b/stable/kube-bench/values.yaml
@@ -1,3 +1,7 @@
+---
+nameOverride: ""
+fullnameOverride: ""
+
 provider: eks
 
 cronjob:
@@ -6,7 +10,7 @@ cronjob:
 
 image:
   repository: aquasec/kube-bench
-  tag: 0.4.0
+  tag: v0.6.12
   pullPolicy: IfNotPresent
 
 serviceAccount:
@@ -15,8 +19,30 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
 
+extraLabels: {}
 resources: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
 concurrencyPolicy: Forbid
+
+volumes:
+  - name: var-lib-kubelet
+    hostPath:
+      path: "/var/lib/kubelet"
+  - name: etc-systemd
+    hostPath:
+      path: "/etc/systemd"
+  - name: etc-kubernetes
+    hostPath:
+      path: "/etc/kubernetes"
+volumeMounts:
+  - name: var-lib-kubelet
+    mountPath: /var/lib/kubelet
+    readOnly: true
+  - name: etc-systemd
+    mountPath: /etc/systemd
+    readOnly: true
+  - name: etc-kubernetes
+    mountPath: /etc/kubernetes
+    readOnly: true


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

### Changes

* bump kube-bench chart version to 0.1.7
* add aks support
* update cis benchmark for gke to 1.2.0
* update cis benchmark for eks to 1.1.0
* update kube-bench image to v0.6.12
* make volumes and volumeMounts configurable
* make jobname configurable to enable multiple deployments of the cronjob with different settings
* fix indent for container resources
* fix cronjob.command has no value if not overwritten by the deployment
* set backoffLimit to 0 to avoid reruns when kube-bench fails
* bump api chart version to v2

### Helmfile example for aks

I would like to use this chart to deploy kube-bench into our AKS Cluster.
This required different volume mounts and a different benchmark.

```yaml
---
repositories:
  - name: deliveryhero
    url: https://charts.deliveryhero.io/

releases:
  - name: kube-bench-aks
    namespace: kube-bench
    chart: /home/daniel/src/deliveryhero-helm-charts/stable/kube-bench
    values:
      - jobName: kube-bench-aks
      - cronjob:
          command:
            - kube-bench
            - --benchmark
            - aks-1.0
            - run
            - --targets
            - controlplane,managedservices,master,node,policies
      - provider: aks
      - volumeMounts:
          - name: var-lib-kubelet
            mountPath: /var/lib/kubelet
            readOnly: true
          - name: etc-systemd
            mountPath: /etc/systemd
            readOnly: true
          - name: etc-default
            mountPath: /etc/default
            readOnly: true
          - name: etc-kubernetes
            mountPath: /etc/kubernetes
            readOnly: true
          - name: usr-local-bin
            mountPath: /usr/local/mount-from-host/bin
            readOnly: true
      - volumes:
          - name: var-lib-kubelet
            hostPath:
              path: "/var/lib/kubelet"
          - name: etc-systemd
            hostPath:
              path: "/etc/systemd"
          - name: etc-default
            hostPath:
              path: "/etc/default"
          - name: etc-kubernetes
            hostPath:
              path: "/etc/kubernetes"
          - name: usr-local-bin
            hostPath:
              path: "/usr/local/bin"

```


## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
