### PR TITLE
[stable/locust] allow to configure nodeSelector, tolerations, affinity for worker explicitly

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.31.2"
+version: "0.31.3"
 appVersion: 2.15.1
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.31.2](https://img.shields.io/badge/Version-0.31.2-informational?style=flat-square) ![AppVersion: 2.15.1](https://img.shields.io/badge/AppVersion-2.15.1-informational?style=flat-square)
+![Version: 0.31.3](https://img.shields.io/badge/Version-0.31.3-informational?style=flat-square) ![AppVersion: 2.15.1](https://img.shields.io/badge/AppVersion-2.15.1-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -120,6 +120,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | service.extraLabels | object | `{}` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |
+| worker.affinity | object | `{}` | Overwrites affinity from global |
 | worker.args | list | `[]` | Any extra command args for the workers |
 | worker.command[0] | string | `"sh"` |  |
 | worker.command[1] | string | `"/config/docker-entrypoint.sh"` |  |
@@ -132,12 +133,14 @@ helm install my-release deliveryhero/locust -f values.yaml
 | worker.hpa.targetCPUUtilizationPercentage | int | `40` |  |
 | worker.image | string | `""` | A custom docker image including tag |
 | worker.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
+| worker.nodeSelector | object | `{}` | Overwrites nodeSelector from global |
 | worker.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the worker pods |
 | worker.replicas | int | `1` |  |
 | worker.resources | object | `{}` | resources for the locust worker |
 | worker.restartPolicy | string | `"Always"` | worker pod's restartPolicy. Can be Always, OnFailure, or Never. |
 | worker.serviceAccountAnnotations | object | `{}` |  |
 | worker.strategy.type | string | `"RollingUpdate"` |  |
+| worker.tolerations | list | `[]` | Overwrites tolerations from global |
 
 ## Maintainers
 

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -143,15 +143,36 @@ spec:
 {{- if .Values.loadtest.mount_external_secret }}
 {{- include "locust.external_secret.volume" . | nindent 8 }}
 {{- end }}
+{{- if .Values.worker.nodeSelector }}
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{ else if .Values.nodeSelector }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{ end }}
+{{- if .Values.worker.affinity }}
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{ else if .Values.affinity }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{ end }}
+{{- if .Values.worker.tolerations }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{ else if .Values.tolerations }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{ end }}

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -130,6 +130,13 @@ worker:
     type: RollingUpdate
   # worker.restartPolicy -- worker pod's restartPolicy. Can be Always, OnFailure, or Never.
   restartPolicy: Always
+  # worker.nodeSelector -- Overwrites nodeSelector from global
+  nodeSelector: {}
+  # worker.tolerations -- Overwrites tolerations from global
+  tolerations: []
+  # worker.affinity -- Overwrites affinity from global
+  affinity: {}
+
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
Allow to configure nodeSelector, tolerations, affinity for worker explicitly.
It will be very useful where master is running using default node pool (so, no need to specify any toleration and affinity), but workers are needed to run on spot instances, which is in another node pool with specific taints. So, in that case, we need to configure only worker deployment

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
