### PR TITLE
[stable/locust]: Fixes locust extra labels on pods

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.31.3"
+version: "0.31.4"
 appVersion: 2.15.1
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.31.3](https://img.shields.io/badge/Version-0.31.3-informational?style=flat-square) ![AppVersion: 2.15.1](https://img.shields.io/badge/AppVersion-2.15.1-informational?style=flat-square)
+![Version: 0.31.4](https://img.shields.io/badge/Version-0.31.4-informational?style=flat-square) ![AppVersion: 2.15.1](https://img.shields.io/badge/AppVersion-2.15.1-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         checksum/config-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         component: master
-        {{- include "locust.selectorLabels" . | nindent 8 }}
+        {{- include "locust.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         checksum/config-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         component: worker
-        {{- include "locust.selectorLabels" . | nindent 8 }}
+        {{- include "locust.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Labels for the pods are not being correctly propagated, it is adding selector labels instead. (Note, locust.labels includes selector labels but also adds extra labels, as can be seen on helpers.tpl) 

```
{{- define "locust.labels" -}}
helm.sh/chart: {{ include "locust.chart" . }}
{{ include "locust.selectorLabels" . }}
{{- if .Chart.AppVersion }}
app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
{{- end }}
app.kubernetes.io/managed-by: {{ .Release.Service }}
{{- range $key, $value := .Values.extraLabels }}
{{ $key }}: {{ $value | quote }}
{{- end }}
{{- end }}
```

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [X] Github actions are passing
