### PR TITLE
[stable/kube-bench] Update kube-bench image to 0.6.14

### DIFF
--- a/stable/kube-bench/Chart.yaml
+++ b/stable/kube-bench/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 0.6.13
+appVersion: 0.6.14
 description: "Helm chart to deploy run kube-bench as a cronjob on aks, gke or eks."
 name: kube-bench
-version: 0.1.8
+version: 0.1.9
 home: https://github.com/aquasecurity/kube-bench
 icon: https://raw.githubusercontent.com/aquasecurity/kube-bench/0d1bd2bbd95608957be024c12d03a0510325e5e2/docs/images/kube-bench.png
 sources:

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -1,6 +1,6 @@
 # kube-bench
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![AppVersion: 0.6.13](https://img.shields.io/badge/AppVersion-0.6.13-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![AppVersion: 0.6.14](https://img.shields.io/badge/AppVersion-0.6.14-informational?style=flat-square)
 
 Helm chart to deploy run kube-bench as a cronjob on aks, gke or eks.
 
@@ -54,7 +54,7 @@ helm install my-release deliveryhero/kube-bench -f values.yaml
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"aquasec/kube-bench"` |  |
-| image.tag | string | `"v0.6.13"` |  |
+| image.tag | string | `"v0.6.14"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | provider | string | `"eks"` |  |

--- a/stable/kube-bench/values.yaml
+++ b/stable/kube-bench/values.yaml
@@ -10,7 +10,7 @@ cronjob:
 
 image:
   repository: aquasec/kube-bench
-  tag: v0.6.13
+  tag: v0.6.14
   pullPolicy: IfNotPresent
 
 serviceAccount:


### PR DESCRIPTION
* bump kube-bench chart version to 0.1.9

## Description

Update kube-bench image to 0.6.14

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
