### PR TITLE
[stable/kube-bench] Add podLabels to kube-bench chart

### DIFF
--- a/stable/kube-bench/Chart.yaml
+++ b/stable/kube-bench/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 0.6.14
 description: "Helm chart to deploy run kube-bench as a cronjob on aks, gke or eks."
 name: kube-bench
-version: 0.1.9
+version: 0.1.10
 home: https://github.com/aquasecurity/kube-bench
 icon: https://raw.githubusercontent.com/aquasecurity/kube-bench/0d1bd2bbd95608957be024c12d03a0510325e5e2/docs/images/kube-bench.png
 sources:

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -1,6 +1,6 @@
 # kube-bench
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![AppVersion: 0.6.14](https://img.shields.io/badge/AppVersion-0.6.14-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![AppVersion: 0.6.14](https://img.shields.io/badge/AppVersion-0.6.14-informational?style=flat-square)
 
 Helm chart to deploy run kube-bench as a cronjob on aks, gke or eks.
 

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -57,6 +57,7 @@ helm install my-release deliveryhero/kube-bench -f values.yaml
 | image.tag | string | `"v0.6.14"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | provider | string | `"eks"` |  |
 | resources | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/stable/kube-bench/templates/cron.yaml
+++ b/stable/kube-bench/templates/cron.yaml
@@ -11,6 +11,11 @@ spec:
     spec:
       backoffLimit: 0
       template:
+        {{- with .Values.podLabels }}
+        metadata:
+          labels:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
         spec:
           {{- if .Values.serviceAccount.create }}
           serviceAccountName: kube-bench

--- a/stable/kube-bench/values.yaml
+++ b/stable/kube-bench/values.yaml
@@ -20,6 +20,7 @@ serviceAccount:
   annotations: {}
 
 extraLabels: {}
+podLabels: {}
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

So we can add specific labels to `kube-bench` pods and not only the deployment

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
