### PR TITLE
[stable/node-local-dns] Allow health endpoint port override

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.22.20
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -51,6 +51,7 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | affinity | object | `{}` |  |
 | config.dnsDomain | string | `"cluster.local"` |  |
 | config.dnsServer | string | `"172.20.0.10"` |  |
+| config.healthPort | int | `8080` |  |
 | config.localDns | string | `"169.254.20.25"` |  |
 | dashboard.annotations | object | `{}` |  |
 | dashboard.enabled | bool | `false` |  |

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
                 force_tcp
         }
         prometheus :9253
-        health {{ .Values.config.localDns }}:8080
+        health {{ .Values.config.localDns }}:{{ .Values.config.healthPort }}
         }
     in-addr.arpa:53 {
         errors

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
           httpGet:
             host: {{ .Values.config.localDns }}
             path: /health
-            port: 8080
+            port: {{ .Values.config.healthPort }}
           initialDelaySeconds: 60
           timeoutSeconds: 5
         volumeMounts:

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -13,6 +13,9 @@ config:
   # Virtual IP to be used by ipvs mode, to be used as --cluster-dns, must not collide.
   localDns: "169.254.20.25"
 
+  # Port used for the health endpoint
+  healthPort: 8080
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Hello, here's a small change to allow overriding the `health` endpoint port in some cases where this port is already used by other components.
As an example, Kured is also using `8080` and thus `NodeLocal DNSCache` is failing :
```bash
listen tcp 169.254.20.20:8080: bind: address already in use
```
```bash
$> sudo netstat -nltp | grep 8080
tcp6       0      0 :::8080                 :::*                    LISTEN      3839/kured
```

The modification is currently running fine in one of our k8s clusters.

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [X] Github actions are passing
