### PR TITLE
[stable/aws-storage-class] Remove the gp2 storageclass from default values file.

### DIFF
--- a/stable/aws-storage-class/Chart.yaml
+++ b/stable/aws-storage-class/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aws-storage-class
-version: "0.1.6"
+version: "0.1.7"
 description: "Creates a StorageClass. From here: https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/storage-class/aws/default.yaml"
 home: https://github.com/deliveryhero/helm-charts
 maintainers:

--- a/stable/aws-storage-class/README.md
+++ b/stable/aws-storage-class/README.md
@@ -1,6 +1,6 @@
 # aws-storage-class
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square)
 
 Creates a StorageClass. From here: https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/storage-class/aws/default.yaml
 
@@ -60,10 +60,6 @@ helm install my-release deliveryhero/aws-storage-class -f values.yaml
 | storage_classes.ebs_io1_20.provisioner | string | `"ebs.csi.aws.com"` |  |
 | storage_classes.ebs_io1_20.type | string | `"io1"` |  |
 | storage_classes.ebs_io1_20.volumeBindingMode | string | `"WaitForFirstConsumer"` |  |
-| storage_classes.gp2.default | bool | `false` |  |
-| storage_classes.gp2.provisioner | string | `"kubernetes.io/aws-ebs"` |  |
-| storage_classes.gp2.type | string | `"gp2"` |  |
-| storage_classes.gp2.volumeBindingMode | string | `"WaitForFirstConsumer"` |  |
 
 ## Maintainers
 

--- a/stable/aws-storage-class/values.yaml
+++ b/stable/aws-storage-class/values.yaml
@@ -1,9 +1,4 @@
 storage_classes:
-  gp2:
-    default: false
-    volumeBindingMode: WaitForFirstConsumer
-    provisioner: "kubernetes.io/aws-ebs"
-    type: "gp2"
   ebs_gp2:
     default: false
     type: "gp2"


### PR DESCRIPTION
## Description

Remove the gp2 storageclass from default values file, to avoid the default creation from the upstream/base chart, however this can be created by providing in the specific values.


## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
