### PR TITLE
[stable/aws-s3-proxy]: Support k8s 1.19 Ingress

### DIFF
--- a/stable/aws-s3-proxy/templates/ingress.yaml
+++ b/stable/aws-s3-proxy/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -29,13 +32,13 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
         {{- range .paths }}
-          - paht: {{ . }}
+          - path: {{ . }}
             pathType: Prefix
             backend:
               service:
@@ -44,7 +47,7 @@ spec:
                   number: {{ $svcPort }}
         {{- end }}
   {{- end }}
-  {{- else -}}
+  {{- else }}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:

--- a/stable/aws-s3-proxy/templates/ingress.yaml
+++ b/stable/aws-s3-proxy/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "aws-s3-proxy.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -27,6 +29,22 @@ spec:
   {{- end }}
 {{- end }}
   rules:
+  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - paht: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+  {{- else -}}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
@@ -37,5 +55,6 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
         {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/aws-s3-proxy/values.yaml
+++ b/stable/aws-s3-proxy/values.yaml
@@ -43,6 +43,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # ingressClassName: nginx
   hosts:
     - host: chart-example.local
       paths: []


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Ingress of `aws-s3-proxy` only support `networking.k8s.io/v1beta1` and `extensions/v1beta1`, so it cannot be deployed over k8s 1.19 versions.

So, add if-else statements to support `networking.k8s.io/v1` apiVersion. This change is compatible to k8s 1.19 under version, so don't worry :)


## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
