### PR TITLE
[stable/kube-downscaler]: Add inactive_in option and update default a…

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,7 +1,7 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.7.1"
-appVersion: 22.9.0
+version: "0.7.2"
+appVersion: 23.2.0
 description: Scale down Kubernetes deployments after work hours
 keywords:
 - k8s pods scheduler

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![AppVersion: 22.9.0](https://img.shields.io/badge/AppVersion-22.9.0-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![AppVersion: 23.2.0](https://img.shields.io/badge/AppVersion-23.2.0-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 

--- a/stable/kube-downscaler/templates/deployment.yaml
+++ b/stable/kube-downscaler/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
         {{- if .Values.namespace.active_in }}
         - --namespace={{ .Values.namespace.active_in }}
         {{- end }}
+        {{- if .Values.namespace.inactive_in }}
+        - --exclude-namespaces={{ .Values.namespace.inactive_in | join "," }}
+        {{- end }}
         {{- end }}
         {{- if .Values.debug.enable }}
         - --debug

--- a/stable/kube-downscaler/values.yaml
+++ b/stable/kube-downscaler/values.yaml
@@ -11,6 +11,7 @@ events:
 # namespace:
   ## Deployment will query all namespaces if left empty:
 #  active_in:
+#  inactive_in:
 ## How frequently kube-downscaler should query applications uptime, unit is in seconds.
 
 ## Default is 60 seconds


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Sorry messed up the last PR!

I added an option to exlude_namespaces from scaling down like in the official "unsupported" helm chart. Furthermore, i increased the appVersion to the latest available image.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
