### PR TITLE
[stable/node-local-dns] feat: add servicemonitor custom labels

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 1.0.1
+version: 1.1.0
 appVersion: 1.22.20
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -70,6 +70,7 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.labels | object | `{}` |  |
 
 ## Maintainers
 

--- a/stable/node-local-dns/templates/servicemonitor.yaml
+++ b/stable/node-local-dns/templates/servicemonitor.yaml
@@ -4,6 +4,10 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "node-local-dns.fullname" . }}
   namespace: kube-system
+  {{- if .Values.serviceMonitor.labels }}
+  labels:
+  {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+  {{- end }}
 spec:
   endpoints:
     - port: metrics

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -34,6 +34,7 @@ podAnnotations: {}
 serviceMonitor:
   # Ensure that servicemonitor is created
   enabled: false
+  labels: {}
 
 # https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md
 dashboard:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Adding additional labels on ServiceMonitor to allow for customization experience

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
