### PR TITLE
[stable/node-local-dns] feat: Add option to specify protocol used for upstream

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.22.20
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -49,6 +49,7 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| config.commProtocol | string | `"force_tcp"` |  |
 | config.dnsDomain | string | `"cluster.local"` |  |
 | config.dnsServer | string | `"172.20.0.10"` |  |
 | config.healthPort | int | `8080` |  |

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
         loop
         bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
         forward . __PILLAR__CLUSTER__DNS__ {
-                force_tcp
+                {{ .Values.config.commProtocol }}
         }
         prometheus :9253
         health {{ .Values.config.localDns }}:{{ .Values.config.healthPort }}
@@ -30,7 +30,7 @@ data:
         loop
         bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
         forward . __PILLAR__CLUSTER__DNS__ {
-                force_tcp
+                {{ .Values.config.commProtocol }}
         }
         prometheus :9253
         }
@@ -41,7 +41,7 @@ data:
         loop
         bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
         forward . __PILLAR__CLUSTER__DNS__ {
-                force_tcp
+                {{ .Values.config.commProtocol }}
         }
         prometheus :9253
         }

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -13,6 +13,9 @@ config:
   # Virtual IP to be used by ipvs mode, to be used as --cluster-dns, must not collide.
   localDns: "169.254.20.25"
 
+  # Set communication protocol. Options are `prefer_udp` or `force_tcp`
+  commProtocol: "force_tcp"
+
   # Port used for the health endpoint
   healthPort: 8080
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

This will allow to specify protocol used for upstream communication. CoreDNS is sometimes tricky to adjust on Cloud Providers so it would be easier to specify it here as well. Especially current hardcoded value is tricky as in case if both force_tcp and prefer_udp options are specified the force_tcp takes precedence.

More info [here](https://coredns.io/plugins/forward/)

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing