### PR TITLE
[stable/prometheus-spot-termination-exporter] Add extra labels support into spot termination exporter

### DIFF
--- a/stable/prometheus-spot-termination-exporter/Chart.yaml
+++ b/stable/prometheus-spot-termination-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.0.1"
+appVersion: "0.0.2"
 description: Spot instance termination exporter for Prometheus
 name: prometheus-spot-termination-exporter
-version: 0.2.8
+version: 0.2.9
 home: https://github.com/banzaicloud/spot-termination-exporter
 sources:
   - https://github.com/banzaicloud/spot-termination-exporter

--- a/stable/prometheus-spot-termination-exporter/README.md
+++ b/stable/prometheus-spot-termination-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-spot-termination-exporter
 
-![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![AppVersion: 0.0.2](https://img.shields.io/badge/AppVersion-0.0.2-informational?style=flat-square)
 
 Spot instance termination exporter for Prometheus
 

--- a/stable/prometheus-spot-termination-exporter/templates/daemonset.yaml
+++ b/stable/prometheus-spot-termination-exporter/templates/daemonset.yaml
@@ -22,6 +22,23 @@ spec:
         prometheus.io/path: "{{ .Values.prometheus.metricsPath }}"
 
     spec:
+      volumes:
+      - name: node-data
+        emptyDir: {}
+      initContainers:
+      - name: init
+        image: scottcrossen/kube-node-labels:1.1.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OUTPUT_DIR
+          value: /output
+        volumeMounts:
+        - name: node-data
+          mountPath: /output
       containers:
       - name: spot-termination-exporter
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -35,6 +52,7 @@ spec:
           --metrics-path {{ .Values.prometheus.metricsPath }} \
           --metadata-endpoint {{ .Values.metadataEndpoint }} \
           --log-level {{ .Values.logLevel }}
+          --extra-labels node_group=$(/node-data/labels.sh node-group)
         ports:
         - name: http
           containerPort: {{ .Values.port }}
@@ -55,6 +73,10 @@ spec:
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+
+        volumeMounts:
+        - name: node-data
+          mountPath: /node-data
     {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Add extra labels support into spot termination exporter

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
