### PR TITLE
[stable/node-local-dns] Disable prometheus annotations when servicemonitor is enabled

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.22.20
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
 
 A chart to install node-local-dns.
 

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -16,9 +16,13 @@ spec:
     metadata:
       labels:
         k8s-app: {{ include "node-local-dns.name" . }}
+      {{- if or .Values.podAnnotations (not .Values.serviceMonitor.enabled) }}
       annotations:
+      {{- end }}
+        {{- if not .Values.serviceMonitor.enabled }}
         prometheus.io/port: "9253"
         prometheus.io/scrape: "true"
+        {{- end }}
         {{- if .Values.podAnnotations }}
           {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}

--- a/stable/node-local-dns/templates/service.yaml
+++ b/stable/node-local-dns/templates/service.yaml
@@ -5,9 +5,11 @@ metadata:
   namespace: kube-system
   labels:
     {{- include "node-local-dns.labels" . | nindent 4 }}
+  {{- if not .Values.serviceMonitor.enabled }}
   annotations:
     prometheus.io/port: "9253"
     prometheus.io/scrape: "true"
+  {{- end }}
 spec:
   clusterIP: None
   ports:

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -40,7 +40,7 @@ securityContext:
 
 # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md
 serviceMonitor:
-  # Ensure that servicemonitor is created
+  # Ensure that servicemonitor is created, this will disable prometheus annotations
   enabled: false
   labels: {}
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->
Prometheus annotations for scraping should not be present when using servicemonitor. I disable them when servicemonitor is enabled.

My use-case is:
- We are in the process in switching from annotation based scraping to prometheus operator with servicemonitor.
- We have to maintain annotation based scraping configuration to support services not yet migrated.
- If there are both annotations and servicemonitor, metrics are scrapped 2 times.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
