### PR TITLE
[stable/gripmock] Expose stubs api

### DIFF
--- a/stable/gripmock/templates/service.yaml
+++ b/stable/gripmock/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: 4770
       protocol: TCP
       name: grpc
+    - port: 4771
+      targetPort: 4771
+      protocol: TCP
+      name: stubs
   selector:
     {{- include "gripmock.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## Description

Extend the service to expose port 4771

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
