### PR TITLE
[stable/kube-bench] Update kube-bench image to 0.6.17

### DIFF
--- a/stable/kube-bench/Chart.yaml
+++ b/stable/kube-bench/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 0.6.16
+appVersion: 0.6.17
 description: "Helm chart to deploy run kube-bench as a cronjob on aks, gke or eks."
 name: kube-bench
-version: 0.1.12
+version: 0.1.13
 home: https://github.com/aquasecurity/kube-bench
 icon: https://raw.githubusercontent.com/aquasecurity/kube-bench/0d1bd2bbd95608957be024c12d03a0510325e5e2/docs/images/kube-bench.png
 sources:

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -1,6 +1,6 @@
 # kube-bench
 
-![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![AppVersion: 0.6.16](https://img.shields.io/badge/AppVersion-0.6.16-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![AppVersion: 0.6.17](https://img.shields.io/badge/AppVersion-0.6.17-informational?style=flat-square)
 
 Helm chart to deploy run kube-bench as a cronjob on aks, gke or eks.
 
@@ -54,12 +54,13 @@ helm install my-release deliveryhero/kube-bench -f values.yaml
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"aquasec/kube-bench"` |  |
-| image.tag | string | `"v0.6.16"` |  |
+| image.tag | string | `"v0.6.17"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | provider | string | `"eks"` |  |
 | resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | tolerations | list | `[]` |  |

--- a/stable/kube-bench/templates/cron.yaml
+++ b/stable/kube-bench/templates/cron.yaml
@@ -31,6 +31,9 @@ spec:
               {{- with .Values.volumeMounts }}
               volumeMounts: {{ toYaml . | nindent 16 }}
               {{- end }}
+              {{- with .Values.securityContext }}
+              securityContext: {{ toYaml . | nindent 16 }}
+              {{- end }}
           {{- with .Values.volumes }}
           volumes: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/stable/kube-bench/values.yaml
+++ b/stable/kube-bench/values.yaml
@@ -10,7 +10,7 @@ cronjob:
 
 image:
   repository: aquasec/kube-bench
-  tag: v0.6.16
+  tag: v0.6.17
   pullPolicy: IfNotPresent
 
 serviceAccount:
@@ -18,6 +18,14 @@ serviceAccount:
   create: false
   # Annotations to add to the service account
   annotations: {}
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+# runAsUser: 1000
 
 extraLabels: {}
 podLabels: {}


### PR DESCRIPTION
* bump kube-bench chart version to 0.1.13
* enable configuration of the cronjob security context

## Description

Updated the chart to use the 0.6.17 kube-bench image and created a variable to enable the configuration for the container security context.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
