### PR TITLE
[stable/gripmock] allow exposing other ports than 4770

### DIFF
--- a/stable/gripmock/Chart.yaml
+++ b/stable/gripmock/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   >
   > Version v1.11.1-beta release is available by overriding the `image.tag` in your `values.yaml` file. This version supports **NO** declaration of `go_package`.
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.10.1"
 maintainers:
   - name: MarceloAplanalp

--- a/stable/gripmock/README.md
+++ b/stable/gripmock/README.md
@@ -1,6 +1,6 @@
 # gripmock
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.1](https://img.shields.io/badge/AppVersion-1.10.1-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.1](https://img.shields.io/badge/AppVersion-1.10.1-informational?style=flat-square)
 
 A chart to install [gripmock](https://github.com/tokopedia/gripmock). A mock server for GRPC services. It uses `.proto` file(s) to generate the implementation of gRPC service(s) for you.
 
@@ -65,6 +65,10 @@ helm install my-release deliveryhero/gripmock -f values.yaml
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.hosts[0].paths[0].port | int | `4770` |  |
+| ingress.hosts[0].paths[1].path | string | `"/"` |  |
+| ingress.hosts[0].paths[1].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.hosts[0].paths[1].port | int | `4471` |  |
 | ingress.tls | list | `[]` |  |
 | labels | object | `{}` | Any extra label to apply to all resources |
 | nameOverride | string | `""` |  |

--- a/stable/gripmock/templates/ingress.yaml
+++ b/stable/gripmock/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "gripmock.fullname" . -}}
-{{- $svcPort := 4770 -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -51,10 +50,10 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ $svcPort }}
+                  number: {{ .port | default 4770 }}
               {{- else }}
               serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              servicePort: {{ .port | default 4770 }}
               {{- end }}
           {{- end }}
     {{- end }}

--- a/stable/gripmock/values.yaml
+++ b/stable/gripmock/values.yaml
@@ -45,6 +45,10 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
+          port: 4770
+        - path: /
+          pathType: ImplementationSpecific
+          port: 4471
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Allow exposing multiple ports in the ingress controller instead of the hardcoded 4770

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
