### PR TITLE
[stable/node-local-dns] support podlabels and ds labels, annotations

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 1.1.4
+version: 1.1.5
 appVersion: 1.22.20
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -57,6 +57,8 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | config.setupInterface | bool | `false` |  |
 | config.setupIptables | bool | `false` |  |
 | config.skipTeardown | bool | `true` |  |
+| daemonsetAnnotations | object | `{}` |  |
+| daemonsetLabels | object | `{}` |  |
 | dashboard.annotations | object | `{}` |  |
 | dashboard.enabled | bool | `false` |  |
 | dashboard.label | string | `"grafana_dashboard"` |  |
@@ -67,6 +69,7 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | resources.limits.memory | string | `"128Mi"` |  |
 | resources.requests.cpu | string | `"25m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -3,8 +3,15 @@ kind: DaemonSet
 metadata:
   name: {{ include "node-local-dns.fullname" . }}
   namespace: kube-system
+  {{- with .Values.daemonsetAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "node-local-dns.labels" . | nindent 4 }}
+  {{- with .Values.daemonsetLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   updateStrategy:
     rollingUpdate:
@@ -15,6 +22,9 @@ spec:
   template:
     metadata:
       labels:
+      {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+      {{- end }}
         k8s-app: {{ include "node-local-dns.name" . }}
       {{- if or .Values.podAnnotations (not .Values.serviceMonitor.enabled) }}
       annotations:

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -39,6 +39,12 @@ serviceAccount:
 
 podAnnotations: {}
 
+podLabels: {}
+
+daemonsetAnnotations: {}
+
+daemonsetLabels: {}
+
 securityContext:
   capabilities:
     add:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Adding support for configuring custom DaemonSet Annotations and Labels and Pod Labels.

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
