### PR TITLE
[stable/node-local-dns]: feat(node-local-dns): add option to override coreDNS config

### DIFF
--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -50,6 +50,7 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | config.commProtocol | string | `"force_tcp"` |  |
+| config.customConfig | string | `""` |  |
 | config.dnsDomain | string | `"cluster.local"` |  |
 | config.dnsServer | string | `"172.20.0.10"` |  |
 | config.healthPort | int | `8080` |  |

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "node-local-dns.labels" . | nindent 4 }}
 data:
   Corefile: |
+    {{ if .Values.config.customConfig }}
+      {{ tpl .Values.config.customConfig . }}
+    {{ else }}
     {{ .Values.config.dnsDomain }}:53 {
         errors
         cache {
@@ -54,3 +57,4 @@ data:
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
         }
+    {{ end }}

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -25,6 +25,9 @@ config:
 
   skipTeardown: true
 
+  # Overrides the generated configuration with specified one.
+  customConfig: ""
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
## Description

Adds possiblity to completly override generated configuration. 

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
