### PR TITLE
[stable/node-problem-detector]: Adding support for defining volumeType of localtime

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.3.5"
+version: "2.3.6"
 appVersion: v0.8.13
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.5](https://img.shields.io/badge/Version-2.3.5-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
+![Version: 2.3.6](https://img.shields.io/badge/Version-2.3.6-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -93,6 +93,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | tolerations[0].effect | string | `"NoSchedule"` |  |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | string | `"RollingUpdate"` | Manage the daemonset update strategy |
+| volume.localtime.type | string | `"FileOrCreate"` |  |
 
 ## Maintainers
 

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -112,7 +112,7 @@ spec:
         - name: localtime
           hostPath:
             path: /etc/localtime
-            type: "FileOrCreate"
+            type: {{ default "FileOrCreate" .Values.volume.localtime.type }}
         - name: custom-config
           configMap:
             name: {{ include "node-problem-detector.customConfig" . }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -76,6 +76,10 @@ rbac:
 hostNetwork: false
 hostPID: false
 
+volume:
+  localtime:
+    type: "FileOrCreate"
+
 priorityClassName: system-node-critical
 
 securityContext:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
The changes in this PR is to add support for defining volumeType of volume named `localtime` in node-problem-detector DaemonSet template. The default is set to `FileOrCreate`.

<!--- Describe your changes in detail -->

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
