### PR TITLE
[stable/node-local-dns] Changes for cilium local redirect support

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 1.1.6
+version: 1.2.0
 appVersion: 1.22.23
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: node-local-dns
-version: 1.1.5
-appVersion: 1.22.20
+version: 1.1.6
+appVersion: 1.22.23
 maintainers:
 - name: gabrieladt
   email: no-reply@deliveryhero.com

--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 1.2.0
+version: 2.0.0
 appVersion: 1.22.23
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -52,7 +52,6 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | config.commProtocol | string | `"force_tcp"` |  |
 | config.dnsDomain | string | `"cluster.local"` |  |
 | config.dnsServer | string | `"172.20.0.10"` |  |
-| config.healthPort | int | `8080` |  |
 | config.localDns | string | `"169.254.20.25"` |  |
 | config.setupInterface | bool | `true` |  |
 | config.setupIptables | bool | `true` |  |

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
 
 A chart to install node-local-dns.
 

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -54,9 +54,9 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | config.dnsServer | string | `"172.20.0.10"` |  |
 | config.healthPort | int | `8080` |  |
 | config.localDns | string | `"169.254.20.25"` |  |
-| config.setupInterface | bool | `false` |  |
-| config.setupIptables | bool | `false` |  |
-| config.skipTeardown | bool | `true` |  |
+| config.setupInterface | bool | `true` |  |
+| config.setupIptables | bool | `true` |  |
+| config.skipTeardown | bool | `false` |  |
 | daemonsetAnnotations | object | `{}` |  |
 | daemonsetLabels | object | `{}` |  |
 | dashboard.annotations | object | `{}` |  |

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
 
 A chart to install node-local-dns.
 

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
+![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
 
 A chart to install node-local-dns.
 

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -16,19 +16,19 @@ data:
         }
         reload
         loop
-        bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
+        bind 0.0.0.0
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
         prometheus :9253
-        health {{ .Values.config.localDns }}:{{ .Values.config.healthPort }}
+        health
         }
     in-addr.arpa:53 {
         errors
         cache 30
         reload
         loop
-        bind {{ .Values.config.localDns }} {{ ternary (printf "%s" .Values.config.dnsServer) "" .Values.config.setupIptables }}
+        bind 0.0.0.0
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
@@ -39,7 +39,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ .Values.config.localDns }} {{ ternary (printf "%s" .Values.config.dnsServer) "" .Values.config.setupIptables }}
+        bind 0.0.0.0
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
@@ -50,7 +50,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ .Values.config.localDns }} {{ ternary (printf "%s" .Values.config.dnsServer) "" .Values.config.setupIptables }}
+        bind 0.0.0.0
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
         }

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
+        bind {{ .Values.config.localDns }} {{ ternary (printf "%s" .Values.config.dnsServer) "" .Values.config.setupIptables }}
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
@@ -39,7 +39,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
+        bind {{ .Values.config.localDns }} {{ ternary (printf "%s" .Values.config.dnsServer) "" .Values.config.setupIptables }}
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
@@ -50,7 +50,7 @@ data:
         cache 30
         reload
         loop
-        bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
+        bind {{ .Values.config.localDns }} {{ ternary (printf "%s" .Values.config.dnsServer) "" .Values.config.setupIptables }}
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
         }

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -75,8 +75,10 @@ spec:
           - "-skipteardown={{ .Values.config.skipTeardown }}"
           - "-setupinterface={{ .Values.config.setupInterface }}"
           - "-setupiptables={{ .Values.config.setupIptables }}"
+        {{- if .Values.config.setupIptables }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 53
           name: dns

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       priorityClassName: system-node-critical
       serviceAccountName: {{ include "node-local-dns.serviceAccountName" . }}
-      hostNetwork: true
+      hostNetwork: {{ .Values.config.setupIptables }}
       dnsPolicy: Default  # Don't use cluster DNS.
       tolerations:
       - key: "CriticalAddonsOnly"

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -61,8 +61,13 @@ spec:
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
         args:
+        {{- if .Values.config.setupIptables }}
           - "-localip"
           - "{{ .Values.config.localDns }},{{ .Values.config.dnsServer }}"
+        {{- else }}
+          - "-localip"
+          - "{{ .Values.config.localDns }}"
+        {{- end }}
           - "-conf"
           - "/etc/Corefile"
           - "-upstreamsvc"

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -89,9 +89,8 @@ spec:
           protocol: TCP
         livenessProbe:
           httpGet:
-            host: {{ .Values.config.localDns }}
             path: /health
-            port: {{ .Values.config.healthPort }}
+            port: 8080
           initialDelaySeconds: 60
           timeoutSeconds: 5
         volumeMounts:

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -19,11 +19,11 @@ config:
   # Port used for the health endpoint
   healthPort: 8080
 
-  setupInterface: false
+  setupInterface: true
 
-  setupIptables: false
+  setupIptables: true
 
-  skipTeardown: true
+  skipTeardown: false
 
 nameOverride: ""
 fullnameOverride: ""

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -16,9 +16,6 @@ config:
   # Set communication protocol. Options are `prefer_udp` or `force_tcp`
   commProtocol: "force_tcp"
 
-  # Port used for the health endpoint
-  healthPort: 8080
-
   setupInterface: true
 
   setupIptables: true


### PR DESCRIPTION
## Description
-  Return default configuration to be compatible  with iptables setup.
- add dnsServer to -localip only if setupIptables is true
- bind to dnsServer ip only if iptables setupIptables is true

## Checklist

- [v] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [v] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [v] Github actions are passing