### PR TITLE
[stable/prometheus-locust-exporter] Add ability to use relablings with ServiceMonitor

### DIFF
--- a/stable/prometheus-locust-exporter/Chart.yaml
+++ b/stable/prometheus-locust-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.4.1"
 description: A Helm chart a prometheus exporter locust load test metrics
 name: prometheus-locust-exporter
-version: 1.1.0
+version: 1.2.0
 home: https://github.com/ContainerSolutions/locust_exporter
 sources:
   - https://github.com/ContainerSolutions/locust_exporter

--- a/stable/prometheus-locust-exporter/README.md
+++ b/stable/prometheus-locust-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-locust-exporter
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square)
 
 A Helm chart a prometheus exporter locust load test metrics
 

--- a/stable/prometheus-locust-exporter/templates/service-monitor.yaml
+++ b/stable/prometheus-locust-exporter/templates/service-monitor.yaml
@@ -14,4 +14,12 @@ spec:
   - port: metrics
     path: /metrics
     interval: 30s
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end -}}

--- a/stable/prometheus-locust-exporter/values.yaml
+++ b/stable/prometheus-locust-exporter/values.yaml
@@ -70,6 +70,9 @@ service:
 serviceMonitor:
   # Enusre that service is created
   enabled: false
+  # relabelings: []
+  # metricRelabelings: []
+
 
 nodeSelector: {}
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->
These changes allow to enable  metric relabelings with ServiceMonitor.
## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [] Github actions are passing
