### PR TITLE
[stable/node-problem-detector] Add configurable servicemonitor relablings

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.3.6"
+version: "2.3.7"
 appVersion: v0.8.13
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.6](https://img.shields.io/badge/Version-2.3.6-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
+![Version: 2.3.7](https://img.shields.io/badge/Version-2.3.7-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -68,6 +68,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | metrics.annotations | object | `{}` | Override all default annotations when `metrics.enabled=true` with specified values. |
 | metrics.enabled | bool | `false` | Expose metrics in Prometheus format with default configuration. |
 | metrics.prometheusRule.additionalLabels | object | `{}` |  |
+| metrics.prometheusRule.additionalRelabelings | list | `[]` |  |
 | metrics.prometheusRule.additionalRules | list | `[]` |  |
 | metrics.prometheusRule.defaultRules.create | bool | `true` |  |
 | metrics.prometheusRule.defaultRules.disabled | list | `[]` |  |

--- a/stable/node-problem-detector/templates/servicemonitor.yaml
+++ b/stable/node-problem-detector/templates/servicemonitor.yaml
@@ -32,4 +32,7 @@ spec:
       targetLabel: host_ip
       sourceLabels:
         - __meta_kubernetes_pod_host_ip
+    {{- if .Values.metrics.serviceMonitor.additionalRelabelings }}
+    {{- toYaml .Values.metrics.serviceMonitor.additionalRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -120,6 +120,7 @@ metrics:
       create: true
       disabled: []
     additionalLabels: {}
+    additionalRelabelings: []
     additionalRules: []
 
 env:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
Add configurable relablings to the node-problem-detector servicemonitor

<!--- Describe your changes in detail -->
* Add `additionalRelabelings` value for node-problem-detector servicemonitor
* Add the additionalRelabelings if provided

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
