### PR TITLE
[stable/node-problem-detector]: servicemonitor metricsRelablings

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.3.8"
+version: "2.3.9"
 appVersion: v0.8.13
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -68,6 +68,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | metrics.annotations | object | `{}` | Override all default annotations when `metrics.enabled=true` with specified values. |
 | metrics.enabled | bool | `false` | Expose metrics in Prometheus format with default configuration. |
 | metrics.prometheusRule.additionalLabels | object | `{}` |  |
+| metrics.prometheusRule.additionalRelabelings | list | `[]` |  |
 | metrics.prometheusRule.additionalRules | list | `[]` |  |
 | metrics.prometheusRule.defaultRules.create | bool | `true` |  |
 | metrics.prometheusRule.defaultRules.disabled | list | `[]` |  |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.8](https://img.shields.io/badge/Version-2.3.8-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
+![Version: 2.3.9](https://img.shields.io/badge/Version-2.3.9-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -68,7 +68,6 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | metrics.annotations | object | `{}` | Override all default annotations when `metrics.enabled=true` with specified values. |
 | metrics.enabled | bool | `false` | Expose metrics in Prometheus format with default configuration. |
 | metrics.prometheusRule.additionalLabels | object | `{}` |  |
-| metrics.prometheusRule.additionalRelabelings | list | `[]` |  |
 | metrics.prometheusRule.additionalRules | list | `[]` |  |
 | metrics.prometheusRule.defaultRules.create | bool | `true` |  |
 | metrics.prometheusRule.defaultRules.disabled | list | `[]` |  |
@@ -76,6 +75,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | metrics.serviceMonitor.additionalLabels | object | `{}` |  |
 | metrics.serviceMonitor.additionalRelabelings | list | `[]` |  |
 | metrics.serviceMonitor.enabled | bool | `false` |  |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | priorityClassName | string | `"system-node-critical"` |  |

--- a/stable/node-problem-detector/templates/servicemonitor.yaml
+++ b/stable/node-problem-detector/templates/servicemonitor.yaml
@@ -35,4 +35,8 @@ spec:
     {{- if .Values.metrics.serviceMonitor.additionalRelabelings }}
     {{- toYaml .Values.metrics.serviceMonitor.additionalRelabelings | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -121,6 +121,7 @@ metrics:
       create: true
       disabled: []
     additionalLabels: {}
+    additionalRelabelings: []
     additionalRules: []
 
 env:

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -115,13 +115,13 @@ metrics:
     enabled: false
     additionalLabels: {}
     additionalRelabelings: []
+    metricRelabelings: []
   prometheusRule:
     enabled: false
     defaultRules:
       create: true
       disabled: []
     additionalLabels: {}
-    additionalRelabelings: []
     additionalRules: []
 
 env:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
Add `metricRelablings` to servicemonitor option

<!--- Describe your changes in detail -->
- Add optional value of type list to provide metricRelablings
- if metricRelablings provided, create the key and add the values

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
