### PR TITLE
stable/node-problem-detector Adding annotation and label options to the service account

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.3.8"
+version: "2.3.9"
 appVersion: v0.8.13
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.3.9"
+version: "2.3.10"
 appVersion: v0.8.13
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.9](https://img.shields.io/badge/Version-2.3.9-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
+![Version: 2.3.10](https://img.shields.io/badge/Version-2.3.10-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -83,6 +83,8 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | resources | object | `{}` |  |
 | securityContext.privileged | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.labels | object | `{}` |  |
 | serviceAccount.name | string | `nil` |  |
 | settings.custom_monitor_definitions | object | `{}` | Custom plugin monitor config files |
 | settings.custom_plugin_monitors | list | `[]` |  |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.8](https://img.shields.io/badge/Version-2.3.8-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
+![Version: 2.3.9](https://img.shields.io/badge/Version-2.3.9-informational?style=flat-square) ![AppVersion: v0.8.13](https://img.shields.io/badge/AppVersion-v0.8.13-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -82,8 +82,8 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | rbac.pspEnabled | bool | `false` |  |
 | resources | object | `{}` |  |
 | securityContext.privileged | bool | `true` |  |
-| serviceAccount.create | bool | `true` |  |
 | serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
 | serviceAccount.labels | object | `{}` |  |
 | serviceAccount.name | string | `nil` |  |
 | settings.custom_monitor_definitions | object | `{}` | Custom plugin monitor config files |

--- a/stable/node-problem-detector/templates/serviceaccount.yaml
+++ b/stable/node-problem-detector/templates/serviceaccount.yaml
@@ -8,5 +8,12 @@ metadata:
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+   {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -98,6 +98,10 @@ tolerations:
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # Labels to add to the service account
+  labels: {}
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
Adding annotation and label options to the service account in order to support IAM for Service Accounts in AWS.


## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
