### PR TITLE
[stable/wiremock] update PDB template

### DIFF
--- a/stable/wiremock/Chart.yaml
+++ b/stable/wiremock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wiremock
-version: "1.4.0"
+version: "1.4.1"
 appVersion: "2.26.0"
 home: http://wiremock.org/
 icon: http://wiremock.org/images/wiremock-concept-icon-01.png

--- a/stable/wiremock/README.md
+++ b/stable/wiremock/README.md
@@ -1,6 +1,6 @@
 # wiremock
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
 
 A service virtualization tool (some call it mock server) for testing purposes.
 

--- a/stable/wiremock/templates/pdb.yaml
+++ b/stable/wiremock/templates/pdb.yaml
@@ -2,9 +2,8 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "wiremock.fullname" . }}-master
+  name: {{ template "wiremock.fullname" . }}
   labels:
-    component: master
 {{ include "wiremock.labels" . | indent 4 }}
 spec:
   maxUnavailable: 0


### PR DESCRIPTION
## Description

This PR removes the unrelated component label and name suffix from PDB template.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
