### PR TITLE
[stable/node-local-dns]: feat(node-local-dns): add option to override coreDNS config

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.22.23
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
 
 A chart to install node-local-dns.
 

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -50,6 +50,7 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | config.commProtocol | string | `"force_tcp"` |  |
+| config.customConfig | string | `""` |  |
 | config.dnsDomain | string | `"cluster.local"` |  |
 | config.dnsServer | string | `"172.20.0.10"` |  |
 | config.localDns | string | `"169.254.20.25"` |  |

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "node-local-dns.labels" . | nindent 4 }}
 data:
   Corefile: |
+    {{ if .Values.config.customConfig }}
+      {{ tpl .Values.config.customConfig . }}
+    {{ else }}
     {{ .Values.config.dnsDomain }}:53 {
         errors
         cache {
@@ -54,3 +57,4 @@ data:
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
         }
+    {{ end }}

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -8,9 +8,9 @@ metadata:
     {{- include "node-local-dns.labels" . | nindent 4 }}
 data:
   Corefile: |
-    {{ if .Values.config.customConfig }}
-      {{ tpl .Values.config.customConfig . }}
-    {{ else }}
+    {{- if .Values.config.customConfig -}}
+    {{- tpl .Values.config.customConfig . | nindent 4}}
+    {{- else }}
     {{ .Values.config.dnsDomain }}:53 {
         errors
         cache {

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -22,6 +22,9 @@ config:
 
   skipTeardown: false
 
+  # Overrides the generated configuration with specified one.
+  customConfig: ""
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Pushing the change from PR #508.
Apparently the original PR was based on an outdated branch, preventing the tests completion.

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
