### PR TITLE
[stable/gripmock] fix: add var to change the service type of gripmock

### DIFF
--- a/stable/gripmock/Chart.yaml
+++ b/stable/gripmock/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   >
   > Version v1.11.1-beta release is available by overriding the `image.tag` in your `values.yaml` file. This version supports **NO** declaration of `go_package`.
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.10.1"
 maintainers:
   - name: MarceloAplanalp

--- a/stable/gripmock/README.md
+++ b/stable/gripmock/README.md
@@ -1,6 +1,6 @@
 # gripmock
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.1](https://img.shields.io/badge/AppVersion-1.10.1-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.1](https://img.shields.io/badge/AppVersion-1.10.1-informational?style=flat-square)
 
 A chart to install [gripmock](https://github.com/tokopedia/gripmock). A mock server for GRPC services. It uses `.proto` file(s) to generate the implementation of gRPC service(s) for you.
 
@@ -76,6 +76,7 @@ helm install my-release deliveryhero/gripmock -f values.yaml
 | podAnnotations | object | `{}` |  |
 | replicaCount | int | `1` | Set the number of replicas in case hpa is not enabled |
 | resources | object | `{}` |  |
+| service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |
 
 ## Maintainers

--- a/stable/gripmock/templates/service.yaml
+++ b/stable/gripmock/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "gripmock.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.service.type }}
   ports:
     - port: 4770
       targetPort: 4770

--- a/stable/gripmock/values.yaml
+++ b/stable/gripmock/values.yaml
@@ -33,6 +33,8 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
+service:
+  type: ClusterIP
 
 ingress:
   enabled: false


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->
This PR sets a variable for the gripmock service type to be able to use types of service like NodePort.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
