### PR TITLE
[stable/toxiproxy] ToxiProxy - Fixes for frontend ingress & container repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Follow these steps:
 1. Fork this repo
 2. Make desired changes to the chart
 3. Bump the chart version
-4. Regenerate the chart `README.md`: `docker run --rm -v "${PWD}:/helm-docs" jnorwood/helm-docs:v1.11.0 --template-files ./ci/README.md.gotmpl`
+4. Regenerate the chart `README.md`: `docker run --rm -v "${PWD}:/helm-docs" jnorwood/helm-docs:v1.11.3 --template-files ./ci/README.md.gotmpl`
 5. Commit and push changes
 6. Open 1 pull request per chart you want to change
 7. Set pull request title to `[stable/<chart name>]: <description>`
@@ -119,7 +119,7 @@ All commands to be run from the root of this repo.
   To generate chart `README.md` files from the [template](ci/README.md.gotmpl):
 
   ```console
-  docker run --rm -v "${PWD}:/helm-docs" jnorwood/helm-docs:v1.11.0 --template-files ./ci/README.md.gotmpl
+  docker run --rm -v "${PWD}:/helm-docs" jnorwood/helm-docs:v1.11.3 --template-files ./ci/README.md.gotmpl
   ```
 
 `helm-conftest`:
@@ -132,6 +132,6 @@ All commands to be run from the root of this repo.
 
 ## License
 
-Copyright © 2022 Delivery Hero
+Copyright © 2023 Delivery Hero
 
 Contents of this repository and any charts without a specific license are licensed under the Apache-2.0 License. Some charts may have their own respective license at `<chart>/LICENSE`. When adding a new chart to this repository and the chart is copied from another repository then include the license from the source if is not Apache-2.0 and include a link to the source under the `sources` section in `<chart>/Chart.yaml`.

--- a/stable/toxiproxy/Chart.yaml
+++ b/stable/toxiproxy/Chart.yaml
@@ -17,8 +17,8 @@ description: |
   helm install toxiproxy deliveryhero/toxiproxy --set toxiproxyConfig=my-toxiproxy-config
   ```
 
-version: "1.3.7"
-appVersion: "2.1.2"
+version: "1.3.8"
+appVersion: "2.7.0"
 home: https://github.com/Shopify/toxiproxy
 sources:
   - https://github.com/Shopify/toxiproxy

--- a/stable/toxiproxy/README.md
+++ b/stable/toxiproxy/README.md
@@ -1,6 +1,6 @@
 # toxiproxy
 
-![Version: 1.3.7](https://img.shields.io/badge/Version-1.3.7-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
+![Version: 1.3.8](https://img.shields.io/badge/Version-1.3.8-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 A TCP proxy to simulate network and system conditions for chaos and resiliency testing.
 
@@ -68,7 +68,12 @@ helm install my-release deliveryhero/toxiproxy -f values.yaml
 | environment | list | `[]` |  |
 | extraLabels | object | `{}` |  |
 | frontend.enabled | bool | `false` |  |
-| frontend.host | string | `"chart-example-ui.local"` |  |
+| frontend.ingress.annotations | object | `{}` |  |
+| frontend.ingress.className | string | `""` |  |
+| frontend.ingress.hosts[0].host | string | `"chart-example-ui.local"` |  |
+| frontend.ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| frontend.ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| frontend.ingress.tls | list | `[]` |  |
 | frontend.repository | string | `"buckle/toxiproxy-frontend"` |  |
 | frontend.resources | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
@@ -86,7 +91,8 @@ helm install my-release deliveryhero/toxiproxy -f values.yaml
 | init.image.repository | string | `"busybox"` | the docker repository and image to be used for the init container. |
 | init.image.tag | string | `"latest"` | the docker image tag for the init container image |
 | nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
+| nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
+| nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
 | pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/stable/toxiproxy/README.md
+++ b/stable/toxiproxy/README.md
@@ -73,8 +73,8 @@ helm install my-release deliveryhero/toxiproxy -f values.yaml
 | frontend.resources | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"shopify/toxiproxy"` |  |
-| image.tag | string | `"2.1.4"` |  |
+| image.repository | string | `"ghcr.io/shopify/toxiproxy"` |  |
+| image.tag | string | `"2.7.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/stable/toxiproxy/templates/ingress-frontend.yaml
+++ b/stable/toxiproxy/templates/ingress-frontend.yaml
@@ -1,25 +1,30 @@
 {{- if .Values.frontend.enabled -}}
 {{- $fullName := include "toxiproxy.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: "{{ $fullName }}-frontend"
+  name: {{ $fullName }}-frontend
   labels:
     component: frontend
 {{ include "toxiproxy.labels" . | indent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.frontend.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+  {{- if and .Values.frontend.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.frontend.ingress.className }}
+  {{- end }}
+  {{- if .Values.frontend.ingress.tls }}
   tls:
-  {{- range .Values.ingress.tls }}
+  {{- range .Values.frontend.ingress.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . | quote }}
@@ -28,11 +33,25 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-    - host: {{ .Values.frontend.host }}
+    {{- range .Values.frontend.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
-              serviceName: {{ $fullName }}-frontend
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-frontend
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/stable/toxiproxy/values.yaml
+++ b/stable/toxiproxy/values.yaml
@@ -3,8 +3,9 @@ toxiproxyConfig: ""
 replicaCount: 1
 
 image:
-  repository: shopify/toxiproxy
-  tag: 2.1.4
+  # https://github.com/shopify/toxiproxy/pkgs/container/toxiproxy
+  repository: ghcr.io/shopify/toxiproxy
+  tag: 2.7.0
   pullPolicy: IfNotPresent
 
 init:
@@ -15,12 +16,21 @@ init:
     tag: latest
 
 frontend:
-  repository: buckle/toxiproxy-frontend
-  # Whether we want to deploy the charts for the frontend or not
-  enabled: false
+  enabled: false # Whether we want to deploy the charts for the frontend or not
+  repository: buckle/toxiproxy-frontend 
   resources: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   # Frontend host address to access it
-  host: chart-example-ui.local
+  ingress:
+    annotations: {}
+    className: ""
+    hosts:
+      - host: chart-example-ui.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
 
 imagePullSecrets: []
 nameOverride: ""
@@ -107,7 +117,9 @@ podAnnotations: {}
 
 extraLabels: {}
 
-nodeSelector: {}
+nodeSelector:
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: linux
 
 tolerations: []
 

--- a/stable/toxiproxy/values.yaml
+++ b/stable/toxiproxy/values.yaml
@@ -1,4 +1,4 @@
-toxiproxyConfig: ""
+toxiproxyConfig: ''
 
 replicaCount: 1
 
@@ -16,15 +16,17 @@ init:
     tag: latest
 
 frontend:
-  enabled: false # Whether we want to deploy the charts for the frontend or not
-  repository: buckle/toxiproxy-frontend 
-  resources: {}
+  # Whether we want to deploy the charts for the frontend or not
+  enabled: false
+  repository: buckle/toxiproxy-frontend
+  resources:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # Frontend host address to access it
   ingress:
     annotations: {}
-    className: ""
+    className: ''
     hosts:
       - host: chart-example-ui.local
         paths:
@@ -33,8 +35,8 @@ frontend:
     tls: []
 
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -47,10 +49,12 @@ serviceAccount:
 pdb:
   enabled: false
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -79,8 +83,9 @@ consumer:
 
 ingress:
   enabled: true
-  className: ""
-  annotations: {}
+  className: ''
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -98,7 +103,8 @@ args:
 
 environment: []
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -110,7 +116,6 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-
 deploymentAnnotations: {}
 
 podAnnotations: {}
@@ -118,8 +123,8 @@ podAnnotations: {}
 extraLabels: {}
 
 nodeSelector:
-    kubernetes.io/arch: amd64
-    kubernetes.io/os: linux
+  kubernetes.io/arch: amd64
+  kubernetes.io/os: linux
 
 tolerations: []
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

* Change from dockerhub hosted container repo to shopify-github repo
* Update toxi version to 2.7 (latest in shopify release at time)
* Change ingress-frontend to function like ingress(backend) as most of the apis in the if statement are on depreciated k8 versions
* Change values to match above changes
* Change values file node selector to default to linux / amd64 for mixed clusters.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
