### PR TITLE
[stable/field-exporter]: field-exporter

### DIFF
--- a/stable/field-exporter/.helmignore
+++ b/stable/field-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/field-exporter/Chart.yaml
+++ b/stable/field-exporter/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: field-exporter
+description: |
+  A chart to install [field-exporter](https://github.com/deliveryhero/field-exporter). This controller is used to fill the gap in [k8s-config-connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) for exporting value from Config Connector managed resources into Secrets and ConfigMaps.
+
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+maintainers:
+  - name: vzholudev
+    email: no-reply@deliveryhero.com
+    url: https://github.com/vzholudev
+  - name: mtahaahmed
+    email: no-reply@deliveryhero.com
+    url: https://github.com/mtahaahmed

--- a/stable/field-exporter/Chart.yaml
+++ b/stable/field-exporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 version: 1.0.0
-appVersion: "1.0.0"
+appVersion: "v1.0.0"
 maintainers:
   - name: vzholudev
     email: no-reply@deliveryhero.com

--- a/stable/field-exporter/README.md
+++ b/stable/field-exporter/README.md
@@ -1,0 +1,69 @@
+# field-exporter
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+
+A chart to install [field-exporter](https://github.com/deliveryhero/field-exporter). This controller is used to fill the gap in [k8s-config-connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) for exporting value from Config Connector managed resources into Secrets and ConfigMaps.
+
+## How to install this chart
+
+Add Delivery Hero public chart repo:
+
+```console
+helm repo add deliveryhero https://charts.deliveryhero.io/
+```
+
+A simple install with default values:
+
+```console
+helm install deliveryhero/field-exporter
+```
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release deliveryhero/field-exporter
+```
+
+To install with some set values:
+
+```console
+helm install my-release deliveryhero/field-exporter --set values_key1=value1 --set values_key2=value2
+```
+
+To install with custom values file:
+
+```console
+helm install my-release deliveryhero/field-exporter -f values.yaml
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controllerManager.manager.args[0] | string | `"--health-probe-bind-address=:8081"` |  |
+| controllerManager.manager.args[1] | string | `"--metrics-bind-address=127.0.0.1:8080"` |  |
+| controllerManager.manager.args[2] | string | `"--leader-elect"` |  |
+| controllerManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| controllerManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| controllerManager.manager.image.repository | string | `"europe-docker.pkg.dev/dp-common-infra-5780/developer-platform-public/deliveryhero/field-exporter"` |  |
+| controllerManager.manager.image.tag | string | `"1.0.0"` |  |
+| controllerManager.manager.resources.limits.cpu | string | `"500m"` |  |
+| controllerManager.manager.resources.limits.memory | string | `"128Mi"` |  |
+| controllerManager.manager.resources.requests.cpu | string | `"10m"` |  |
+| controllerManager.manager.resources.requests.memory | string | `"64Mi"` |  |
+| controllerManager.podLabels | object | `{}` |  |
+| controllerManager.replicas | int | `1` |  |
+| controllerManager.serviceAccount.annotations | object | `{}` |  |
+| kubernetesClusterDomain | string | `"cluster.local"` |  |
+| metricsService.ports[0].name | string | `"https"` |  |
+| metricsService.ports[0].port | int | `8443` |  |
+| metricsService.ports[0].protocol | string | `"TCP"` |  |
+| metricsService.ports[0].targetPort | string | `"https"` |  |
+| metricsService.type | string | `"ClusterIP"` |  |
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| vzholudev | <no-reply@deliveryhero.com> | <https://github.com/vzholudev> |
+| mtahaahmed | <no-reply@deliveryhero.com> | <https://github.com/mtahaahmed> |

--- a/stable/field-exporter/README.md
+++ b/stable/field-exporter/README.md
@@ -50,7 +50,7 @@ helm install my-release deliveryhero/field-exporter -f values.yaml
 | controllerManager.manager.resources.limits.cpu | string | `"500m"` |  |
 | controllerManager.manager.resources.limits.memory | string | `"128Mi"` |  |
 | controllerManager.manager.resources.requests.cpu | string | `"10m"` |  |
-| controllerManager.manager.resources.requests.memory | string | `"64Mi"` |  |
+| controllerManager.manager.resources.requests.memory | string | `"128Mi"` |  |
 | controllerManager.podLabels | object | `{}` |  |
 | controllerManager.replicas | int | `1` |  |
 | controllerManager.serviceAccount.annotations | object | `{}` |  |

--- a/stable/field-exporter/README.md
+++ b/stable/field-exporter/README.md
@@ -1,6 +1,6 @@
 # field-exporter
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 A chart to install [field-exporter](https://github.com/deliveryhero/field-exporter). This controller is used to fill the gap in [k8s-config-connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) for exporting value from Config Connector managed resources into Secrets and ConfigMaps.
 
@@ -46,7 +46,7 @@ helm install my-release deliveryhero/field-exporter -f values.yaml
 | controllerManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | controllerManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | controllerManager.manager.image.repository | string | `"europe-docker.pkg.dev/dp-common-infra-5780/developer-platform-public/deliveryhero/field-exporter"` |  |
-| controllerManager.manager.image.tag | string | `"1.0.0"` |  |
+| controllerManager.manager.image.tag | string | `"v1.0.0"` |  |
 | controllerManager.manager.resources.limits.cpu | string | `"500m"` |  |
 | controllerManager.manager.resources.limits.memory | string | `"128Mi"` |  |
 | controllerManager.manager.resources.requests.cpu | string | `"10m"` |  |

--- a/stable/field-exporter/crds/resourcefieldexport-crd.yaml
+++ b/stable/field-exporter/crds/resourcefieldexport-crd.yaml
@@ -1,0 +1,138 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcefieldexports.gdp.deliveryhero.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+spec:
+  group: gdp.deliveryhero.io
+  names:
+    kind: ResourceFieldExport
+    listKind: ResourceFieldExportList
+    plural: resourcefieldexports
+    singular: resourcefieldexport
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceFieldExport is the Schema for the resourcefieldexports
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceFieldExportSpec defines the desired state of ResourceFieldExport
+            properties:
+              from:
+                properties:
+                  apiVersion:
+                    description: APIVersion is the group version of the resource
+                    pattern: ^([a-zA-Z0-9.-]+[a-zA-Z0-9-]\/[a-zA-Z0-9]+|[a-zA-Z0-9]+)$
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+              outputs:
+                items:
+                  properties:
+                    key:
+                      type: string
+                    path:
+                      type: string
+                  required:
+                  - key
+                  - path
+                  type: object
+                type: array
+              requiredFields:
+                properties:
+                  statusConditions:
+                    items:
+                      properties:
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                type: object
+              to:
+                description: DestinationRef is where the fields should be written.
+                properties:
+                  name:
+                    type: string
+                  type:
+                    description: DestinationType is a ConfigMap or a Secret
+                    enum:
+                    - ConfigMap
+                    - Secret
+                    type: string
+                required:
+                - name
+                - type
+                type: object
+            required:
+            - from
+            - outputs
+            - to
+            type: object
+          status:
+            description: ResourceFieldExportStatus defines the observed state of ResourceFieldExport
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time the condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human-readable message indicating details about
+                        the transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/stable/field-exporter/templates/_helpers.tpl
+++ b/stable/field-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "field-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "field-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "field-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "field-exporter.labels" -}}
+helm.sh/chart: {{ include "field-exporter.chart" . }}
+{{ include "field-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "field-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "field-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "field-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "field-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stable/field-exporter/templates/deployment.yaml
+++ b/stable/field-exporter/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "field-exporter.fullname" . }}-controller-manager
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: field-exporter
+    app.kubernetes.io/part-of: field-exporter
+    control-plane: controller-manager
+  {{- include "field-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controllerManager.replicas }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+    {{- include "field-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+      {{- include "field-exporter.selectorLabels" . | nindent 8 }}
+      {{- if .Values.controllerManager.podLabels }}
+{{ toYaml .Values.controllerManager.podLabels | indent 8 }}
+      {{- end }}
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      containers:
+      - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
+        command:
+        - /manager
+        env:
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 10
+          }}
+        securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
+          | nindent 10 }}
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: {{ include "field-exporter.fullname" . }}-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/stable/field-exporter/templates/leader-election-rbac.yaml
+++ b/stable/field-exporter/templates/leader-election-rbac.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "field-exporter.fullname" . }}-leader-election-role
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: field-exporter
+    app.kubernetes.io/part-of: field-exporter
+  {{- include "field-exporter.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "field-exporter.fullname" . }}-leader-election-rolebinding
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: field-exporter
+    app.kubernetes.io/part-of: field-exporter
+  {{- include "field-exporter.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "field-exporter.fullname" . }}-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "field-exporter.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/stable/field-exporter/templates/manager-rbac.yaml
+++ b/stable/field-exporter/templates/manager-rbac.yaml
@@ -1,0 +1,91 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "field-exporter.fullname" . }}-manager-role
+  labels:
+  {{- include "field-exporter.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - alloydb.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gdp.deliveryhero.io
+  resources:
+  - resourcefieldexports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gdp.deliveryhero.io
+  resources:
+  - resourcefieldexports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gdp.deliveryhero.io
+  resources:
+  - resourcefieldexports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - iam.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - redis.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sql.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "field-exporter.fullname" . }}-manager-rolebinding
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: field-exporter
+    app.kubernetes.io/part-of: field-exporter
+  {{- include "field-exporter.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "field-exporter.fullname" . }}-manager-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "field-exporter.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/stable/field-exporter/templates/serviceaccount.yaml
+++ b/stable/field-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "field-exporter.fullname" . }}-controller-manager
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: field-exporter
+    app.kubernetes.io/part-of: field-exporter
+  {{- include "field-exporter.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}

--- a/stable/field-exporter/values.yaml
+++ b/stable/field-exporter/values.yaml
@@ -1,0 +1,33 @@
+controllerManager:
+  manager:
+    args:
+    - --health-probe-bind-address=:8081
+    - --metrics-bind-address=127.0.0.1:8080
+    - --leader-elect
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    image:
+      repository: europe-docker.pkg.dev/dp-common-infra-5780/developer-platform-public/deliveryhero/field-exporter
+      tag: 1.0.0
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+  replicas: 1
+  serviceAccount:
+    annotations: {}
+  podLabels: {}
+kubernetesClusterDomain: cluster.local
+metricsService:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  type: ClusterIP

--- a/stable/field-exporter/values.yaml
+++ b/stable/field-exporter/values.yaml
@@ -11,7 +11,7 @@ controllerManager:
         - ALL
     image:
       repository: europe-docker.pkg.dev/dp-common-infra-5780/developer-platform-public/deliveryhero/field-exporter
-      tag: 1.0.0
+      tag: v1.0.0
     resources:
       limits:
         cpu: 500m

--- a/stable/field-exporter/values.yaml
+++ b/stable/field-exporter/values.yaml
@@ -18,7 +18,7 @@ controllerManager:
         memory: 128Mi
       requests:
         cpu: 10m
-        memory: 64Mi
+        memory: 128Mi
   replicas: 1
   serviceAccount:
     annotations: {}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

  A chart to install [field-exporter](https://github.com/deliveryhero/field-exporter). This controller is used to fill the gap in [k8s-config-connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) for exporting value from Config Connector managed resources into Secrets and ConfigMaps.


## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
