### PR TITLE
[stable/field-exporter]: fixes rbac permissions and image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ helm install my-release deliveryhero/<chart>
 - [cortex-gateway](stable/cortex-gateway)
 - [datadog-controller](stable/datadog-controller)
 - [dregsy](stable/dregsy)
+- [field-exporter](stable/field-exporter)
 - [gripmock](stable/gripmock)
 - [hoppscotch](stable/hoppscotch)
 - [k8s-cloudwatch-adapter](stable/k8s-cloudwatch-adapter)

--- a/stable/field-exporter/Chart.yaml
+++ b/stable/field-exporter/Chart.yaml
@@ -4,8 +4,8 @@ description: |
   A chart to install [field-exporter](https://github.com/deliveryhero/field-exporter). This controller is used to fill the gap in [k8s-config-connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) for exporting value from Config Connector managed resources into Secrets and ConfigMaps.
 
 type: application
-version: 1.0.0
-appVersion: "v1.0.0"
+version: 1.0.2
+appVersion: "v1.0.2"
 maintainers:
   - name: vzholudev
     email: no-reply@deliveryhero.com

--- a/stable/field-exporter/README.md
+++ b/stable/field-exporter/README.md
@@ -1,6 +1,6 @@
 # field-exporter
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
 
 A chart to install [field-exporter](https://github.com/deliveryhero/field-exporter). This controller is used to fill the gap in [k8s-config-connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) for exporting value from Config Connector managed resources into Secrets and ConfigMaps.
 
@@ -46,7 +46,7 @@ helm install my-release deliveryhero/field-exporter -f values.yaml
 | controllerManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | controllerManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | controllerManager.manager.image.repository | string | `"europe-docker.pkg.dev/dp-common-infra-5780/developer-platform-public/deliveryhero/field-exporter"` |  |
-| controllerManager.manager.image.tag | string | `"v1.0.0"` |  |
+| controllerManager.manager.image.tag | string | `"v1.0.2"` |  |
 | controllerManager.manager.resources.limits.cpu | string | `"500m"` |  |
 | controllerManager.manager.resources.limits.memory | string | `"128Mi"` |  |
 | controllerManager.manager.resources.requests.cpu | string | `"10m"` |  |

--- a/stable/field-exporter/templates/manager-rbac.yaml
+++ b/stable/field-exporter/templates/manager-rbac.yaml
@@ -6,6 +6,16 @@ metadata:
   {{- include "field-exporter.labels" . | nindent 4 }}
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
   - alloydb.cnrm.cloud.google.com
   resources:
   - '*'

--- a/stable/field-exporter/values.yaml
+++ b/stable/field-exporter/values.yaml
@@ -11,7 +11,7 @@ controllerManager:
         - ALL
     image:
       repository: europe-docker.pkg.dev/dp-common-infra-5780/developer-platform-public/deliveryhero/field-exporter
-      tag: v1.0.0
+      tag: v1.0.2
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

- RBAC Permissions to manage secrets and config map
- Updated image version to v1.0.2


## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
