### PR TITLE
[stable/kube-downscaler] bump version to be k8s>=1.25 ready

### DIFF
--- a/stable/kube-downscaler/Chart.yaml
+++ b/stable/kube-downscaler/Chart.yaml
@@ -1,7 +1,7 @@
 name: kube-downscaler
 apiVersion: v1
-version: "0.7.3"
-appVersion: 23.2.0
+version: "0.7.4"
+appVersion: 23.2.0-6-gc9b88e8
 description: Scale down Kubernetes deployments after work hours
 keywords:
 - k8s pods scheduler

--- a/stable/kube-downscaler/README.md
+++ b/stable/kube-downscaler/README.md
@@ -1,6 +1,6 @@
 # kube-downscaler
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![AppVersion: 23.2.0](https://img.shields.io/badge/AppVersion-23.2.0-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![AppVersion: 23.2.0-6-gc9b88e8](https://img.shields.io/badge/AppVersion-23.2.0--6--gc9b88e8-informational?style=flat-square)
 
 Scale down Kubernetes deployments after work hours
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Update kube-downscaler version to be able to manage Cronjobs in k8s>=1.25, after cronjob/v1beta1 removal. see the corresponding [issue](https://codeberg.org/hjacobs/kube-downscaler/issues/39)

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
