### PR TITLE
[stable/cachet] ingress use tls key

### DIFF
--- a/stable/cachet/Chart.yaml
+++ b/stable/cachet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.3.15"
 description: The open source status page system
 name: cachet
-version: 1.3.2
+version: 1.3.3
 home: https://cachethq.io/
 sources:
   - https://github.com/CachetHQ/Docker

--- a/stable/cachet/README.md
+++ b/stable/cachet/README.md
@@ -1,6 +1,6 @@
 # cachet
 
-![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![AppVersion: 2.3.15](https://img.shields.io/badge/AppVersion-2.3.15-informational?style=flat-square)
+![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square) ![AppVersion: 2.3.15](https://img.shields.io/badge/AppVersion-2.3.15-informational?style=flat-square)
 
 The open source status page system
 

--- a/stable/cachet/templates/ingress.yaml
+++ b/stable/cachet/templates/ingress.yaml
@@ -13,6 +13,16 @@ spec:
   {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+  - hosts:
+    {{- range .hosts }}
+      - {{ . | quote }}
+    {{- end }}
+    secretName: {{ .secretName }}
+  {{- end }}
+  {{- end }}
   rules:
   - host: {{ .Values.ingress.host }}
     http:


### PR DESCRIPTION
## Description

Without this configuration cert-manager cannot correctly generate certificate.

I've copied from `stable/hoppscotch` the snippet

## Checklist

[✔️] Title of the PR starts with chart name (e.g. [stable/mychartname])
[✔️] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs