### PR TITLE
[stable/node-local-dns]: customize liveness probe port

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.0.3
+version: 2.0.4
 appVersion: 1.22.23
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
+![Version: 2.0.4](https://img.shields.io/badge/Version-2.0.4-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -53,6 +53,7 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | config.customConfig | string | `""` |  |
 | config.dnsDomain | string | `"cluster.local"` |  |
 | config.dnsServer | string | `"172.20.0.10"` |  |
+| config.healthPort | int | `8080` |  |
 | config.localDns | string | `"169.254.20.25"` |  |
 | config.setupInterface | bool | `true` |  |
 | config.setupIptables | bool | `true` |  |

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
                 {{ .Values.config.commProtocol }}
         }
         prometheus :9253
-        health
+        health :{{ .Values.config.healthPort }}
         }
     in-addr.arpa:53 {
         errors

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -92,7 +92,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 8080
+            port: {{ .Values.config.healthPort }}
           initialDelaySeconds: 60
           timeoutSeconds: 5
         volumeMounts:

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -16,6 +16,9 @@ config:
   # Set communication protocol. Options are `prefer_udp` or `force_tcp`
   commProtocol: "force_tcp"
 
+  # Port used for the health endpoint
+  healthPort: 8080
+
   setupInterface: true
 
   setupIptables: true


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

- Return customization of liveness probe port. It was deleted here https://github.com/deliveryhero/helm-charts/pull/510
<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
