### PR TITLE
[stable/cachet] DB_DRIVER defined twice

### DIFF
--- a/stable/cachet/Chart.yaml
+++ b/stable/cachet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.3.15"
 description: The open source status page system
 name: cachet
-version: 1.3.3
+version: 1.3.4
 home: https://cachethq.io/
 sources:
   - https://github.com/CachetHQ/Docker

--- a/stable/cachet/README.md
+++ b/stable/cachet/README.md
@@ -1,6 +1,6 @@
 # cachet
 
-![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square) ![AppVersion: 2.3.15](https://img.shields.io/badge/AppVersion-2.3.15-informational?style=flat-square)
+![Version: 1.3.4](https://img.shields.io/badge/Version-1.3.4-informational?style=flat-square) ![AppVersion: 2.3.15](https://img.shields.io/badge/AppVersion-2.3.15-informational?style=flat-square)
 
 The open source status page system
 
@@ -53,7 +53,6 @@ helm install my-release deliveryhero/cachet -f values.yaml
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| database.driver | string | `"pssql"` |  |
 | database.host | string | `"cachet-db.example.com"` |  |
 | database.name | string | `"cachet"` |  |
 | database.password | string | `""` |  |

--- a/stable/cachet/templates/configmap.yaml
+++ b/stable/cachet/templates/configmap.yaml
@@ -9,7 +9,6 @@ data:
   DB_HOST: {{ .Values.database.host  }}
   DB_DATABASE: {{ .Values.database.name  }}
   DB_USERNAME: {{ .Values.database.username }}
-  DB_DRIVER: {{ .Values.database.driver }}
   DB_PORT: {{ .Values.database.port | quote }}
   APP_ENV: {{ default "production" .Values.env.APP_ENV | quote }}
   APP_URL: {{ .Values.ingress.host }}

--- a/stable/cachet/values.yaml
+++ b/stable/cachet/values.yaml
@@ -57,7 +57,6 @@ database:
   name: cachet
   username: cachet
   password: ""
-  driver: pssql
 
 env:
   public:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

`DB_DRIVER` is being defined twice in the configmap, which makes helm fail with:
```
Helm upgrade failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 28: mapping key "DB_DRIVER" already defined at line 19
```
Removed one of the properties and left the `env.public.DB_DRIVER`, which had the correct default value `pgsql`.

Version 1.3.3 only works if `env.public.DB_DRIVER` is defined as empty, so it's ignored and not set in the configmap.

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
