### PR TITLE
[stable/kube-bench] Update kube-bench image to 0.7.1

### DIFF
--- a/stable/kube-bench/Chart.yaml
+++ b/stable/kube-bench/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 0.6.19
+appVersion: 0.7.1
 description: "Helm chart to deploy run kube-bench as a cronjob on aks, gke or eks."
 name: kube-bench
-version: 0.1.14
+version: 0.1.15
 home: https://github.com/aquasecurity/kube-bench
 icon: https://raw.githubusercontent.com/aquasecurity/kube-bench/0d1bd2bbd95608957be024c12d03a0510325e5e2/docs/images/kube-bench.png
 sources:

--- a/stable/kube-bench/README.md
+++ b/stable/kube-bench/README.md
@@ -1,6 +1,6 @@
 # kube-bench
 
-![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![AppVersion: 0.6.19](https://img.shields.io/badge/AppVersion-0.6.19-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
 
 Helm chart to deploy run kube-bench as a cronjob on aks, gke or eks.
 
@@ -54,7 +54,7 @@ helm install my-release deliveryhero/kube-bench -f values.yaml
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"aquasec/kube-bench"` |  |
-| image.tag | string | `"v0.6.19"` |  |
+| image.tag | string | `"v0.7.1"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podLabels | object | `{}` |  |

--- a/stable/kube-bench/values.yaml
+++ b/stable/kube-bench/values.yaml
@@ -10,7 +10,7 @@ cronjob:
 
 image:
   repository: aquasec/kube-bench
-  tag: v0.6.19
+  tag: v0.7.1
   pullPolicy: IfNotPresent
 
 serviceAccount:


### PR DESCRIPTION
* bump kube-bench chart version to 0.1.15

## Description

Update kube-bench image to 0.7.1

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
