### PR TITLE
[stable/node-local-dns]: Fix template rendering

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.0.5
+version: 2.0.6
 appVersion: 1.22.23
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
+![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
 
 A chart to install node-local-dns.
 

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -19,11 +19,11 @@ data:
         }
         reload
         loop
-    {{- if .Values.config.bindIp -}}
+    {{- if .Values.config.bindIp }}
         bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
     {{- else }}
         bind 0.0.0.0
-    {{ end }}
+    {{- end }}
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
@@ -35,11 +35,11 @@ data:
         cache 30
         reload
         loop
-    {{- if .Values.config.bindIp -}}
+    {{- if .Values.config.bindIp }}
         bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
     {{- else }}
         bind 0.0.0.0
-    {{ end }}
+    {{- end }}
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
@@ -50,11 +50,11 @@ data:
         cache 30
         reload
         loop
-    {{- if .Values.config.bindIp -}}
+    {{- if .Values.config.bindIp }}
         bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
     {{- else }}
         bind 0.0.0.0
-    {{ end }}
+    {{- end }}
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
@@ -65,11 +65,11 @@ data:
         cache 30
         reload
         loop
-    {{- if .Values.config.bindIp -}}
+    {{- if .Values.config.bindIp }}
         bind {{ .Values.config.localDns }} {{ .Values.config.dnsServer }}
     {{- else }}
         bind 0.0.0.0
-    {{ end }}
+    {{- end }}
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
         }


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

I'm really sorry; in my previous [pull request](https://github.com/deliveryhero/helm-charts/pull/563) I didn't test the template rendering very well.
The result was wrong
`loopbind 169.254.20.25 172.20.0.10`
<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
