### PR TITLE
[stable/locust]: Add additional custom manifests

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.31.5"
+version: "0.31.6"
 appVersion: 2.15.1
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.31.5](https://img.shields.io/badge/Version-0.31.5-informational?style=flat-square) ![AppVersion: 2.15.1](https://img.shields.io/badge/AppVersion-2.15.1-informational?style=flat-square)
+![Version: 0.31.6](https://img.shields.io/badge/Version-0.31.6-informational?style=flat-square) ![AppVersion: 2.15.1](https://img.shields.io/badge/AppVersion-2.15.1-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -65,6 +65,7 @@ helm install my-release deliveryhero/locust -f values.yaml
 | affinity | object | `{}` |  |
 | extraConfigMaps | object | `{}` | Any extra configmaps to mount for the master and worker. Can be used for extra python packages |
 | extraLabels | object | `{}` | Any extra labels to apply to all resources |
+| extraObjects | list | `[]` | Any extra manifests to deploy alongside locust. Can be used for external secret providers |
 | fullnameOverride | string | `""` |  |
 | hostAliases | list | `[]` | List of entries added to the /etc/hosts file on the pod to resolve custom hosts |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/stable/locust/templates/extra-manifests.yaml
+++ b/stable/locust/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -181,3 +181,15 @@ tolerations: []
 affinity: {}
 # extraLabels -- Any extra labels to apply to all resources
 extraLabels: {}
+
+# extraObjects -- Any extra manifests to deploy alongside locust. Can be used for external secret providers
+extraObjects: []
+  # - apiVersion: "kubernetes-client.io/v1"
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: locust-secrets
+  #   spec:
+  #     backendType: gcpSecretsManager
+  #     data:
+  #       - key: app-admin-password
+  #         name: adminPassword


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

This adds an easy way to deploy additional manifests alongside the locust chart like for example external secrets that can then be mounted into the locust pods via existing means (`environment_external_secret`)

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
