### PR TITLE
[stable/k8s-resources] update hpa to latest v2 version

### DIFF
--- a/stable/k8s-resources/Chart.yaml
+++ b/stable/k8s-resources/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.5
+version: 0.6.6
 appVersion: 0.0.1
 name: k8s-resources
 description: |

--- a/stable/k8s-resources/README.md
+++ b/stable/k8s-resources/README.md
@@ -1,6 +1,6 @@
 # k8s-resources
 
-![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.6.6](https://img.shields.io/badge/Version-0.6.6-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Not an application but a Helm chart to create any and many resources in Kubernetes.
 

--- a/stable/k8s-resources/templates/hpa.yaml
+++ b/stable/k8s-resources/templates/hpa.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.HorizontalPodAutoscalers -}}
 {{- range .Values.HorizontalPodAutoscalers }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ .apiVersion | default "autoscaling/v2beta1" }}
 kind: HorizontalPodAutoscaler
 metadata:
 {{- if .namespace }}

--- a/stable/k8s-resources/templates/hpa.yaml
+++ b/stable/k8s-resources/templates/hpa.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.HorizontalPodAutoscalers -}}
 {{- range .Values.HorizontalPodAutoscalers }}
-apiVersion: {{ .apiVersion | default "autoscaling/v2beta1" }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
 {{- if .namespace }}
@@ -26,13 +26,17 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .targetCPUUtilizationPercentage }}
+      target:
+          type: Utilization
+          averageUtilization: {{ .targetCPUUtilizationPercentage }}
 {{- end }}
 {{- if .targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
       name: memory
-      targetAverageUtilization: {{ .targetMemoryUtilizationPercentage }}
+      target:
+          type: Utilization
+          averageUtilization: {{ .targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

**latest api version is v2 so I updated the hpa file.**

In my case sync failed because of this error:
`The Kubernetes API could not find version "v2beta1" of autoscaling/HorizontalPodAutoscaler for requested resource kube-system/k8s-resources-coredns-hpa. Version "v2" of autoscaling/HorizontalPodAutoscaler is installed on the destination cluster.`

**this PR will it.**

## Checklist

- [ X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
