### PR TITLE
[stable/node-local-dns]: add option to set customUpstreamsvc

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.0.6
+version: 2.0.7
 appVersion: 1.22.23
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
+![Version: 2.0.7](https://img.shields.io/badge/Version-2.0.7-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -52,6 +52,7 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | config.bindIp | bool | `false` |  |
 | config.commProtocol | string | `"force_tcp"` |  |
 | config.customConfig | string | `""` |  |
+| config.customUpstreamsvc | string | `""` |  |
 | config.dnsDomain | string | `"cluster.local"` |  |
 | config.dnsServer | string | `"172.20.0.10"` |  |
 | config.healthPort | int | `8080` |  |

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -71,7 +71,11 @@ spec:
           - "-conf"
           - "/etc/Corefile"
           - "-upstreamsvc"
+        {{- if .Values.config.customUpstreamsvc }}
+          - "{{ .Values.config.customUpstreamsvc }}"
+        {{- else }}
           - "{{ include "node-local-dns.fullname" . }}-upstream"
+        {{- end }}
           - "-skipteardown={{ .Values.config.skipTeardown }}"
           - "-setupinterface={{ .Values.config.setupInterface }}"
           - "-setupiptables={{ .Values.config.setupIptables }}"

--- a/stable/node-local-dns/templates/service-upstream.yaml
+++ b/stable/node-local-dns/templates/service-upstream.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.config.customUpstreamsvc -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
     targetPort: 53
   selector:
     k8s-app: kube-dns
+{{- end -}}

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -13,6 +13,9 @@ config:
   # Virtual IP to be used by ipvs mode, to be used as --cluster-dns, must not collide.
   localDns: "169.254.20.25"
 
+  # Use a custom upstreamsvc for -upstreamsvc
+  customUpstreamsvc: ""
+
   # If true, it will bind 0.0.0.0, otherwise dnsServer and localDns will be used. https://github.com/bottlerocket-os/bottlerocket/issues/3711#issuecomment-1907087528
   bindIp: false
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
add option the set a custom Upstreamsvc 
if the custom upstreamsvc is set the upstream service is not created
## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
