### PR TITLE
[stable/NONE]: update README, make helm-docs instructions robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ All commands to be run from the root of this repo.
   To generate chart `README.md` files from the [template](ci/README.md.gotmpl), you can run `helm-docs` via docker:
 
   ```console
-  docker run --rm -v "${PWD}:/helm-docs" jnorwood/helm-docs:v1.11.3 --template-files ./ci/README.md.gotmpl
+  docker run --rm -v "$(git rev-parse --show-toplevel):/helm-docs" jnorwood/helm-docs:v1.11.3 --template-files ./ci/README.md.gotmpl
   ```
 
   Or alternatively install via [pre-commit](https://pre-commit.com/#install):


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

 `${PWD}` implies that the command could be run from any directory within the repo. This is not true since the path to `./ci/README.md.gotmpl` is relative. 

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
