### PR TITLE
[stable/node-local-dns]: serviceMonitor endoints configuration not completed

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.0.7
+version: 2.0.8
 appVersion: 1.22.23
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.0.7](https://img.shields.io/badge/Version-2.0.7-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
+![Version: 2.0.8](https://img.shields.io/badge/Version-2.0.8-informational?style=flat-square) ![AppVersion: 1.22.23](https://img.shields.io/badge/AppVersion-1.22.23-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -82,7 +82,11 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.honorLabels | bool | `false` |  |
 | serviceMonitor.labels | object | `{}` |  |
+| serviceMonitor.metricRelabelings | list | `[]` |  |
+| serviceMonitor.path | string | `"/metrics"` |  |
+| serviceMonitor.relabelings | list | `[]` |  |
 
 ## Maintainers
 

--- a/stable/node-local-dns/templates/servicemonitor.yaml
+++ b/stable/node-local-dns/templates/servicemonitor.yaml
@@ -11,6 +11,22 @@ metadata:
 spec:
   endpoints:
     - port: metrics
+      path: {{ .Values.serviceMonitor.path }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- tpl (toYaml . | nindent 6) $ }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - kube-system

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -64,6 +64,30 @@ serviceMonitor:
   # Ensure that servicemonitor is created, this will disable prometheus annotations
   enabled: false
   labels: {}
+  path: /metrics
+  honorLabels: false
+  # Fallback to the prometheus default unless specified
+  # interval: 10s
+
+  # Fallback to the prometheus default unless specified
+  # scrapeTimeout: 30s
+
+  # Metric relabel configs to apply to samples before ingestion.
+  # [Metric Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs)
+  metricRelabelings: []
+  # - action: keep
+  #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+  #   sourceLabels: [__name__]
+
+  ## Relabel configs to apply to samples before ingestion.
+  ## [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
+  relabelings: []
+  # - sourceLabels: [__meta_kubernetes_pod_node_name]
+  #   separator: ;
+  #   regex: ^(.*)$
+  #   targetLabel: nodename
+  #   replacement: $1
+  #   action: replace
 
 # https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md
 dashboard:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->
We are moving to prometheus operator monitoring but we need some extra configuration allowed by serviceMonitor like relabelings or metricsRelabelings. Unfortunately, it's not par of the chart yet.

I've included `path`, `honorLabels`, `interval`, `scrapeTimeout`, `metricRelabelings`, `relabelings`.

here an extra test.yaml to make sure it works
```yaml
serviceMonitor:
  enabled: true
  labels:
    prometheus.io/operator: "true"
  interval: 60s
  scrapeTimeout: 90s
  metricRelabelings:
  - action: keep
    regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
    sourceLabels: [__name__]
  relabelings:
  - sourceLabels: [__meta_kubernetes_pod_node_name]
    separator: ;
    regex: ^(.*)$
    targetLabel: nodename
    replacement: $1
    action: replace
```

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
