### PR TITLE
[stable/prometheus-statsd-exporter] add ServiceMonitor support for prometheus-statsd-exporter

### DIFF
--- a/stable/prometheus-statsd-exporter/Chart.yaml
+++ b/stable/prometheus-statsd-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.18.0
 description: StatsD to Prometheus metrics exporter
 name: prometheus-statsd-exporter
-version: 0.1.3
+version: 0.1.4
 home: https://github.com/prometheus/statsd_exporter
 sources:
   - https://github.com/prometheus/statsd_exporter

--- a/stable/prometheus-statsd-exporter/README.md
+++ b/stable/prometheus-statsd-exporter/README.md
@@ -53,8 +53,8 @@ helm install my-release deliveryhero/prometheus-statsd-exporter -f values.yaml
 | image.repository | string | `"prom/statsd-exporter"` |  |
 | image.tag | string | `"v0.18.0"` |  |
 | imagePullSecrets | list | `[]` |  |
-| metrics.enabled | bool | `false` |  |
 | metrics.additionalLabels | object | `{}` |  |
+| metrics.enabled | bool | `false` |  |
 | metrics.scrapeInterval | string | `"30s"` |  |
 | metrics.scrapeTimeout | string | `"10s"` |  |
 | nameOverride | string | `""` |  |

--- a/stable/prometheus-statsd-exporter/README.md
+++ b/stable/prometheus-statsd-exporter/README.md
@@ -53,6 +53,10 @@ helm install my-release deliveryhero/prometheus-statsd-exporter -f values.yaml
 | image.repository | string | `"prom/statsd-exporter"` |  |
 | image.tag | string | `"v0.18.0"` |  |
 | imagePullSecrets | list | `[]` |  |
+| metrics.enabled | bool | `false` |  |
+| metrics.additionalLabels | object | `{}` |  |
+| metrics.scrapeInterval | string | `"30s"` |  |
+| metrics.scrapeTimeout | string | `"10s"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
@@ -62,10 +66,6 @@ helm install my-release deliveryhero/prometheus-statsd-exporter -f values.yaml
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| metrics.enabled | bool | `false` |  |
-| metrics.additionalLabels | object | `{}` |  |
-| metrics.scrapeInterval | string | `"30s"` |  |
-| metrics.scrapeTimeout | string | `"10s"` |  |
 | tolerations | list | `[]` |  |
 
 ## Maintainers

--- a/stable/prometheus-statsd-exporter/README.md
+++ b/stable/prometheus-statsd-exporter/README.md
@@ -62,6 +62,10 @@ helm install my-release deliveryhero/prometheus-statsd-exporter -f values.yaml
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| metrics.enabled | bool | `false` |  |
+| metrics.additionalLabels | object | `{}` |  |
+| metrics.scrapeInterval | string | `"30s"` |  |
+| metrics.scrapeTimeout | string | `"10s"` |  |
 | tolerations | list | `[]` |  |
 
 ## Maintainers

--- a/stable/prometheus-statsd-exporter/README.md
+++ b/stable/prometheus-statsd-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-statsd-exporter
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
 
 StatsD to Prometheus metrics exporter
 

--- a/stable/prometheus-statsd-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-statsd-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.metrics.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "prometheus-statsd-exporter.fullname" . }}
+  labels:
+    name: {{ include "prometheus-statsd-exporter.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.metrics.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "prometheus-statsd-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+  - port: frontend
+    {{- if .Values.metrics.scrapeInterval }}
+    interval: {{ .Values.metrics.scrapeInterval }}
+    {{- end }}
+    {{- if .Values.metrics.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.metrics.scrapeTimeout }}
+    {{- end }}
+{{- end }}

--- a/stable/prometheus-statsd-exporter/values.yaml
+++ b/stable/prometheus-statsd-exporter/values.yaml
@@ -34,6 +34,12 @@ securityContext: {}
 service:
   type: ClusterIP
 
+metrics:
+  enabled: false
+  additionalLabels: {}
+  scrapeInterval: 30s
+  scrapeTimeout: 10s
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Description

This supports prometheus extension for service monitor CRD optionally.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
