### PR TITLE
[stable/prometheus-locust-exporter]: Additional Service Monitor Template Values

### DIFF
--- a/stable/prometheus-locust-exporter/Chart.yaml
+++ b/stable/prometheus-locust-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.4.1"
 description: A Helm chart a prometheus exporter locust load test metrics
 name: prometheus-locust-exporter
-version: 1.2.1
+version: 1.2.2
 home: https://github.com/ContainerSolutions/locust_exporter
 sources:
   - https://github.com/ContainerSolutions/locust_exporter

--- a/stable/prometheus-locust-exporter/README.md
+++ b/stable/prometheus-locust-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-locust-exporter
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square)
 
 A Helm chart a prometheus exporter locust load test metrics
 

--- a/stable/prometheus-locust-exporter/templates/service-monitor.yaml
+++ b/stable/prometheus-locust-exporter/templates/service-monitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "prometheus-locust-exporter.fullname" . }}
   labels:
 {{ include "prometheus-locust-exporter.labels" . | indent 4 }}
+{{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:
@@ -14,6 +17,9 @@ spec:
   - port: metrics
     path: /metrics
     interval: 30s
+    {{- if .Values.serviceMonitor.bearerTokenFile}}
+    bearerTokenFile: {{ .Values.serviceMonitor.bearerTokenFile }}
+    {{- end }}
     {{- if .Values.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}

--- a/stable/prometheus-locust-exporter/values.yaml
+++ b/stable/prometheus-locust-exporter/values.yaml
@@ -70,6 +70,8 @@ service:
 serviceMonitor:
   # Enusre that service is created
   enabled: false
+  # additionalLabels: {}
+  # bearerTokenFile: ''
   # relabelings: []
   # metricRelabelings: []
 


### PR DESCRIPTION
## Description

Service monitors for some Prometheus installation require specific labels and a bearer token to be picked up by the Prometheus scraper.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
