### PR TITLE
[stable/node-local-dns] add prefetch options to configuration

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.0.11
+version: 2.0.12
 appVersion: 1.23.1
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.0.11](https://img.shields.io/badge/Version-2.0.11-informational?style=flat-square) ![AppVersion: 1.23.1](https://img.shields.io/badge/AppVersion-1.23.1-informational?style=flat-square)
+![Version: 2.0.12](https://img.shields.io/badge/Version-2.0.12-informational?style=flat-square) ![AppVersion: 1.23.1](https://img.shields.io/badge/AppVersion-1.23.1-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -57,6 +57,10 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | config.dnsServer | string | `"172.20.0.10"` |  |
 | config.healthPort | int | `8080` |  |
 | config.localDns | string | `"169.254.20.25"` |  |
+| config.prefetch.amount | int | `3` |  |
+| config.prefetch.duration | string | `"30s"` |  |
+| config.prefetch.enabled | bool | `false` |  |
+| config.prefetch.percentage | string | `"20%"` |  |
 | config.setupInterface | bool | `true` |  |
 | config.setupIptables | bool | `true` |  |
 | config.skipTeardown | bool | `false` |  |

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -16,6 +16,9 @@ data:
         cache {
                 success 9984 30
                 denial 9984 5
+            {{- if .Values.config.prefetch.enabled}}
+                prefetch {{ .Values.config.prefetch.amount }} {{ .Values.config.prefetch.duration }} {{ .Values.config.prefetch.percentage }}
+            {{- end }}
         }
         reload
         loop
@@ -32,7 +35,13 @@ data:
         }
     in-addr.arpa:53 {
         errors
+    {{- if .Values.config.prefetch.enabled}}
+        cache 30 {
+                prefetch {{ .Values.config.prefetch.amount }} {{ .Values.config.prefetch.duration }} {{ .Values.config.prefetch.percentage }}
+        }
+    {{- else }}
         cache 30
+    {{- end }}
         reload
         loop
     {{- if .Values.config.bindIp }}
@@ -47,7 +56,13 @@ data:
         }
     ip6.arpa:53 {
         errors
+    {{- if .Values.config.prefetch.enabled}}
+        cache 30 {
+                prefetch {{ .Values.config.prefetch.amount }} {{ .Values.config.prefetch.duration }} {{ .Values.config.prefetch.percentage }}
+        }
+    {{- else }}
         cache 30
+    {{- end }}
         reload
         loop
     {{- if .Values.config.bindIp }}
@@ -62,7 +77,13 @@ data:
         }
     .:53 {
         errors
+    {{- if .Values.config.prefetch.enabled}}
+        cache 30 {
+                prefetch {{ .Values.config.prefetch.amount }} {{ .Values.config.prefetch.duration }} {{ .Values.config.prefetch.percentage }}
+        }
+    {{- else }}
         cache 30
+    {{- end }}
         reload
         loop
     {{- if .Values.config.bindIp }}

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -22,6 +22,13 @@ config:
   # Set communication protocol. Options are `prefer_udp` or `force_tcp`
   commProtocol: "force_tcp"
 
+  # If enabled, coredns will prefetch popular items when they are about to be expunged from the cache. https://coredns.io/plugins/cache/
+  prefetch:
+    enabled: false
+    amount: 3
+    duration: 30s
+    percentage: 20%
+
   # Port used for the health endpoint
   healthPort: 8080
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
add ability to enable [prefetch](https://coredns.io/plugins/cache/)
<!--- Describe your changes in detail -->
prefetch will prefetch popular items when they are about to be expunged from the cache. Popular means AMOUNT queries have been seen with no gaps of DURATION or more between them. DURATION defaults to 1m. Prefetching will happen when the TTL drops below PERCENTAGE, which defaults to 10%, or latest 1 second before TTL expiration. Values should be in the range [10%, 90%]. Note the percent sign is mandatory. PERCENTAGE is treated as an int.
## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
