### PR TITLE
[stable/node-local-dns] add noIPv6Lookups config option

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.0.12
+version: 2.0.13
 appVersion: 1.23.1
 maintainers:
 - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.0.12](https://img.shields.io/badge/Version-2.0.12-informational?style=flat-square) ![AppVersion: 1.23.1](https://img.shields.io/badge/AppVersion-1.23.1-informational?style=flat-square)
+![Version: 2.0.13](https://img.shields.io/badge/Version-2.0.13-informational?style=flat-square) ![AppVersion: 1.23.1](https://img.shields.io/badge/AppVersion-1.23.1-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -57,6 +57,7 @@ helm install my-release deliveryhero/node-local-dns -f values.yaml
 | config.dnsServer | string | `"172.20.0.10"` |  |
 | config.healthPort | int | `8080` |  |
 | config.localDns | string | `"169.254.20.25"` |  |
+| config.noIPv6Lookups | bool | `false` |  |
 | config.prefetch.amount | int | `3` |  |
 | config.prefetch.duration | string | `"30s"` |  |
 | config.prefetch.enabled | bool | `false` |  |

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -30,6 +30,11 @@ data:
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
+    {{- if .Values.config.noIPv6Lookups }}
+        template IN AAAA {
+            rcode NOERROR
+        }
+    {{- end }}
         prometheus :9253
         health :{{ .Values.config.healthPort }}
         }
@@ -52,6 +57,11 @@ data:
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
+    {{- if .Values.config.noIPv6Lookups }}
+        template IN AAAA {
+            rcode NOERROR
+        }
+    {{- end }}
         prometheus :9253
         }
     ip6.arpa:53 {
@@ -73,6 +83,11 @@ data:
         forward . __PILLAR__CLUSTER__DNS__ {
                 {{ .Values.config.commProtocol }}
         }
+    {{- if .Values.config.noIPv6Lookups }}
+        template IN AAAA {
+            rcode NOERROR
+        }
+    {{- end }}
         prometheus :9253
         }
     .:53 {
@@ -93,5 +108,10 @@ data:
     {{- end }}
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
+    {{- if .Values.config.noIPv6Lookups }}
+        template IN AAAA {
+            rcode NOERROR
+        }
+    {{- end }}
         }
     {{ end }}

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
         }
     {{- if .Values.config.noIPv6Lookups }}
         template IN AAAA {
-            rcode NOERROR
+                rcode NOERROR
         }
     {{- end }}
         prometheus :9253
@@ -59,7 +59,7 @@ data:
         }
     {{- if .Values.config.noIPv6Lookups }}
         template IN AAAA {
-            rcode NOERROR
+                rcode NOERROR
         }
     {{- end }}
         prometheus :9253
@@ -85,7 +85,7 @@ data:
         }
     {{- if .Values.config.noIPv6Lookups }}
         template IN AAAA {
-            rcode NOERROR
+                rcode NOERROR
         }
     {{- end }}
         prometheus :9253
@@ -110,7 +110,7 @@ data:
         prometheus :9253
     {{- if .Values.config.noIPv6Lookups }}
         template IN AAAA {
-            rcode NOERROR
+                rcode NOERROR
         }
     {{- end }}
         }

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -22,6 +22,9 @@ config:
   # Set communication protocol. Options are `prefer_udp` or `force_tcp`
   commProtocol: "force_tcp"
 
+  # If true, return NOERROR when attempting to resolve an IPv6 address
+  noIPv6Lookups: false
+
   # If enabled, coredns will prefetch popular items when they are about to be expunged from the cache. https://coredns.io/plugins/cache/
   prefetch:
     enabled: false


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
https://jbn1233.medium.com/disable-coredns-aaaa-ipv6-query-response-a99ce9bc6dec
<!--- Describe your changes in detail -->
Many  k8s clusters operate on an internal network using only IPv4. The `no_ipv6_lookups` configuration option allows disabling IPv6 lookups, reducing the load and latency on CoreDNS servers.
## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
