### PR TITLE
[stable/k8s-event-logger]: Enhance Helm Chart with Consistent Naming and Labeling Conventions

### DIFF
--- a/stable/k8s-event-logger/Chart.yaml
+++ b/stable/k8s-event-logger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "2.1"
-version: "1.1.6"
+version: "1.1.7"
 description: |
   This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
 

--- a/stable/k8s-event-logger/README.md
+++ b/stable/k8s-event-logger/README.md
@@ -1,6 +1,6 @@
 # k8s-event-logger
 
-![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square) ![AppVersion: 2.1](https://img.shields.io/badge/AppVersion-2.1-informational?style=flat-square)
+![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square) ![AppVersion: 2.1](https://img.shields.io/badge/AppVersion-2.1-informational?style=flat-square)
 
 This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
 

--- a/stable/k8s-event-logger/templates/_helpers.tpl
+++ b/stable/k8s-event-logger/templates/_helpers.tpl
@@ -36,7 +36,6 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "k8s-event-logger.labels" -}}
-app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
 helm.sh/chart: {{ include "k8s-event-logger.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}

--- a/stable/k8s-event-logger/templates/_helpers.tpl
+++ b/stable/k8s-event-logger/templates/_helpers.tpl
@@ -43,3 +43,13 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+
+
+{{/*
+Selector labels
+*/}}
+{{- define "k8s-event-logger.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/stable/k8s-event-logger/templates/clusterrole.yaml
+++ b/stable/k8s-event-logger/templates/clusterrole.yaml
@@ -4,9 +4,7 @@ metadata:
   name: {{ include "k8s-event-logger.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
-    helm.sh/chart: {{ include "k8s-event-logger.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "k8s-event-logger.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["events"]

--- a/stable/k8s-event-logger/templates/clusterrolebinding.yaml
+++ b/stable/k8s-event-logger/templates/clusterrolebinding.yaml
@@ -4,9 +4,7 @@ metadata:
   name: {{ include "k8s-event-logger.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
-    helm.sh/chart: {{ include "k8s-event-logger.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "k8s-event-logger.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/k8s-event-logger/templates/deployment.yaml
+++ b/stable/k8s-event-logger/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
-      {{- include "k8s-event-logger.labels" . | nindent 4 }}
+      {{- include "k8s-event-logger.labels" . | nindent 6 }}
   template:
     metadata:
 {{- with .Values.podAnnotations }}

--- a/stable/k8s-event-logger/templates/deployment.yaml
+++ b/stable/k8s-event-logger/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "k8s-event-logger.labels" . | nindent 4 }}
   template:
     metadata:
 {{- with .Values.podAnnotations }}

--- a/stable/k8s-event-logger/templates/deployment.yaml
+++ b/stable/k8s-event-logger/templates/deployment.yaml
@@ -12,8 +12,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
-      {{- include "k8s-event-logger.labels" . | nindent 6 }}
+      {{- include "k8s-event-logger.selectorLabels" . | nindent 6 }}
   template:
     metadata:
 {{- with .Values.podAnnotations }}
@@ -22,7 +21,7 @@ spec:
 {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "k8s-event-logger.labels" . | nindent 8 }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->
Enhance Helm Chart with Consistent Naming and Labeling Conventions

This pull request introduces several improvements to the Helm chart to ensure consistent naming and labeling across all Kubernetes resources. The changes include the addition of helper templates and the application of these templates in various resource definitions.

All templates now use the `k8s-event-logger.labels` helper. Name label is still used outside of the helper call

Source updated chart via this [PR](https://github.com/max-rocket-internet/k8s-event-logger/pull/47) with more context and details

### Diff Report previous vs proposed
```
diff new.yaml org.yaml
9c9
<     helm.sh/chart: k8s-event-logger-1.1.7
---
>     helm.sh/chart: k8s-event-logger-1.1.6
20c20
<     helm.sh/chart: k8s-event-logger-1.1.7
---
>     helm.sh/chart: k8s-event-logger-1.1.6
22d21
<     app.kubernetes.io/version: "2.1"
36c35
<     helm.sh/chart: k8s-event-logger-1.1.7
---
>     helm.sh/chart: k8s-event-logger-1.1.6
38d36
<     app.kubernetes.io/version: "2.1"
55,56c53,54
<     helm.sh/chart: k8s-event-logger-1.1.7
<     app.kubernetes.io/instance: test
---
>     app.kubernetes.io/name: k8s-event-logger
>     helm.sh/chart: k8s-event-logger-1.1.6
64d61
<       helm.sh/chart: k8s-event-logger-1.1.7
66,67d62
<       app.kubernetes.io/version: "2.1"
<       app.kubernetes.io/managed-by: Helm
```

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
