### PR TITLE
[stable/wiremock] Add serviceAccount

### DIFF
--- a/stable/wiremock/Chart.yaml
+++ b/stable/wiremock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wiremock
-version: "1.4.1"
+version: "1.4.2"
 appVersion: "2.26.0"
 home: http://wiremock.org/
 icon: http://wiremock.org/images/wiremock-concept-icon-01.png

--- a/stable/wiremock/README.md
+++ b/stable/wiremock/README.md
@@ -1,6 +1,6 @@
 # wiremock
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
 
 A service virtualization tool (some call it mock server) for testing purposes.
 
@@ -163,6 +163,8 @@ helm install my-release deliveryhero/wiremock -f values.yaml
 | resources.requests.memory | string | `"3Gi"` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
+| serviceAccount.enabled | bool | `false` | Whether to create a ServiceAccount |
+| serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | serviceAnnotations | object | `{}` |  |
 | strategy.type | string | `"RollingUpdate"` |  |
 | tolerations | list | `[]` |  |

--- a/stable/wiremock/README.md
+++ b/stable/wiremock/README.md
@@ -1,6 +1,6 @@
 # wiremock
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
 
 A service virtualization tool (some call it mock server) for testing purposes.
 
@@ -163,8 +163,8 @@ helm install my-release deliveryhero/wiremock -f values.yaml
 | resources.requests.memory | string | `"3Gi"` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
-| serviceAccount.enabled | bool | `false` | Whether to create a ServiceAccount |
-| serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.enabled | bool | `false` |  |
 | serviceAnnotations | object | `{}` |  |
 | strategy.type | string | `"RollingUpdate"` |  |
 | tolerations | list | `[]` |  |

--- a/stable/wiremock/templates/deployment.yaml
+++ b/stable/wiremock/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
 {{ toYaml . | trim | indent 8 }}
 {{- end}}
     spec:
+{{- if .Values.serviceAccount.enabled }}
+      serviceAccount: {{ template "wiremock.fullname" . }}
+{{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | indent 8 }}

--- a/stable/wiremock/templates/serviceaccount.yaml
+++ b/stable/wiremock/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
+{{- with .Values.serviceAccount.annotations }}
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+  name: {{ template "wiremock.fullname" . }}
+{{- end }}

--- a/stable/wiremock/values.yaml
+++ b/stable/wiremock/values.yaml
@@ -15,6 +15,10 @@ consumer:
   # consumer.initVolume -- custom extra volume for the initialization container providing the zip archive.
   initVolume: []
 
+serviceAccount:
+  enabled: false
+  annotations: {}
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

This PR adds the capability of creating a service account resource with custom annotations for the wiremock consumer pod. 

Since we are using large stubs files for our mock tests and we are constantly updating those large files, it is the best solution for us to upload those files in to an s3 bucket and copy them to our wiremock consumer pod using an init container. To be able to this, we need some kind of authorization and authentication mechanism for our aws account. And using a service account for this suits us perfectly. Because of those reasons, related updates were made on the wiremock helm chart. All kinds of feedbacks are appreciated. Thanks in advance.

<!--- Describe your changes in detail -->

- serviceaccount.yaml is created
- template.spec.serviceAccount filed is added to deployment.yaml
- serviceAccount field is added to values.yaml file to control related resources 

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
