### PR TITLE
[stable/k8s-event-logger]: add args to chart

### DIFF
--- a/stable/k8s-event-logger/Chart.yaml
+++ b/stable/k8s-event-logger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "2.1"
-version: "1.1.7"
+version: "1.1.8"
 description: |
   This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
 

--- a/stable/k8s-event-logger/README.md
+++ b/stable/k8s-event-logger/README.md
@@ -1,6 +1,6 @@
 # k8s-event-logger
 
-![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square) ![AppVersion: 2.1](https://img.shields.io/badge/AppVersion-2.1-informational?style=flat-square)
+![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square) ![AppVersion: 2.1](https://img.shields.io/badge/AppVersion-2.1-informational?style=flat-square)
 
 This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
 
@@ -59,6 +59,7 @@ helm install my-release deliveryhero/k8s-event-logger -f values.yaml
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | annotations | object | `{}` |  |
+| args | list | `[]` |  |
 | containerName | string | `"k8s-event-logger"` |  |
 | env | object | `{}` | A map of environment variables |
 | fullnameOverride | string | `""` |  |

--- a/stable/k8s-event-logger/templates/deployment.yaml
+++ b/stable/k8s-event-logger/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
 {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/k8s-event-logger/values.yaml
+++ b/stable/k8s-event-logger/values.yaml
@@ -15,6 +15,7 @@ resources:
 
 # env -- A map of environment variables
 env: {}
+args: []
 
 securityContext: {}
 


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Add missing args into values.yaml
`args` are showing up on original repo https://github.com/max-rocket-internet/k8s-event-logger/blob/master/chart/values.yaml#L15-L16
but not in helm charts

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
