### PR TITLE
[stable/node-problem-detector]: update NPD chart to use version v0.8.19

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.3.13"
-appVersion: v0.8.18
+version: "2.3.14"
+appVersion: v0.8.19
 home: https://github.com/kubernetes/node-problem-detector
 description: |
   This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.13](https://img.shields.io/badge/Version-2.3.13-informational?style=flat-square) ![AppVersion: v0.8.18](https://img.shields.io/badge/AppVersion-v0.8.18-informational?style=flat-square)
+![Version: 2.3.14](https://img.shields.io/badge/Version-2.3.14-informational?style=flat-square) ![AppVersion: v0.8.19](https://img.shields.io/badge/AppVersion-v0.8.19-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -59,7 +59,7 @@ helm install my-release deliveryhero/node-problem-detector -f values.yaml
 | image.digest | string | `""` | the image digest. If given it takes precedence over a given tag. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"registry.k8s.io/node-problem-detector/node-problem-detector"` |  |
-| image.tag | string | `"v0.8.18"` |  |
+| image.tag | string | `"v0.8.19"` |  |
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -56,7 +56,7 @@ logDir:
 
 image:
   repository: registry.k8s.io/node-problem-detector/node-problem-detector
-  tag: v0.8.18
+  tag: v0.8.19
   # image.digest -- the image digest. If given it takes precedence over a given tag.
   digest: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Current AppVersion of node-problem-detector is v0.8.18, but a new version has been released a couple of months ago: https://github.com/kubernetes/node-problem-detector/releases/tag/v0.8.19

There is no need to update the manifests. Bumping the image is enough.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing

close #602