### PR TITLE
[stable/k8s-resources]: support ClusterRoles and ClusterRoleBindings

### DIFF
--- a/stable/k8s-resources/Chart.yaml
+++ b/stable/k8s-resources/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.6
+version: 0.7.0
 appVersion: 0.0.1
 name: k8s-resources
 description: |
@@ -17,6 +17,8 @@ description: |
   - Service
   - ServiceAccount
   - ScaledObject (KEDA)
+  - ClusterRole
+  - ClusterRoleBinding
 
   Every resource type can have custom labels, annotations or a `fullnameOverride` set. See default [values.yaml](https://github.com/deliveryhero/helm-charts/blob/master/stable/k8s-resources/values.yaml) for examples.
 

--- a/stable/k8s-resources/README.md
+++ b/stable/k8s-resources/README.md
@@ -1,6 +1,6 @@
 # k8s-resources
 
-![Version: 0.6.6](https://img.shields.io/badge/Version-0.6.6-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Not an application but a Helm chart to create any and many resources in Kubernetes.
 
@@ -16,6 +16,8 @@ Currently supports:
 - Service
 - ServiceAccount
 - ScaledObject (KEDA)
+- ClusterRole
+- ClusterRoleBinding
 
 Every resource type can have custom labels, annotations or a `fullnameOverride` set. See default [values.yaml](https://github.com/deliveryhero/helm-charts/blob/master/stable/k8s-resources/values.yaml) for examples.
 
@@ -32,7 +34,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/k8s-resource
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/k8s-resources --version 0.6.6
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/k8s-resources --version 0.7.0
 ```
 
 To install the chart with the release name `my-release`:
@@ -57,6 +59,8 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/k8s-resources -f 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| ClusterRoleBindings | list | `[]` | A list ClusterRoleBindings to create |
+| ClusterRoles | list | `[]` | A list ClusterRoles to create |
 | ConfigMaps | list | `[]` | A list ConfigMap to create |
 | CronJobs | list | `[]` | A list CronJobs to create |
 | CustomResources | list | `[]` | A list resources to create that are completely custom |

--- a/stable/k8s-resources/ci/ct-values.yaml
+++ b/stable/k8s-resources/ci/ct-values.yaml
@@ -116,3 +116,42 @@ Namespaces:
     fullnameOverride: ""
     annotations: {}
     extraLabels: {}
+
+ClusterRoles:
+  - name: example-cr-1
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels: {}
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - '*'
+  - name: example-cr-2
+    extraLabels:
+      mylabel: myvalue
+
+ClusterRoleBindings:
+  - name: example-crb-1
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels: {}
+    roleRef:
+      kind: ClusterRole
+      name: cluster-admin
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: my-sa
+        namespace: my-ns
+  - name: example-crb-2
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels:
+      mylabel: myvalue
+    roleRef:
+      kind: ClusterRole
+      name: cluster-admin
+      apiGroup: rbac.authorization.k8s.io

--- a/stable/k8s-resources/templates/clusterrole.yaml
+++ b/stable/k8s-resources/templates/clusterrole.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.ClusterRoles -}}
+{{- range .Values.ClusterRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+{{- if .namespace }}
+  namespace: {{ .namespace }}
+{{- end }}
+  name: {{ if .fullnameOverride }}{{ .fullnameOverride }}{{ else }}{{ include "k8s-resources.fullname" $ }}-{{ .name }}{{ end }}
+  labels:
+    {{- include "k8s-resources.labels" $ | nindent 4 }}
+  {{- with .extraLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .rules }}
+rules:
+ {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/stable/k8s-resources/templates/clusterrolebinding.yaml
+++ b/stable/k8s-resources/templates/clusterrolebinding.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ClusterRoleBindings -}}
+{{- range .Values.ClusterRoleBindings }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+{{- if .namespace }}
+  namespace: {{ .namespace }}
+{{- end }}
+  name: {{ if .fullnameOverride }}{{ .fullnameOverride }}{{ else }}{{ include "k8s-resources.fullname" $ }}-{{ .name }}{{ end }}
+  labels:
+    {{- include "k8s-resources.labels" $ | nindent 4 }}
+  {{- with .extraLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  {{- toYaml .roleRef | nindent 2 }}
+{{- with .subjects }}
+subjects:
+ {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/stable/k8s-resources/values.yaml
+++ b/stable/k8s-resources/values.yaml
@@ -152,3 +152,32 @@ ScaledObjects: []
   #         cortexOrgID: logistics
   #         threshold: "4"
   #       type: prometheus
+
+# ClusterRoles -- A list ClusterRoles to create
+ClusterRoles: []
+  # - name: example-cr
+  #   fullnameOverride: ""
+  #   annotations: {}
+  #   extraLabels: {}
+  #   rules:
+  #     - apiGroups:
+  #         - ""
+  #       resources:
+  #         - configmaps
+  #       verbs:
+  #         - '*'
+
+# ClusterRoleBindings -- A list ClusterRoleBindings to create
+ClusterRoleBindings: []
+  # - name: example-crb
+  #   fullnameOverride: ""
+  #   annotations: {}
+  #   extraLabels: {}
+  #   roleRef:
+  #     kind: ClusterRole
+  #     name: cluster-admin
+  #     apiGroup: rbac.authorization.k8s.io
+  #   subjects:
+  #     - kind: ServiceAccount
+  #       name: my-sa
+  #       namespace: my-ns


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Adding `ClusterRole` and `ClusterRoleBinding` resources support.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
