### PR TITLE
[stable/k8s-resources]: introduce enabled flag

### DIFF
--- a/stable/k8s-resources/Chart.yaml
+++ b/stable/k8s-resources/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.7.0
+version: 0.8.0
 appVersion: 0.0.1
 name: k8s-resources
 description: |

--- a/stable/k8s-resources/README.md
+++ b/stable/k8s-resources/README.md
@@ -1,6 +1,6 @@
 # k8s-resources
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Not an application but a Helm chart to create any and many resources in Kubernetes.
 
@@ -34,7 +34,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/k8s-resource
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/k8s-resources --version 0.7.0
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/k8s-resources --version 0.8.0
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/k8s-resources/ci/ct-values.yaml
+++ b/stable/k8s-resources/ci/ct-values.yaml
@@ -12,9 +12,34 @@ CronJobs:
           - "sh"
           - "-c"
           - "'echo yes'"
+  - name: example-cronjob-1
+    enabled: false
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels:
+      app: my-app
+    schedule: 00 19 * * *
+    containers:
+      - name: my-container
+        image: ubuntu:bionic
+        args:
+          - "sh"
+          - "-c"
+          - "'echo yes'"
 
 ConfigMaps:
   - name: example-cm
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels: {}
+    kv_data:
+      key: value
+    multiline_data:
+      key: |
+        line 1
+        line 2
+  - name: example-cm-1
+    enabled: false
     fullnameOverride: ""
     annotations: {}
     extraLabels: {}
@@ -41,6 +66,22 @@ Ingresses:
                   name: example-service
                   port:
                     number: 8080
+  - name: example-ingress-1
+    enabled: false
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels: {}
+    rules:
+      - host: chart-example.local
+        http:
+          paths:
+            - path: /api
+              pathType: Prefix
+              backend:
+                service:
+                  name: example-service
+                  port:
+                    number: 8080
 
 Secrets:
   - name: example-secret
@@ -53,7 +94,18 @@ Secrets:
       key2: value1
     keys:
       key3: dmFsdWUyCg==
+  - name: example-secret-1
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels: {}
+    tplB64Keys:
+      key1: '{{ (index .Values.Secrets 0).name }}'
+    b64Keys:
+      key2: value1
+    keys:
+      key3: dmFsdWUyCg==
   - name: example-secret-2
+    enabled: false
     fullnameOverride: ""
     annotations: {}
     extraLabels: {}
@@ -76,7 +128,19 @@ Services:
       - port: 80
         targetPort: 8080
         protocol: TCP
+  - name: example-service-1
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels: {}
+    type: ClusterIP
+    selector:
+      key2: value2
+    ports:
+      - port: 443
+        targetPort: 443
+        protocol: TCP
   - name: example-service-2
+    enabled: false
     fullnameOverride: ""
     annotations: {}
     extraLabels: {}
@@ -93,7 +157,12 @@ ServiceAccounts:
     fullnameOverride: ""
     annotations: {}
     extraLabels: {}
+  - name: example-sa-1
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels: {}
   - name: example-sa-2
+    enabled: false
     fullnameOverride: ""
     annotations: {}
     extraLabels: {}
@@ -110,9 +179,26 @@ HorizontalPodAutoscalers:
       apiVersion: apps/v1
       kind: Deployment
       name: my-deployment
+  - name: example-hpa2
+    enabled: false
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels: {}
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    scaleTargetRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: my-deployment
 
 Namespaces:
   - name: production
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels: {}
+  - name: test
+    enabled: false
     fullnameOverride: ""
     annotations: {}
     extraLabels: {}
@@ -132,6 +218,10 @@ ClusterRoles:
   - name: example-cr-2
     extraLabels:
       mylabel: myvalue
+  - name: example-cr-3
+    enabled: false
+    extraLabels:
+      mylabel: myvalue
 
 ClusterRoleBindings:
   - name: example-crb-1
@@ -147,6 +237,16 @@ ClusterRoleBindings:
         name: my-sa
         namespace: my-ns
   - name: example-crb-2
+    fullnameOverride: ""
+    annotations: {}
+    extraLabels:
+      mylabel: myvalue
+    roleRef:
+      kind: ClusterRole
+      name: cluster-admin
+      apiGroup: rbac.authorization.k8s.io
+  - name: example-crb-3
+    enabled: false
     fullnameOverride: ""
     annotations: {}
     extraLabels:

--- a/stable/k8s-resources/templates/clusterrole.yaml
+++ b/stable/k8s-resources/templates/clusterrole.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ClusterRoles -}}
 {{- range .Values.ClusterRoles }}
+{{- if . | dig "enabled" true }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -21,5 +22,6 @@ rules:
  {{- toYaml . | nindent 2 }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/clusterrolebinding.yaml
+++ b/stable/k8s-resources/templates/clusterrolebinding.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ClusterRoleBindings -}}
 {{- range .Values.ClusterRoleBindings }}
+{{- if . | dig "enabled" true }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -23,5 +24,6 @@ subjects:
  {{- toYaml . | nindent 2 }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/configmap.yaml
+++ b/stable/k8s-resources/templates/configmap.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ConfigMaps -}}
 {{- range .Values.ConfigMaps }}
+{{- if . | dig "enabled" true }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,5 +32,6 @@ data:
 {{- end }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/cronjob.yaml
+++ b/stable/k8s-resources/templates/cronjob.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.CronJobs -}}
 {{- range .Values.CronJobs }}
+{{- if . | dig "enabled" true }}
 {{- if semverCompare ">=1.24-0" $.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
 {{- else -}}
@@ -47,5 +48,6 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/custom.yaml
+++ b/stable/k8s-resources/templates/custom.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.CustomResources -}}
 {{- range .Values.CustomResources }}
+{{- if . | dig "enabled" true }}
 apiVersion: {{ .apiVersion }}
 kind: {{ .kind }}
 metadata:
@@ -19,5 +20,6 @@ metadata:
 spec:
 {{- toYaml .spec | nindent 2 }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/hpa.yaml
+++ b/stable/k8s-resources/templates/hpa.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.HorizontalPodAutoscalers -}}
 {{- range .Values.HorizontalPodAutoscalers }}
+{{- if . | dig "enabled" true }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -39,5 +40,6 @@ spec:
           averageUtilization: {{ .targetMemoryUtilizationPercentage }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/ingress.yaml
+++ b/stable/k8s-resources/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.Ingresses -}}
 {{- range .Values.Ingresses }}
+{{- if . | dig "enabled" true }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -39,5 +40,6 @@ spec:
     {{- toYaml . | nindent 2 }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/namespace.yaml
+++ b/stable/k8s-resources/templates/namespace.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.Namespaces -}}
 {{- range .Values.Namespaces }}
+{{- if . | dig "enabled" true }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -14,5 +15,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/priorityclass.yaml
+++ b/stable/k8s-resources/templates/priorityclass.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.PriorityClasses -}}
 {{- range .Values.PriorityClasses }}
+{{- if . | dig "enabled" true }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -9,5 +10,6 @@ preemptionPolicy: {{ .preemptionPolicy }}
 globalDefault: {{ .globalDefault}}
 description: {{ .description }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/scaledObject.yaml
+++ b/stable/k8s-resources/templates/scaledObject.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ScaledObjects -}}
 {{- range .Values.ScaledObjects }}
+{{- if . | dig "enabled" true }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -30,5 +31,6 @@ spec:
   {{- with .triggers }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/secret.yaml
+++ b/stable/k8s-resources/templates/secret.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.Secrets -}}
 {{- range .Values.Secrets }}
+{{- if . | dig "enabled" true }}
 apiVersion: v1
 kind: Secret
 type: {{ if .type }}{{ .type }}{{ else }}Opaque{{ end }}
@@ -34,5 +35,6 @@ data:
 {{- end }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/service.yaml
+++ b/stable/k8s-resources/templates/service.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.Services -}}
 {{- range .Values.Services }}
+{{- if . | dig "enabled" true }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,5 +28,6 @@ spec:
   selector:
 {{- toYaml .selector | nindent 4 }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/k8s-resources/templates/serviceaccount.yaml
+++ b/stable/k8s-resources/templates/serviceaccount.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ServiceAccounts -}}
 {{- range .Values.ServiceAccounts }}
+{{- if . | dig "enabled" true }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -17,5 +18,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

In case when `values.yaml` is not static, but generated, using tools like [helmfile](https://github.com/helmfile/helmfile), or [KCL](https://www.kcl-lang.io) or any other. It's often needed to _dynamically enable / disable_ some resources based on certain conditions. For example using Helm like syntax 

##### values.gotmpl.yaml
```yaml
{{- $condition1 := .... -}}
{{- $condition2 := .... -}}
ServiceAccounts:
  {{- if $condition1 }}
  - fullnameOverride: sa1
    annotations: 
      foo: bar1
  {{- end }}
  {{- if $condition2 }}
  - fullnameOverride: sa2
    annotations: 
      foo: bar2
  {{- end }}
  {{- if or $condition1 $condition2 }}
  - fullnameOverride: sa3
    annotations: 
      foo: bar3
  {{- end }
  - fullnameOverride: sa4
    annotations: 
      foo: bar4
```

With this PR the above fragment could be rewritten like below, resulting in more readable and concise code.

##### values.gotmpl.yaml
```yaml
{{- $condition1 := .... -}}
{{- $condition2 := .... -}}
ServiceAccounts:
  - fullnameOverride: sa1
    enabled: {{- $condition1 -}}
    annotations: 
      foo: bar1
  - fullnameOverride: sa2
    enabled: {{- $condition2 -}}
    annotations: 
      foo: bar2
  - fullnameOverride: sa3
    enabled: {{- or $condition1 $condition2 -}}
    annotations: 
      foo: bar3
  - fullnameOverride: sa4
    annotations: 
      foo: bar4
```

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
