### PR TITLE
[stable/node-problem-detector]: update NPD chart to use v0.8.20

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: node-problem-detector
-version: "2.3.14"
-appVersion: v0.8.19
+version: "2.3.15"
+appVersion: v0.8.20
 home: https://github.com/kubernetes/node-problem-detector
 description: |
   This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -91,7 +91,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-problem-dete
 | settings.custom_plugin_monitors | list | `[]` |  |
 | settings.extraArgs | list | `[]` |  |
 | settings.heartBeatPeriod | string | `"5m0s"` | Syncing interval with API server |
-| settings.log_monitors | list | `["/config/kernel-monitor.json", "/config/docker-monitor.json", "/config/readonly-monitor.json"]` | User-specified custom monitor definitions |
+| settings.log_monitors | list | `["/config/kernel-monitor.json","/config/docker-monitor.json","/config/readonly-monitor.json"]` | User-specified custom monitor definitions |
 | settings.prometheus_address | string | `"0.0.0.0"` | Prometheus exporter address |
 | settings.prometheus_port | int | `20257` | Prometheus exporter port |
 | tolerations[0].effect | string | `"NoSchedule"` |  |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -91,7 +91,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-problem-dete
 | settings.custom_plugin_monitors | list | `[]` |  |
 | settings.extraArgs | list | `[]` |  |
 | settings.heartBeatPeriod | string | `"5m0s"` | Syncing interval with API server |
-| settings.log_monitors | list | `["/config/kernel-monitor.json","/config/docker-monitor.json", "/config/readonly-monitor.json"]` | User-specified custom monitor definitions |
+| settings.log_monitors | list | `["/config/kernel-monitor.json", "/config/docker-monitor.json", "/config/readonly-monitor.json"]` | User-specified custom monitor definitions |
 | settings.prometheus_address | string | `"0.0.0.0"` | Prometheus exporter address |
 | settings.prometheus_port | int | `20257` | Prometheus exporter port |
 | tolerations[0].effect | string | `"NoSchedule"` |  |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.14](https://img.shields.io/badge/Version-2.3.14-informational?style=flat-square) ![AppVersion: v0.8.19](https://img.shields.io/badge/AppVersion-v0.8.19-informational?style=flat-square)
+![Version: 2.3.15](https://img.shields.io/badge/Version-2.3.15-informational?style=flat-square) ![AppVersion: v0.8.20](https://img.shields.io/badge/AppVersion-v0.8.20-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -17,7 +17,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector --version 2.3.14
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector --version 2.3.15
 ```
 
 To install the chart with the release name `my-release`:
@@ -59,7 +59,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-problem-dete
 | image.digest | string | `""` | the image digest. If given it takes precedence over a given tag. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"registry.k8s.io/node-problem-detector/node-problem-detector"` |  |
-| image.tag | string | `"v0.8.19"` |  |
+| image.tag | string | `"v0.8.20"` |  |
 | imagePullSecrets | list | `[]` |  |
 | labels | object | `{}` |  |
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |
@@ -91,7 +91,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-problem-dete
 | settings.custom_plugin_monitors | list | `[]` |  |
 | settings.extraArgs | list | `[]` |  |
 | settings.heartBeatPeriod | string | `"5m0s"` | Syncing interval with API server |
-| settings.log_monitors | list | `["/config/kernel-monitor.json","/config/docker-monitor.json"]` | User-specified custom monitor definitions |
+| settings.log_monitors | list | `["/config/kernel-monitor.json","/config/docker-monitor.json", "/config/readonly-monitor.json"]` | User-specified custom monitor definitions |
 | settings.prometheus_address | string | `"0.0.0.0"` | Prometheus exporter address |
 | settings.prometheus_port | int | `20257` | Prometheus exporter port |
 | tolerations[0].effect | string | `"NoSchedule"` |  |

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -30,6 +30,7 @@ settings:
   log_monitors:
     - /config/kernel-monitor.json
     - /config/docker-monitor.json
+    - /config/readonly-monitor.json
     # An example of activating a custom log monitor definition in
     # Node Problem Detector
     # - /custom-config/docker-monitor-filelog.json
@@ -56,7 +57,7 @@ logDir:
 
 image:
   repository: registry.k8s.io/node-problem-detector/node-problem-detector
-  tag: v0.8.19
+  tag: v0.8.20
   # image.digest -- the image digest. If given it takes precedence over a given tag.
   digest: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Description

Current AppVersion of node-problem-detector is v0.8.19, but a new version has been released a couple of months ago: https://github.com/kubernetes/node-problem-detector/releases/tag/v0.8.20

An update in `settings.log_monitors` is required because of a refactoring in https://github.com/kubernetes/node-problem-detector/pull/955 

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing

closes #620 
