### PR TITLE
[stable/wiremock]: implements environment secrets support

### DIFF
--- a/stable/wiremock/Chart.yaml
+++ b/stable/wiremock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wiremock
-version: "1.4.2"
+version: "1.4.3"
 appVersion: "2.26.0"
 home: http://wiremock.org/
 icon: http://wiremock.org/images/wiremock-concept-icon-01.png

--- a/stable/wiremock/README.md
+++ b/stable/wiremock/README.md
@@ -1,6 +1,6 @@
 # wiremock
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
 
 A service virtualization tool (some call it mock server) for testing purposes.
 
@@ -88,7 +88,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/wiremock
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/wiremock --version 1.4.2
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/wiremock --version 1.4.3
 ```
 
 To install the chart with the release name `my-release`:
@@ -121,7 +121,8 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/wiremock -f value
 | affinity | object | `{}` |  |
 | consumer.args | list | `[]` | custom WireMock startup arguments. |
 | consumer.args_include_default | bool | `true` | whether WireMock arguments for performance test setup should be included |
-| consumer.environment | object | `{}` |  |
+| consumer.environment | object | `{}` | environment variables used in the WireMock container |
+| consumer.environment_secret | object | `{}` | environment variables used in the WireMock container, stored as secrets |
 | consumer.initContainer | list | `[]` | support for stubs with large files using binary container with zip archive. |
 | consumer.initVolume | list | `[]` | custom extra volume for the initialization container providing the zip archive. |
 | consumer.name | string | `"example"` | a name used for resources and settings in this WireMock |

--- a/stable/wiremock/templates/secret.yaml
+++ b/stable/wiremock/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.consumer.environment_secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "wiremock.fullname" . }}
+  labels:
+{{ include "wiremock.labels" . | indent 4 }}
+type: Opaque
+data:
+{{- range $key, $value := .Values.consumer.environment_secret }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/stable/wiremock/values.yaml
+++ b/stable/wiremock/values.yaml
@@ -1,9 +1,11 @@
 consumer:
   # consumer.name -- a name used for resources and settings in this WireMock
   name: example
-  # consumer.hostname -- the public host name for this WireMock
+  # consumer.environment -- environment variables used in the WireMock container
   environment: {}
     # WM_LOGGING_LEVEL: INFO
+  # consumer.environment_secret -- environment variables used in the WireMock container, stored as secrets
+  environment_secret: {}
   # consumer.args_include_default -- whether WireMock arguments for performance test setup should be included
   args_include_default: true
   # consumer.args -- custom WireMock startup arguments.


### PR DESCRIPTION
## Description

This PR implements environment secrets support for the chart.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
