### PR TITLE
[stable/locust]: Updates locust version, adds fix for web-login, adds ability to pass reserved ip to load balancer service

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: locust
-version: "0.31.6"
-appVersion: 2.15.1
+version: "0.31.7"
+appVersion: 2.32.1
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png
 maintainers:

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.31.6](https://img.shields.io/badge/Version-0.31.6-informational?style=flat-square) ![AppVersion: 2.15.1](https://img.shields.io/badge/AppVersion-2.15.1-informational?style=flat-square)
+![Version: 0.31.7](https://img.shields.io/badge/Version-0.31.7-informational?style=flat-square) ![AppVersion: 2.32.1](https://img.shields.io/badge/AppVersion-2.32.1-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -37,7 +37,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust --version 0.31.6
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust --version 0.31.7
 ```
 
 To install the chart with the release name `my-release`:
@@ -120,6 +120,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |
 | service.extraLabels | object | `{}` |  |
+| service.loadBalancerIP | string | `""` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |
 | worker.affinity | object | `{}` | Overwrites affinity from global |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -70,7 +70,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | hostAliases | list | `[]` | List of entries added to the /etc/hosts file on the pod to resolve custom hosts |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"locustio/locust"` |  |
-| image.tag | string | `"2.15.1"` |  |
+| image.tag | string | `"2.32.1"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -61,7 +61,11 @@ spec:
           - --headless
 {{- end }}
 {{- if .Values.master.auth.enabled }}
+{{- if or (semverCompare ">=2.21.0" .Values.image.tag) (semverCompare ">=2.21.0" .Values.master.image.tag) (semverCompare ">=2.21.0" .Values.worker.image.tag)}}
+          - --web-login={{ .Values.master.auth.username }}:{{ .Values.master.auth.password }}
+{{ else }}
           - --web-auth={{ .Values.master.auth.username }}:{{ .Values.master.auth.password }}
+{{- end }}
 {{- end }}
 {{- if .Values.loadtest.tags }}
           - --tags {{ .Values.loadtest.tags }}

--- a/stable/locust/templates/master-service.yaml
+++ b/stable/locust/templates/master-service.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (.Values.service.loadBalancerIP)}}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - name: master-p1
     port: 5557

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -38,13 +38,14 @@ loadtest:
 
 image:
   repository: locustio/locust
-  tag: 2.15.1
+  tag: 2.32.1
   pullPolicy: IfNotPresent
 
 service:
   type: ClusterIP
   annotations: {}
   extraLabels: {}
+  loadBalancerIP: ""
 
 master:
   # master.image -- A custom docker image including tag


### PR DESCRIPTION

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail --> Updated the image version to the latest. Added in a fix for web-login argument. Adds ability to pass in a kubernetes attribute `loadBalancerIP` to the master service if it's type `LoadBalancer` so that you can attach a reserved IP to it if you wanted to.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
