### PR TITLE
[stable/locust]: Updates the service and ingress to accept more port configurability

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.31.9"
+version: "0.32.0"
 appVersion: 2.32.2
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -106,25 +106,16 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | master.envs_include_default | bool | `true` | Whether to include default environment variables |
 | master.extraPorts | string | `nil` |  |
 | master.image | string | `""` | A custom docker image including tag |
-| master.livenessProbe.enabled | bool | `false` |  |
-| master.livenessProbe.failureThreshold | int | `2` |  |
-| master.livenessProbe.initialDelaySeconds | int | `60` |  |
-| master.livenessProbe.path | string | `"/"` |  |
-| master.livenessProbe.periodSeconds | int | `30` |  |
-| master.livenessProbe.port | int | `8089` |  |
-| master.livenessProbe.scheme | string | `"HTTP"` |  |
-| master.livenessProbe.successThreshold | int | `1` |  |
-| master.livenessProbe.timeoutSeconds | int | `30` |  |
+| master.livenessProbe | object | `{}` |  |
 | master.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
 | master.nodeSelector | object | `{}` | Overwrites nodeSelector from global |
 | master.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the master pod |
-| master.readinessProbe.enabled | bool | `true` |  |
 | master.readinessProbe.failureThreshold | int | `2` |  |
+| master.readinessProbe.httpGet.path | string | `"/"` |  |
+| master.readinessProbe.httpGet.port | int | `8089` |  |
+| master.readinessProbe.httpGet.scheme | string | `"HTTP"` |  |
 | master.readinessProbe.initialDelaySeconds | int | `5` |  |
-| master.readinessProbe.path | string | `"/"` |  |
 | master.readinessProbe.periodSeconds | int | `30` |  |
-| master.readinessProbe.port | int | `8089` |  |
-| master.readinessProbe.scheme | string | `"HTTP"` |  |
 | master.readinessProbe.successThreshold | int | `1` |  |
 | master.readinessProbe.timeoutSeconds | int | `30` |  |
 | master.replicas | int | `1` | Should be set to either 0 or 1. |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -122,6 +122,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | master.resources | object | `{}` | resources for the locust master |
 | master.restartPolicy | string | `"Always"` | master pod's restartPolicy. Can be Always, OnFailure, or Never. |
 | master.serviceAccountAnnotations | object | `{}` |  |
+| master.startupProbe | object | `{}` |  |
 | master.strategy.type | string | `"RollingUpdate"` |  |
 | master.tolerations | list | `[]` | Overwrites tolerations from global |
 | nameOverride | string | `""` |  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.31.9](https://img.shields.io/badge/Version-0.31.9-informational?style=flat-square) ![AppVersion: 2.32.2](https://img.shields.io/badge/AppVersion-2.32.2-informational?style=flat-square)
+![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![AppVersion: 2.32.2](https://img.shields.io/badge/AppVersion-2.32.2-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -37,7 +37,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust --version 0.31.9
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust --version 0.32.0
 ```
 
 To install the chart with the release name `my-release`:
@@ -104,10 +104,29 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | master.deploymentAnnotations | object | `{}` | Annotations on the deployment for master |
 | master.environment | object | `{}` | environment variables for the master |
 | master.envs_include_default | bool | `true` | Whether to include default environment variables |
+| master.extraPorts | string | `nil` |  |
 | master.image | string | `""` | A custom docker image including tag |
+| master.livenessProbe.enabled | bool | `false` |  |
+| master.livenessProbe.failureThreshold | int | `2` |  |
+| master.livenessProbe.initialDelaySeconds | int | `60` |  |
+| master.livenessProbe.path | string | `"/"` |  |
+| master.livenessProbe.periodSeconds | int | `30` |  |
+| master.livenessProbe.port | int | `8089` |  |
+| master.livenessProbe.scheme | string | `"HTTP"` |  |
+| master.livenessProbe.successThreshold | int | `1` |  |
+| master.livenessProbe.timeoutSeconds | int | `30` |  |
 | master.logLevel | string | `"INFO"` | Log level. Can be INFO or DEBUG |
 | master.nodeSelector | object | `{}` | Overwrites nodeSelector from global |
 | master.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the master pod |
+| master.readinessProbe.enabled | bool | `true` |  |
+| master.readinessProbe.failureThreshold | int | `2` |  |
+| master.readinessProbe.initialDelaySeconds | int | `5` |  |
+| master.readinessProbe.path | string | `"/"` |  |
+| master.readinessProbe.periodSeconds | int | `30` |  |
+| master.readinessProbe.port | int | `8089` |  |
+| master.readinessProbe.scheme | string | `"HTTP"` |  |
+| master.readinessProbe.successThreshold | int | `1` |  |
+| master.readinessProbe.timeoutSeconds | int | `30` |  |
 | master.replicas | int | `1` | Should be set to either 0 or 1. |
 | master.resources | object | `{}` | resources for the locust master |
 | master.restartPolicy | string | `"Always"` | master pod's restartPolicy. Can be Always, OnFailure, or Never. |
@@ -121,6 +140,8 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | service.annotations | object | `{}` |  |
 | service.extraLabels | object | `{}` |  |
 | service.loadBalancerIP | string | `""` |  |
+| service.port | int | `8089` |  |
+| service.targetPort | int | `8089` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |
 | worker.affinity | object | `{}` | Overwrites affinity from global |

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -60,6 +60,9 @@ spec:
 {{- if .Values.loadtest.headless }}
           - --headless
 {{- end }}
+{{- if ne (.Values.service.targetPort | toString) "8089" }}
+          - --web-port {{ .Values.service.targetPort }}
+{{- end }}
 {{- if .Values.master.auth.enabled }}
 {{- if or (semverCompare ">=2.21.0" .Values.image.tag) (semverCompare ">=2.21.0" .Values.master.image.tag) (semverCompare ">=2.21.0" .Values.worker.image.tag)}}
           - --web-login
@@ -132,7 +135,7 @@ spec:
 {{- end }}
 {{- end }}
         ports:
-          - containerPort: 8089
+          - containerPort: {{ .Values.service.targetPort }}
             name: loc-master-web
             protocol: TCP
           - containerPort: 5557
@@ -141,24 +144,60 @@ spec:
           - containerPort: 5558
             name: loc-master-p2
             protocol: TCP
+        {{- if .Values.master.extraPorts -}}
+        {{ toYaml .Values.master.extraPorts | nindent 10 }}
+        {{- end }}
+        {{- if .Values.master.readinessProbe.enabled }}
         readinessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 30
-          timeoutSeconds: 30
-          failureThreshold: 2
-{{- if .Values.loadtest.headless }}
+          {{- if .Values.loadtest.headless }}
           tcpSocket:
             port: 5557
-{{ else }}
+          {{- else if .Values.master.readinessProbe.execCommand }}
+          exec:
+            command:
+            {{- range (.Values.master.readinessProbe.execCommand) }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- else }}
           httpGet:
-            path: /
-            port: 8089
-{{- if .Values.master.auth.enabled }}
+            path: {{ .Values.master.readinessProbe.path | quote }}
+            port: {{ .Values.master.readinessProbe.port }}
+            scheme: {{ .Values.master.readinessProbe.scheme }}
+            {{- if and (.Values.master.auth.enabled) (semverCompare "<=2.20.0" .Values.image.tag) }}
             httpHeaders:
-                - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.master.auth.username .Values.master.auth.password | b64enc }}
-{{- end }}
-{{- end }}
+            - name: Authorization
+              value: Basic {{ printf "%s:%s" .Values.master.auth.username .Values.master.auth.password | b64enc }}
+            {{- end }}
+          {{- end }}
+          initialDelaySeconds: {{ .Values.master.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.master.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.master.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.master.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.master.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.master.livenessProbe.enabled }}
+        livenessProbe:
+          {{- if .Values.loadtest.headless }}
+          tcpSocket:
+            port: 5557
+          {{- else if .Values.master.livenessProbe.execCommand }}
+          exec:
+            command:
+            {{- range (.Values.master.livenessProbe.execCommand) }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- else }}
+          httpGet:
+            path: {{ .Values.master.livenessProbe.path | quote }}
+            port: {{ .Values.master.livenessProbe.port }}
+            scheme: {{ .Values.master.livenessProbe.scheme }}
+          {{- end }}
+          failureThreshold: {{ .Values.master.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.master.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.master.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
+        {{- end }}
       restartPolicy: {{ .Values.master.restartPolicy }}
       volumes:
         {{- if .Values.loadtest.locust_lib_configmap }}

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -147,10 +147,18 @@ spec:
         {{- if .Values.master.extraPorts -}}
         {{ toYaml .Values.master.extraPorts | nindent 10 }}
         {{- end }}
+        {{- if .Values.master.readinessProbe }}
         readinessProbe:
           {{- toYaml .Values.master.readinessProbe | nindent 12 }}
+        {{- end }}
+        {{- if .Values.master.livenessProbe }}
         livenessProbe:
           {{- toYaml .Values.master.livenessProbe | nindent 12 }}
+        {{- end }}
+        {{- if .Values.master.startupProbe }}
+        startupProbe:
+          {{- toYaml .Values.master.startupProbe | nindent 12 }}
+        {{- end }}
       restartPolicy: {{ .Values.master.restartPolicy }}
       volumes:
         {{- if .Values.loadtest.locust_lib_configmap }}

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -147,57 +147,10 @@ spec:
         {{- if .Values.master.extraPorts -}}
         {{ toYaml .Values.master.extraPorts | nindent 10 }}
         {{- end }}
-        {{- if .Values.master.readinessProbe.enabled }}
         readinessProbe:
-          {{- if .Values.loadtest.headless }}
-          tcpSocket:
-            port: 5557
-          {{- else if .Values.master.readinessProbe.execCommand }}
-          exec:
-            command:
-            {{- range (.Values.master.readinessProbe.execCommand) }}
-            - {{ . | quote }}
-            {{- end }}
-          {{- else }}
-          httpGet:
-            path: {{ .Values.master.readinessProbe.path | quote }}
-            port: {{ .Values.master.readinessProbe.port }}
-            scheme: {{ .Values.master.readinessProbe.scheme }}
-            {{- if and (.Values.master.auth.enabled) (semverCompare "<=2.20.0" .Values.image.tag) }}
-            httpHeaders:
-            - name: Authorization
-              value: Basic {{ printf "%s:%s" .Values.master.auth.username .Values.master.auth.password | b64enc }}
-            {{- end }}
-          {{- end }}
-          initialDelaySeconds: {{ .Values.master.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.master.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.master.readinessProbe.timeoutSeconds }}
-          failureThreshold: {{ .Values.master.readinessProbe.failureThreshold }}
-          successThreshold: {{ .Values.master.readinessProbe.successThreshold }}
-        {{- end }}
-        {{- if .Values.master.livenessProbe.enabled }}
+          {{- toYaml .Values.master.readinessProbe | nindent 12 }}
         livenessProbe:
-          {{- if .Values.loadtest.headless }}
-          tcpSocket:
-            port: 5557
-          {{- else if .Values.master.livenessProbe.execCommand }}
-          exec:
-            command:
-            {{- range (.Values.master.livenessProbe.execCommand) }}
-            - {{ . | quote }}
-            {{- end }}
-          {{- else }}
-          httpGet:
-            path: {{ .Values.master.livenessProbe.path | quote }}
-            port: {{ .Values.master.livenessProbe.port }}
-            scheme: {{ .Values.master.livenessProbe.scheme }}
-          {{- end }}
-          failureThreshold: {{ .Values.master.livenessProbe.failureThreshold }}
-          initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.master.livenessProbe.periodSeconds }}
-          successThreshold: {{ .Values.master.livenessProbe.successThreshold }}
-          timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
-        {{- end }}
+          {{- toYaml .Values.master.livenessProbe | nindent 12 }}
       restartPolicy: {{ .Values.master.restartPolicy }}
       volumes:
         {{- if .Values.loadtest.locust_lib_configmap }}

--- a/stable/locust/templates/master-ingress.yaml
+++ b/stable/locust/templates/master-ingress.yaml
@@ -49,10 +49,10 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: 8089
+                  number: {{ $.Values.service.port }}
               {{- else }}
               serviceName: {{ $fullName }}
-              servicePort: 8089
+              servicePort: {{ $.Values.service.port }}
               {{- end }}
     {{- end }}
   {{- end }}

--- a/stable/locust/templates/master-service.yaml
+++ b/stable/locust/templates/master-service.yaml
@@ -24,9 +24,12 @@ spec:
     protocol: TCP
     targetPort: 5558
   - name: master-p3
-    port: 8089
+    port: {{ .Values.service.port }}
     protocol: TCP
-    targetPort: 8089
+    targetPort: {{ .Values.service.targetPort }}
+    {{- if and (.Values.service.nodePort) (eq (.Values.service.type | toString) "NodePort") }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
   selector:
     component: master
     {{- include "locust.selectorLabels" . | nindent 4 }}

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -119,6 +119,18 @@ master:
     #   port: 8089
     #   scheme: HTTP
 
+  # Used to define startupProbe for the pod
+  startupProbe: {}
+    # initialDelaySeconds: 60
+    # periodSeconds: 30
+    # timeoutSeconds: 30
+    # failureThreshold: 2
+    # successThreshold: 1
+    # httpGet:
+    #   path: /
+    #   port: 8089
+    #   scheme: HTTP
+
   # master.restartPolicy -- master pod's restartPolicy. Can be Always, OnFailure, or Never.
   restartPolicy: Always
   # master.nodeSelector -- Overwrites nodeSelector from global

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -95,37 +95,29 @@ master:
     # - containerPort: 8080
     #   name: http-monitoring
 
-  # Used to define custom readinessProbe settings
+  # Used to define readinessProbe for the pod
   readinessProbe:
-    enabled: true
-    # execCommand: []
-    # - /bin/sh
-    # - -c
-    # - /mnt/locust/myreadinessscript.sh
-    path: "/"
-    port: 8089
-    scheme: "HTTP"
     initialDelaySeconds: 5
     periodSeconds: 30
     timeoutSeconds: 30
     failureThreshold: 2
     successThreshold: 1
+    httpGet:
+      path: /
+      port: 8089
+      scheme: HTTP
 
-  # Used to enable a livenessProbe for the pods
-  livenessProbe:
-    enabled: false
-    # execCommand: []
-    # - /bin/sh
-    # - -c
-    # - /mnt/locust/mylivenessscript.sh
-    path: "/"
-    port: 8089
-    scheme: "HTTP"
-    initialDelaySeconds: 60
-    periodSeconds: 30
-    timeoutSeconds: 30
-    failureThreshold: 2
-    successThreshold: 1
+  # Used to define livenessProbe for the pod
+  livenessProbe: {}
+    # initialDelaySeconds: 60
+    # periodSeconds: 30
+    # timeoutSeconds: 30
+    # failureThreshold: 2
+    # successThreshold: 1
+    # httpGet:
+    #   path: /
+    #   port: 8089
+    #   scheme: HTTP
 
   # master.restartPolicy -- master pod's restartPolicy. Can be Always, OnFailure, or Never.
   restartPolicy: Always

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -46,6 +46,9 @@ service:
   annotations: {}
   extraLabels: {}
   loadBalancerIP: ""
+  port: 8089
+  targetPort: 8089
+  # nodePort: 8089
 
 master:
   # master.image -- A custom docker image including tag
@@ -85,6 +88,45 @@ master:
     enabled: false
     username: ""
     password: ""
+
+  # extraPorts is a list of extra ports. Specified as a YAML list.
+  # This is useful if you need to add additional ports for monitoring.
+  extraPorts: null
+    # - containerPort: 8080
+    #   name: http-monitoring
+
+  # Used to define custom readinessProbe settings
+  readinessProbe:
+    enabled: true
+    # execCommand: []
+    # - /bin/sh
+    # - -c
+    # - /mnt/locust/myreadinessscript.sh
+    path: "/"
+    port: 8089
+    scheme: "HTTP"
+    initialDelaySeconds: 5
+    periodSeconds: 30
+    timeoutSeconds: 30
+    failureThreshold: 2
+    successThreshold: 1
+
+  # Used to enable a livenessProbe for the pods
+  livenessProbe:
+    enabled: false
+    # execCommand: []
+    # - /bin/sh
+    # - -c
+    # - /mnt/locust/mylivenessscript.sh
+    path: "/"
+    port: 8089
+    scheme: "HTTP"
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    timeoutSeconds: 30
+    failureThreshold: 2
+    successThreshold: 1
+
   # master.restartPolicy -- master pod's restartPolicy. Can be Always, OnFailure, or Never.
   restartPolicy: Always
   # master.nodeSelector -- Overwrites nodeSelector from global


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Updates the service and ingress to accept more port configurability

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
