### PR TITLE
[stable/wiremock] fix environment secrets handling

### DIFF
--- a/stable/wiremock/Chart.yaml
+++ b/stable/wiremock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wiremock
-version: "1.4.3"
+version: "1.4.4"
 appVersion: "2.26.0"
 home: http://wiremock.org/
 icon: http://wiremock.org/images/wiremock-concept-icon-01.png

--- a/stable/wiremock/README.md
+++ b/stable/wiremock/README.md
@@ -1,6 +1,6 @@
 # wiremock
 
-![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
+![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
 
 A service virtualization tool (some call it mock server) for testing purposes.
 
@@ -88,7 +88,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/wiremock
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/wiremock --version 1.4.3
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/wiremock --version 1.4.4
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/wiremock/templates/deployment.yaml
+++ b/stable/wiremock/templates/deployment.yaml
@@ -81,6 +81,14 @@ spec:
             value: {{ $value | quote }}
 {{- end }}
 
+{{- range $key, $value := .Values.consumer.environment_secret }}
+          - name: {{ $key }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "wiremock.fullname" $ }}
+                key: {{ $key }}
+{{- end }}
+
 {{- if .Values.consumer.args_include_default }}
         args:
           - --disable-banner


### PR DESCRIPTION
## Description
This PR fixes an issue with environment secrets handling where configured secrets have not been added to the env spec.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
