### PR TITLE
[stable/locust]: Updates configmap for locustfile and lib to not be wrapped in explictstring "example"

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.32.0"
+version: "0.32.1"
 appVersion: 2.32.2
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -86,7 +86,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |
 | loadtest.locustCmd | string | `"/opt/venv/bin/locust"` | The command to run Locust |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |
-| loadtest.locust_lib_configmap | string | `"example-lib"` | name of a configmap containing your lib (default uses the example lib) |
+| loadtest.locust_lib_configmap | string | `""` | name of a configmap containing your lib (default uses the example lib) |
 | loadtest.locust_locustfile | string | `"main.py"` | the name of the locustfile |
 | loadtest.locust_locustfile_configmap | string | `"example-locustfile"` | name of a configmap containing your locustfile (default uses the example locustfile) |
 | loadtest.locust_locustfile_path | string | `"/mnt/locust"` | the path of the locustfile (without trailing backslash) |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![AppVersion: 2.32.2](https://img.shields.io/badge/AppVersion-2.32.2-informational?style=flat-square)
+![Version: 0.32.1](https://img.shields.io/badge/Version-0.32.1-informational?style=flat-square) ![AppVersion: 2.32.2](https://img.shields.io/badge/AppVersion-2.32.2-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -37,7 +37,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust --version 0.32.0
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust --version 0.32.1
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -86,7 +86,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | loadtest.headless | bool | `false` | whether to run locust with headless settings |
 | loadtest.locustCmd | string | `"/opt/venv/bin/locust"` | The command to run Locust |
 | loadtest.locust_host | string | `"https://www.google.com"` | the host you will load test |
-| loadtest.locust_lib_configmap | string | `""` | name of a configmap containing your lib (default uses the example lib) |
+| loadtest.locust_lib_configmap | string | `"example-lib"` | name of a configmap containing your lib (default uses the example lib) |
 | loadtest.locust_locustfile | string | `"main.py"` | the name of the locustfile |
 | loadtest.locust_locustfile_configmap | string | `"example-locustfile"` | name of a configmap containing your locustfile (default uses the example locustfile) |
 | loadtest.locust_locustfile_path | string | `"/mnt/locust"` | the path of the locustfile (without trailing backslash) |

--- a/stable/locust/templates/configmap-locust-lib.yaml
+++ b/stable/locust/templates/configmap-locust-lib.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.loadtest.locust_lib_configmap "example-lib" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,4 +6,3 @@ metadata:
 {{ include "locust.labels" . | indent 4 }}
 data:
 {{ ($.Files.Glob (printf "locustfiles/%s/lib/*" .Values.loadtest.name)).AsConfig | indent 2 }}
-{{- end }}

--- a/stable/locust/templates/configmap-locust-lib.yaml
+++ b/stable/locust/templates/configmap-locust-lib.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loadtest.locust_lib_configmap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
 {{ include "locust.labels" . | indent 4 }}
 data:
 {{ ($.Files.Glob (printf "locustfiles/%s/lib/*" .Values.loadtest.name)).AsConfig | indent 2 }}
+{{- end }}

--- a/stable/locust/templates/configmap-locust-locustfile.yaml
+++ b/stable/locust/templates/configmap-locust-locustfile.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.loadtest.locust_locustfile_configmap "example-locustfile" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,4 +6,3 @@ metadata:
 {{ include "locust.labels" . | indent 4 }}
 data:
 {{ ($.Files.Glob (printf "locustfiles/%s/%s" .Values.loadtest.name .Values.loadtest.locust_locustfile)).AsConfig | indent 2 }}
-{{- end }}

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -8,7 +8,7 @@ loadtest:
   # loadtest.locust_locustfile_configmap -- name of a configmap containing your locustfile (default uses the example locustfile)
   locust_locustfile_configmap: "example-locustfile"
   # loadtest.locust_lib_configmap -- name of a configmap containing your lib (default uses the example lib)
-  locust_lib_configmap: "example-lib"
+  locust_lib_configmap: ""
   # loadtest.locust_host -- the host you will load test
   locust_host: https://www.google.com
   # loadtest.pip_packages -- a list of extra python pip packages to install

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -8,7 +8,7 @@ loadtest:
   # loadtest.locust_locustfile_configmap -- name of a configmap containing your locustfile (default uses the example locustfile)
   locust_locustfile_configmap: "example-locustfile"
   # loadtest.locust_lib_configmap -- name of a configmap containing your lib (default uses the example lib)
-  locust_lib_configmap: ""
+  locust_lib_configmap: "example-lib"
   # loadtest.locust_host -- the host you will load test
   locust_host: https://www.google.com
   # loadtest.pip_packages -- a list of extra python pip packages to install


### PR DESCRIPTION
## Description

Updates configmap for locustfile and lib to not be wrapped in explictstring "example"

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
