### PR TITLE
[stable/locust]: Updates locust chart configmap files glog statement

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.32.1"
+version: "0.32.2"
 appVersion: 2.32.2
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.32.1](https://img.shields.io/badge/Version-0.32.1-informational?style=flat-square) ![AppVersion: 2.32.2](https://img.shields.io/badge/AppVersion-2.32.2-informational?style=flat-square)
+![Version: 0.32.2](https://img.shields.io/badge/Version-0.32.2-informational?style=flat-square) ![AppVersion: 2.32.2](https://img.shields.io/badge/AppVersion-2.32.2-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -37,7 +37,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust --version 0.32.1
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust --version 0.32.2
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/locust/templates/configmap-locust-lib.yaml
+++ b/stable/locust/templates/configmap-locust-lib.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.loadtest.locust_lib_configmap }}
+{{- if eq .Values.loadtest.locust_lib_configmap "example-lib" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/locust/templates/configmap-locust-locustfile.yaml
+++ b/stable/locust/templates/configmap-locust-locustfile.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.loadtest.locust_locustfile_configmap "example-locustfile" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
 {{ include "locust.labels" . | indent 4 }}
 data:
 {{ (.Files.Glob (printf "locustfiles/%s/%s" .Values.loadtest.name .Values.loadtest.locust_locustfile)).AsConfig | indent 2 }}
+{{- end }}

--- a/stable/locust/templates/configmap-locust-locustfile.yaml
+++ b/stable/locust/templates/configmap-locust-locustfile.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
 {{ include "locust.labels" . | indent 4 }}
 data:
-{{ ($.Files.Glob (printf "locustfiles/%s/%s" .Values.loadtest.name .Values.loadtest.locust_locustfile)).AsConfig | indent 2 }}
+{{ (.Files.Glob (printf "locustfiles/%s/%s" .Values.loadtest.name .Values.loadtest.locust_locustfile)).AsConfig | indent 2 }}


### PR DESCRIPTION
## Description

Updates the locustfile's configmap Files Glob syntax. Seems to be a small syntax change for helm 3 maybe.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
