### PR TITLE
Second try: host and update helm charts repo index.yaml on github

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -13,9 +13,9 @@ env:
   REGISTRY: "ghcr.io/${{ github.repository }}"
 
 jobs:
-  helm:
+  package-and-release:
     permissions:
-      contents: read
+      contents: write
       packages: write
     runs-on: ubuntu-latest
     steps:
@@ -54,7 +54,7 @@ jobs:
         shell: bash
         run: |
           helm repo index .
-      - name: Update URLs in index.yaml
+      - name: Update URLs in index.yaml with yq
         uses: mikefarah/yq@v4.44.6
         with:
           cmd: yq eval -i '. |= .entries[][] |= .urls[0] = "oci://" + env(REGISTRY) + "/" + .name + ":" + .version' index.yaml
@@ -64,4 +64,5 @@ jobs:
           add: 'index.yaml'
           committer_name: GitHub Actions
           committer_email: actions@github.com
+          author_email: actions@github.com
           message: "$GITHUB_ACTION is updating index.yaml for $GITHUB_REF"

--- a/stable/aws-ebs-csi-driver/Chart.yaml
+++ b/stable/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.16.1
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.17.2
+version: 2.17.3
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/stable/aws-ebs-csi-driver/README.md
+++ b/stable/aws-ebs-csi-driver/README.md
@@ -1,6 +1,6 @@
 # aws-ebs-csi-driver
 
-![Version: 2.17.2](https://img.shields.io/badge/Version-2.17.2-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
+![Version: 2.17.3](https://img.shields.io/badge/Version-2.17.3-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
 
 A Helm chart for AWS EBS CSI Driver
 
@@ -17,7 +17,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/aws-ebs-csi-
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/aws-ebs-csi-driver --version 2.17.2
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/aws-ebs-csi-driver --version 2.17.3
 ```
 
 To install the chart with the release name `my-release`:


### PR DESCRIPTION
This is part of an effort to move away from chartmuseum