### PR TITLE
[stable/locust] Add support for git sync

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 name: locust
-version: "0.32.3"
+version: "0.33.0"
 appVersion: 2.32.2
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png
 maintainers:
-- name: max-rocket-internet
-  email: no-reply@deliveryhero.com
+  - name: max-rocket-internet
+    email: no-reply@deliveryhero.com
 description: |
   A chart to install Locust, a scalable load testing tool written in Python.
 

--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -12,7 +12,11 @@ description: |
 
   This chart will setup everything required to run a full distributed locust environment with any amount of workers.
 
-  This chart will also create configmaps for storing the locust files in Kubernetes, this way there is no need to build custom docker images.
+  Locust requires locust files to execute load testing, and this chart provides different ways to populate locust files.
+
+  ## Kubernetes ConfigMap
+
+  This chart can create configmaps for storing the locust files in Kubernetes, this way there is no need to build custom docker images.
 
   By default it will install using an example locustfile and lib from [stable/locust/locustfiles/example](https://github.com/deliveryhero/helm-charts/tree/master/stable/locust/locustfiles/example). When you want to provide your own locustfile, you will need to create 2 configmaps using the structure from that example:
 
@@ -28,4 +32,26 @@ description: |
     --set loadtest.name=my-loadtest \
     --set loadtest.locust_locustfile_configmap=my-loadtest-locustfile \
     --set loadtest.locust_lib_configmap=my-loadtest-lib
+  ```
+
+  ## Git Sync
+
+  Another way to fetch locust files in the pods is to continously track a git repository containing the files.
+
+  While activating this feature, you also have to disable the default ConfigMap-based provisioning, through a custom `values.yaml` file:
+
+  ```yaml
+  loadtest:
+    enabled = false
+  locustfiles:
+    gitSync:
+      enabled = true
+  ```
+
+  Then configure the gitSync process to fetch the right repository and the right files:
+
+  ```yaml
+  locustfiles:
+    gitSync:
+      repo: https://github.com/username/reponame.git
   ```

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.32.3](https://img.shields.io/badge/Version-0.32.3-informational?style=flat-square) ![AppVersion: 2.32.2](https://img.shields.io/badge/AppVersion-2.32.2-informational?style=flat-square)
+![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![AppVersion: 2.32.2](https://img.shields.io/badge/AppVersion-2.32.2-informational?style=flat-square)
 
 A chart to install Locust, a scalable load testing tool written in Python.
 
@@ -37,7 +37,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust --version 0.32.3
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/locust --version 0.33.0
 ```
 
 To install the chart with the release name `my-release`:
@@ -72,6 +72,17 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | image.repository | string | `"locustio/locust"` |  |
 | image.tag | string | `"2.32.2"` |  |
 | imagePullSecrets | list | `[]` |  |
+| images.defaultLocustRepository | string | `"locustio/locust"` |  |
+| images.defaultLocustTag | string | `"2.32.2"` |  |
+| images.gitSync.pullPolicy | string | `"IfNotPresent"` |  |
+| images.gitSync.repository | string | `"registry.k8s.io/git-sync/git-sync"` |  |
+| images.gitSync.tag | string | `"v4.1.0"` |  |
+| images.master.pullPolicy | string | `"IfNotPresent"` |  |
+| images.master.repository | string | `nil` |  |
+| images.master.tag | string | `nil` |  |
+| images.worker.pullPolicy | string | `"IfNotPresent"` |  |
+| images.worker.repository | string | `nil` |  |
+| images.worker.tag | string | `nil` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
@@ -79,6 +90,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | ingress.hosts[0].path | string | `"/"` |  |
 | ingress.hosts[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| loadtest.enabled | bool | `true` |  |
 | loadtest.environment | object | `{}` | environment variables used in the load test for both master and workers |
 | loadtest.environment_external_secret | object | `{}` | environment variables used in the load test for both master and workers, stored in secrets created outside this chart. Each secret contains a list of values in it. Usage: `secret_name: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]` |
 | loadtest.environment_secret | object | `{}` | environment variables used in the load test for both master and workers, stored as secrets |
@@ -94,6 +106,24 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/locust -f values.
 | loadtest.name | string | `"example"` | a name used for resources and settings in this load test |
 | loadtest.pip_packages | list | `[]` | a list of extra python pip packages to install |
 | loadtest.tags | string | `""` | whether to run locust with `--tags [TAG [TAG ...]]` options, so only tasks with any matching tags will be executed |
+| locustfiles.gitSync.containerLifecycleHooks | object | `{}` |  |
+| locustfiles.gitSync.containerName | string | `"git-sync"` |  |
+| locustfiles.gitSync.depth | int | `1` |  |
+| locustfiles.gitSync.enabled | bool | `false` |  |
+| locustfiles.gitSync.env | list | `[]` |  |
+| locustfiles.gitSync.envFrom | string | `nil` |  |
+| locustfiles.gitSync.extraVolumeMounts | list | `[]` |  |
+| locustfiles.gitSync.maxFailures | int | `0` |  |
+| locustfiles.gitSync.period | string | `"5s"` |  |
+| locustfiles.gitSync.ref | string | `"main"` |  |
+| locustfiles.gitSync.repo | string | `nil` |  |
+| locustfiles.gitSync.resources | object | `{}` |  |
+| locustfiles.gitSync.securityContext | object | `{}` |  |
+| locustfiles.gitSync.securityContexts.container | object | `{}` |  |
+| locustfiles.gitSync.subPath | string | `"locustfiles"` |  |
+| locustfiles.gitSync.uid | int | `65533` |  |
+| locustfiles.mountPath | string | `"/mnt/locust"` |  |
+| locustfiles.requirements | string | `nil` |  |
 | master.affinity | object | `{}` | Overwrites affinity from global |
 | master.args | list | `[]` | Any extra command args for the master |
 | master.auth.enabled | bool | `false` | When enabled using image tag 2.21.0 or later you do not need username or pass word. Older image tags you are required to |

--- a/stable/locust/templates/_helpers.tpl
+++ b/stable/locust/templates/_helpers.tpl
@@ -122,8 +122,16 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- template "locust.legacy_image" -}}
   {{- else }}
     {{- $repository := .Values.images.master.repository | default .Values.images.defaultLocustRepository -}}
-    {{- $tag := .Values.images.master.tag | default .Values.defaultLocustTag -}}
+    {{- $tag := .Values.images.master.tag | default .Values.images.defaultLocustTag -}}
     {{- printf "%s:%s" $repository $tag -}}
+  {{- end }}
+{{- end }}
+
+{{- define "locust.master_pull_policy" -}}
+{{- if .Values.image }}
+    {{- .Values.image.pullPolicy -}}
+  {{- else }}
+    {{- .Values.images.master.pullPolicy -}}
   {{- end }}
 {{- end }}
 
@@ -132,10 +140,19 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- template "locust.legacy_image" -}}
   {{- else }}
     {{- $repository := .Values.images.worker.repository | default .Values.images.defaultLocustRepository -}}
-    {{- $tag := .Values.images.worker.tag | default .Values.defaultLocustTag -}}
+    {{- $tag := .Values.images.worker.tag | default .Values.images.defaultLocustTag -}}
     {{- printf "%s:%s" $repository $tag -}}
   {{- end }}
 {{- end }}
+
+{{- define "locust.worker_pull_policy" -}}
+{{- if .Values.image }}
+    {{- .Values.image.pullPolicy -}}
+  {{- else }}
+    {{- .Values.images.worker.pullPolicy -}}
+  {{- end }}
+{{- end }}
+
 
 {{- define "git_sync_image" -}}
   {{- printf "%s:%s" .Values.images.gitSync.repository .Values.images.gitSync.tag }}
@@ -182,7 +199,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{- end }}
 {{- end }}
 
-{{- define "locust.locustfiles_mount" -}}
+{{- define "locust.locustfiles_mount" }}
 - name: locustfiles
   mountPath: {{ .Values.locustfiles.mountPath }}
   readOnly: {{ .Values.locustfiles.gitSync.enabled | ternary "True" "False" }}

--- a/stable/locust/templates/configmap-config.yaml
+++ b/stable/locust/templates/configmap-config.yaml
@@ -10,8 +10,11 @@ data:
 
     set -eu
 
-    {{- if .Values.loadtest.pip_packages }}
+    {{- if and .Values.loadtest.enabled .Values.loadtest.pip_packages }}
     pip install {{ range .Values.loadtest.pip_packages }}{{ . }} {{ end }}
+    {{- end }}
+    {{- if .Values.locustfiles.requirements }}
+    pip install -r {{ .Values.locustfiles.requirements }}
     {{- end }}
 
     exec {{ .Values.loadtest.locustCmd }} $@

--- a/stable/locust/templates/configmap-locust-lib.yaml
+++ b/stable/locust/templates/configmap-locust-lib.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loadtest.enabled }}
 {{- if eq .Values.loadtest.locust_lib_configmap "example-lib" }}
 apiVersion: v1
 kind: ConfigMap
@@ -7,4 +8,5 @@ metadata:
 {{ include "locust.labels" . | indent 4 }}
 data:
 {{ ($.Files.Glob (printf "locustfiles/%s/lib/*" .Values.loadtest.name)).AsConfig | indent 2 }}
+{{- end }}
 {{- end }}

--- a/stable/locust/templates/configmap-locust-locustfile.yaml
+++ b/stable/locust/templates/configmap-locust-locustfile.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.loadtest.enabled }}
 {{- if eq .Values.loadtest.locust_locustfile_configmap "example-locustfile" }}
 apiVersion: v1
 kind: ConfigMap
@@ -6,5 +7,6 @@ metadata:
   labels:
 {{ include "locust.labels" . | indent 4 }}
 data:
-{{ (.Files.Glob (printf "locustfiles/%s/%s" .Values.loadtest.name .Values.loadtest.locust_locustfile)).AsConfig | indent 2 }}
+{{ ($.Files.Glob (printf "locustfiles/%s/%s" .Values.loadtest.name .Values.loadtest.locust_locustfile)).AsConfig | indent 2 }}
+{{- end }}
 {{- end }}

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -45,16 +45,16 @@ spec:
 {{- end }}
       initContainers:
         {{- if .Values.locustfiles.gitSync.enabled }}
-          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
+          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 6 }}
         {{- end }}
       containers:
       {{- if .Values.locustfiles.gitSync.enabled }}
-        {{- include "git_sync_container" . | nindent 8 }}
+        {{- include "git_sync_container" . | nindent 6 }}
       {{- end }}
       - name: {{ .Chart.Name }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-        image: {{ template "locust.master_image" }}
+        image: {{ template "locust.master_image" . }}
 {{- with .Values.master.command }}
         command:
         {{- toYaml . | nindent 8 }}
@@ -83,20 +83,22 @@ spec:
 {{- if .Values.loadtest.excludeTags }}
           - --exclude-tags {{ .Values.loadtest.excludeTags }}
 {{- end }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ template "locust.master_pull_policy" . }}
         resources:
 {{ toYaml .Values.master.resources | indent 10 }}
         volumeMounts:
-          {{- if .Values.loadtest.locust_locustfile_configmap}}
+          {{- if .Values.loadtest.enabled }}
+            {{- if .Values.loadtest.locust_locustfile_configmap}}
           - name: locustfile
             mountPath: "{{ .Values.loadtest.locust_locustfile_path }}"
-          {{- end }}
-          {{- if .Values.loadtest.locust_lib_configmap }}
+            {{- end }}
+            {{- if .Values.loadtest.locust_lib_configmap }}
           - name: lib
             mountPath: "{{ .Values.loadtest.locust_locustfile_path }}/lib"
+            {{- end }}
           {{- end }}
           {{- if .Values.locustfiles.gitSync.enabled }}
-            {{- include "locust.locustfiles_mount" . | nindent 12 }}
+            {{- include "locust.locustfiles_mount" . | nindent 10 }}
           {{- end }}
           - name: config
             mountPath: /config
@@ -117,7 +119,11 @@ spec:
           - name: LOCUST_LOGLEVEL
             value: "{{ .Values.master.logLevel }}"
           - name: LOCUST_LOCUSTFILE
+            {{- if .Values.loadtest.enabled }}
             value: "{{ .Values.loadtest.locust_locustfile_path }}/{{ .Values.loadtest.locust_locustfile }}"
+            {{- else if .Values.locustfiles.gitSync.enabled }}
+            value: "{{ .Values.locustfiles.mountPath }}/repo/{{ .Values.locustfiles.gitSync.subPath }}/"
+            {{- end }}
 {{- end }}
 {{- range $key, $value := .Values.loadtest.environment }}
           - name: {{ $key }}
@@ -171,19 +177,21 @@ spec:
         {{- end }}
       restartPolicy: {{ .Values.master.restartPolicy }}
       volumes:
-        {{- if .Values.loadtest.locust_lib_configmap }}
+        {{- if .Values.loadtest.enabled }}
+          {{- if .Values.loadtest.locust_lib_configmap }}
         - name: lib
           configMap:
             name: {{ .Values.loadtest.locust_lib_configmap }}
-        {{- end }}
-        {{- if .Values.loadtest.locust_locustfile_configmap }}
+          {{- end }}
+          {{- if .Values.loadtest.locust_locustfile_configmap }}
         - name: locustfile
           configMap:
             name: {{ .Values.loadtest.locust_locustfile_configmap }}
+          {{- end }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.locustfiles.gitSync.enabled }}
         - name: locustfiles
-          emptyDir:
+          emptyDir: {}
         {{- end }}
         - name: config
           configMap:

--- a/stable/locust/templates/master-deployment.yaml
+++ b/stable/locust/templates/master-deployment.yaml
@@ -43,11 +43,18 @@ spec:
 {{- if .Values.hostAliases }}
       hostAliases: {{- .Values.hostAliases | toYaml | nindent 8 }}
 {{- end }}
+      initContainers:
+        {{- if .Values.locustfiles.gitSync.enabled }}
+          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
+        {{- end }}
       containers:
+      {{- if .Values.locustfiles.gitSync.enabled }}
+        {{- include "git_sync_container" . | nindent 8 }}
+      {{- end }}
       - name: {{ .Chart.Name }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-        image: "{{ if .Values.master.image }}{{ .Values.master.image }}{{ else }}{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ end }}"
+        image: {{ template "locust.master_image" }}
 {{- with .Values.master.command }}
         command:
         {{- toYaml . | nindent 8 }}
@@ -87,6 +94,9 @@ spec:
           {{- if .Values.loadtest.locust_lib_configmap }}
           - name: lib
             mountPath: "{{ .Values.loadtest.locust_locustfile_path }}/lib"
+          {{- end }}
+          {{- if .Values.locustfiles.gitSync.enabled }}
+            {{- include "locust.locustfiles_mount" . | nindent 12 }}
           {{- end }}
           - name: config
             mountPath: /config
@@ -170,6 +180,10 @@ spec:
         - name: locustfile
           configMap:
             name: {{ .Values.loadtest.locust_locustfile_configmap }}
+        {{- end }}
+        {{- if .Values.dags.gitSync.enabled }}
+        - name: locustfiles
+          emptyDir:
         {{- end }}
         - name: config
           configMap:

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -45,11 +45,18 @@ spec:
 {{- if .Values.hostAliases }}
       hostAliases: {{- .Values.hostAliases | toYaml | nindent 8 }}
 {{- end }}
+      initContainers:
+        {{- if .Values.locustfiles.gitSync.enabled }}
+          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
+        {{- end }}
       containers:
+      {{- if .Values.locustfiles.gitSync.enabled }}
+        {{- include "git_sync_container" . | nindent 8 }}
+      {{- end }}
       - name: {{ .Chart.Name }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-        image: "{{ if .Values.worker.image }}{{ .Values.worker.image }}{{ else }}{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ end }}"
+        image: {{ template "locust.worker_image" }}
 {{- with .Values.worker.command }}
         command:
         {{- toYaml . | nindent 8 }}
@@ -70,6 +77,9 @@ spec:
           {{- if .Values.loadtest.locust_lib_configmap }}
           - name: lib
             mountPath: "{{ .Values.loadtest.locust_locustfile_path }}/lib"
+          {{- end }}
+          {{- if .Values.locustfiles.gitSync.enabled }}
+            {{- include "locust.locustfiles_mount" . | nindent 12 }}
           {{- end }}
           - name: config
             mountPath: /config
@@ -132,6 +142,10 @@ spec:
         - name: locustfile
           configMap:
             name: {{ .Values.loadtest.locust_locustfile_configmap }}
+        {{- end }}
+        {{- if .Values.dags.gitSync.enabled }}
+        - name: locustfiles
+          emptyDir:
         {{- end }}
         - name: config
           configMap:

--- a/stable/locust/templates/worker-deployment.yaml
+++ b/stable/locust/templates/worker-deployment.yaml
@@ -51,12 +51,12 @@ spec:
         {{- end }}
       containers:
       {{- if .Values.locustfiles.gitSync.enabled }}
-        {{- include "git_sync_container" . | nindent 8 }}
+        {{- include "git_sync_container" . | nindent 6 }}
       {{- end }}
       - name: {{ .Chart.Name }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-        image: {{ template "locust.worker_image" }}
+        image: {{ template "locust.worker_image" . }}
 {{- with .Values.worker.command }}
         command:
         {{- toYaml . | nindent 8 }}
@@ -66,20 +66,22 @@ spec:
 {{- if .Values.worker.args }}
           {{- toYaml .Values.worker.args | nindent 10 }}
 {{- end }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ template "locust.worker_pull_policy" . }}
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
         volumeMounts:
-          {{- if .Values.loadtest.locust_locustfile_configmap}}
+          {{- if .Values.loadtest.enabled }}
+            {{- if .Values.loadtest.locust_locustfile_configmap}}
           - name: locustfile
             mountPath: "{{ .Values.loadtest.locust_locustfile_path }}"
-          {{- end }}
-          {{- if .Values.loadtest.locust_lib_configmap }}
+            {{- end }}
+            {{- if .Values.loadtest.locust_lib_configmap }}
           - name: lib
             mountPath: "{{ .Values.loadtest.locust_locustfile_path }}/lib"
+            {{- end }}
           {{- end }}
           {{- if .Values.locustfiles.gitSync.enabled }}
-            {{- include "locust.locustfiles_mount" . | nindent 12 }}
+            {{- include "locust.locustfiles_mount" . | nindent 10 }}
           {{- end }}
           - name: config
             mountPath: /config
@@ -104,7 +106,11 @@ spec:
           - name: LOCUST_LOGLEVEL
             value: "{{ .Values.worker.logLevel }}"
           - name: LOCUST_LOCUSTFILE
+            {{- if .Values.loadtest.enabled }}
             value: "{{ .Values.loadtest.locust_locustfile_path }}/{{ .Values.loadtest.locust_locustfile }}"
+            {{- else if .Values.locustfiles.gitSync.enabled }}
+            value: "{{ .Values.locustfiles.mountPath }}/repo/{{ .Values.locustfiles.gitSync.subPath }}/"
+            {{- end }}
 {{- end }}
 {{- range $key, $value := .Values.worker.environment }}
           - name: {{ $key }}
@@ -133,19 +139,21 @@ spec:
 {{- end }}
       restartPolicy: {{ .Values.worker.restartPolicy }}
       volumes:
-        {{- if .Values.loadtest.locust_lib_configmap }}
+        {{- if .Values.loadtest.enabled }}
+          {{- if .Values.loadtest.locust_lib_configmap }}
         - name: lib
           configMap:
             name: {{ .Values.loadtest.locust_lib_configmap }}
-        {{- end }}
-        {{- if .Values.loadtest.locust_locustfile_configmap }}
+          {{- end }}
+          {{- if .Values.loadtest.locust_locustfile_configmap }}
         - name: locustfile
           configMap:
             name: {{ .Values.loadtest.locust_locustfile_configmap }}
+          {{- end }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.locustfiles.gitSync.enabled }}
         - name: locustfiles
-          emptyDir:
+          emptyDir: {}
         {{- end }}
         - name: config
           configMap:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -38,22 +38,27 @@ loadtest:
   locustCmd: "/opt/venv/bin/locust"
 
 locustfiles:
+  # locustfiles.mountPath -- the path of the locustfiles (without trailing backslash)
   mountPath: "/mnt/locust"
+  # locustfiles.requirements -- Path to a file containing requirements to install
   requirements: ~
   gitSync:
+    # locustfiles.gitSync.enabled -- Enable the Git Sync feature (mutually exclusive with loadtest.enabled)
     enabled: false
+    # locustfiles.gitSync.repo -- Git repository to synchronize
     repo: ~
+    # locustfiles.gitSync.ref -- Git reference to pull
     ref: main
     depth: 1
-    # the number of consecutive failures allowed before aborting
+    # locustfiles.gitSync.maxFailures -- the number of consecutive failures allowed before aborting
     maxFailures: 0
-    # subpath within the repo where locustfiles are located
+    # locustfiles.gitSync.subPath -- subpath within the repo where locustfiles are located,
     # should be "" if files are at repo root
     subPath: "locustfiles"
-    # interval between git sync attempts in seconds
+    # locustfiles.gitSync.period - interval between git sync attempts in seconds
     # Go-style duration string (e.g. "100ms" or "0.1s" = 100ms).
     period: 5s
-    # add variables from secret into gitSync containers, such proxy-config
+    # locustfiles.gitSync.envFrom -- add variables from secret into gitSync containers, such proxy-config
     envFrom: ~
     # envFrom: |
     #   - secretRef:
@@ -104,21 +109,29 @@ image:
   pullPolicy: IfNotPresent
 
 images:
+  # images.defaultLocustRepository -- default image used by locust containers (master and workers)
   defaultLocustRepository: locustio/locust
+  # images.defaultLocustTag -- default tag used by locust containers (master and workers)
   defaultLocustTag: 2.32.2
 
   master:
+    # images.master.repository -- image used by locust master container
     repository: ~
+    # images.master.tag -- tag used by locust master container
     tag: ~
     pullPolicy: IfNotPresent
 
   worker:
+    # images.worker.repository -- image used by locust worker containers
     repository: ~
+    # images.worker.tag -- tag used by locust worker containers
     tag: ~
     pullPolicy: IfNotPresent
 
   gitSync:
+    # images.gitSync.repository -- image used by gitSync container
     repository: registry.k8s.io/git-sync/git-sync
+    # images.gitSync.tag -- tag used by gitSync container
     tag: v4.1.0
     pullPolicy: IfNotPresent
 

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -1,4 +1,5 @@
 loadtest:
+  enabled: true
   # loadtest.name -- a name used for resources and settings in this load test
   name: example
   # loadtest.locust_locustfile -- the name of the locustfile
@@ -36,10 +37,91 @@ loadtest:
   # loadtest.locustCmd -- The command to run Locust
   locustCmd: "/opt/venv/bin/locust"
 
+locustfiles:
+  mountPath: "/mnt/locust"
+  requirements: ~
+  gitSync:
+    enabled: false
+    repo: ~
+    ref: main
+    depth: 1
+    # the number of consecutive failures allowed before aborting
+    maxFailures: 0
+    # subpath within the repo where locustfiles are located
+    # should be "" if files are at repo root
+    subPath: "locustfiles"
+    # interval between git sync attempts in seconds
+    # Go-style duration string (e.g. "100ms" or "0.1s" = 100ms).
+    period: 5s
+    # add variables from secret into gitSync containers, such proxy-config
+    envFrom: ~
+    # envFrom: |
+    #   - secretRef:
+    #       name: 'proxy-config'
+
+    containerName: git-sync
+    uid: 65533
+
+    # When not set, the values defined in the global securityContext will be used
+    securityContext: {}
+    #  runAsUser: 65533
+    #  runAsGroup: 0
+
+    securityContexts:
+      container: {}
+
+    # container level lifecycle hooks
+    containerLifecycleHooks: {}
+
+    # Mount additional volumes into git-sync. It can be templated like in the following example:
+    #   extraVolumeMounts:
+    #     - name: my-templated-extra-volume
+    #       mountPath: "{{ .Values.my_custom_path }}"
+    #       readOnly: true
+    extraVolumeMounts: []
+    env: []
+    # Supported env vars for gitsync can be found at https://github.com/kubernetes/git-sync
+    # - name: ""
+    #   value: ""
+
+    # Configuration for empty dir volume
+    # emptyDirConfig:
+    #   sizeLimit: 1Gi
+    #   medium: Memory
+
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+
 image:
   repository: locustio/locust
   tag: 2.32.2
   pullPolicy: IfNotPresent
+
+images:
+  defaultLocustRepository: locustio/locust
+  defaultLocustTag: 2.32.2
+
+  master:
+    repository: ~
+    tag: ~
+    pullPolicy: IfNotPresent
+
+  worker:
+    repository: ~
+    tag: ~
+    pullPolicy: IfNotPresent
+
+  gitSync:
+    repository: registry.k8s.io/git-sync/git-sync
+    tag: v4.1.0
+    pullPolicy: IfNotPresent
+
 
 service:
   type: ClusterIP


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Add Git Sync support to locust chart to easily deploy multiple locustfiles.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
