### PR TITLE
Update index.yaml from github actions after merge to master

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -58,12 +58,16 @@ jobs:
         uses: mikefarah/yq@v4.44.6
         with:
           cmd: yq eval -i '. |= .entries[][] |= .urls[0] = "oci://" + env(REGISTRY) + "/" + .name + ":" + .version' index.yaml
-      - name: Commit index.yaml to master branch
-        uses: EndBug/add-and-commit@v9.1.4
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
         with:
-          add: 'index.yaml'
-          committer_name: GitHub Actions
-          committer_email: actions@github.com
-          author_email: actions@github.com
-          author_name: GitHub Actions
-          message: "$GITHUB_ACTION is updating index.yaml for $GITHUB_REF"
+          commit-message: "$GITHUB_ACTION is updating index.yaml for $GITHUB_REF"
+          branch: update-index
+          delete-branch: true
+          title: '[index] Updating for $GITHUB_REF'
+          add-paths: |
+            index.yaml
+          labels: |
+            index
+            automated pr

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -65,7 +65,7 @@ jobs:
           commit-message: "$GITHUB_ACTION is updating index.yaml for $GITHUB_REF"
           branch: update-index
           delete-branch: true
-          title: '[index] Updating for $GITHUB_REF'
+          title: '[stable/index] Updating index.yaml for $GITHUB_REF'
           add-paths: |
             index.yaml
           labels: |

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -65,7 +65,7 @@ jobs:
           commit-message: "$GITHUB_ACTION is updating index.yaml for $GITHUB_REF"
           branch: update-index
           delete-branch: true
-          title: '[stable/index] Updating index.yaml for $GITHUB_REF'
+          title: "[stable/index] Updating index.yaml for $GITHUB_REF"
           add-paths: |
             index.yaml
           labels: |

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Generate Helm repo index.yaml
         shell: bash
         run: |
-          helm repo index .
+          helm repo index --merge .
       - name: Update URLs in index.yaml with yq
         uses: mikefarah/yq@v4.44.6
         with:
@@ -65,4 +65,5 @@ jobs:
           committer_name: GitHub Actions
           committer_email: actions@github.com
           author_email: actions@github.com
+          author_name: GitHub Actions
           message: "$GITHUB_ACTION is updating index.yaml for $GITHUB_REF"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ __pycache__
 .idea/
 *.tmproj
 .vscode/
+
+*.tgz


### PR DESCRIPTION
Resolves https://github.com/deliveryhero/helm-charts/issues/614

Goal: after chart changes are merged to `master` branch, we want to update [index.yaml](https://github.com/deliveryhero/helm-charts/blob/master/index.yaml) with the new chart versions.

How do we commit from a Github action to `master` branch? Problems:
- Job fails due to branch protection: https://github.com/deliveryhero/helm-charts/actions/runs/12371219728/job/34526841580#step:10:92
- Common problem: https://github.com/orgs/community/discussions/13836