### PR TITLE
fix: add quotes to key name

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -46,7 +46,7 @@ jobs:
                   continue
               fi
               echo "$d"
-              helm package --sign "$d" -u --key ${{ steps.import_gpg.outputs.name }} --passphrase-file passphrase.txt --keyring ~/.gnupg/secring.gpg
+              helm package --sign "$d" -u --key "${{ steps.import_gpg.outputs.name }}" --passphrase-file passphrase.txt --keyring ~/.gnupg/secring.gpg
           done
           rm passphrase.txt
           echo "Packing done"


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

key  name is `Delivery Hero - helm-charts` so it need quotes

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
