### PR TITLE
Allow extraInitContainers

### DIFF
--- a/stable/metabase/templates/deployment.yaml
+++ b/stable/metabase/templates/deployment.yaml
@@ -25,6 +25,15 @@ spec:
 {{ toYaml .Values.podLabels | trim | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+        {{- /*
+             tpl is used if you want the user to be able to use template functions or .Values references
+             inside their extraInitContainers definitions. If you prefer, you can omit tpl:
+             e.g. toYaml .Values.extraInitContainers | nindent 8
+        */}}
+        {{- tpl (toYaml .Values.extraInitContainers) . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Metabase does not ship certain drivers (e.g., for Oracle) due to licensing restrictions. To support those drivers, you have to place a .jar file into /plugins before Metabase starts. An init container is the canonical Kubernetes approach for ensuring certain files or configuration are present in a shared volume before the main container launches.

I am new to this - but it works on my machine. Ha

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
