### PR TITLE
[stable/node-problem-detector] allow setting dnsPolicy

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-problem-detector
-version: 2.3.16
+version: 2.3.17
 appVersion: v0.8.20
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.16](https://img.shields.io/badge/Version-2.3.16-informational?style=flat-square) ![AppVersion: v0.8.20](https://img.shields.io/badge/AppVersion-v0.8.20-informational?style=flat-square)
+![Version: 2.3.17](https://img.shields.io/badge/Version-2.3.17-informational?style=flat-square) ![AppVersion: v0.8.20](https://img.shields.io/badge/AppVersion-v0.8.20-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -17,7 +17,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector --version 2.3.16
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector --version 2.3.17
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -49,6 +49,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-problem-dete
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | annotations | object | `{}` |  |
+| dnsPolicy | string | `"ClusterFirst"` |  |
 | env | string | `nil` |  |
 | extraContainers | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -44,6 +44,7 @@ spec:
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       hostPID: {{ .Values.hostPID }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
       terminationGracePeriodSeconds: 30
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -76,6 +76,7 @@ rbac:
 # not recommended, but may be useful for certain use cases.
 hostNetwork: false
 hostPID: false
+dnsPolicy: "ClusterFirst"
 
 volume:
   localtime:


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Allows setting dnsPolicy for node problem detector. This is useful if users are using `hostNetwork: true` and are using checks that depend on their k8s dns setup (ex requires setting dnsPolicy to `ClusterFirstWithHostNet`)

The default value here is `ClusterFirst` (not `Default` ) - https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
