### PR TITLE
[stable/hoppscotch] fix Ingress version

### DIFF
--- a/stable/hoppscotch/Chart.yaml
+++ b/stable/hoppscotch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2024.8.2"
 description: A free, fast and beautiful API request builder
 name: hoppscotch
-version: 0.3.1
+version: 0.3.2
 home: https://github.com/hoppscotch/hoppscotch
 sources:
   - https://github.com/hoppscotch/hoppscotch

--- a/stable/hoppscotch/README.md
+++ b/stable/hoppscotch/README.md
@@ -1,6 +1,6 @@
 # hoppscotch
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![AppVersion: 2024.8.2](https://img.shields.io/badge/AppVersion-2024.8.2-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![AppVersion: 2024.8.2](https://img.shields.io/badge/AppVersion-2024.8.2-informational?style=flat-square)
 
 A free, fast and beautiful API request builder
 
@@ -17,7 +17,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/hoppscotch
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/hoppscotch --version 0.3.1
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/hoppscotch --version 0.3.2
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/hoppscotch/templates/ingress.yaml
+++ b/stable/hoppscotch/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "hoppscotch.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Changed ingress version to networking.k8s.io/v1

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
