### PR TITLE
[stable/aws-storage-class] Enable volume expansion, add values schema

### DIFF
--- a/stable/aws-storage-class/Chart.yaml
+++ b/stable/aws-storage-class/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aws-storage-class
-version: 0.1.9
+version: 0.1.10
 description: "Creates a StorageClass. From here: https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/storage-class/aws/default.yaml"
 home: https://github.com/deliveryhero/helm-charts
 maintainers:

--- a/stable/aws-storage-class/README.md
+++ b/stable/aws-storage-class/README.md
@@ -1,6 +1,6 @@
 # aws-storage-class
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square)
 
 Creates a StorageClass. From here: https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/storage-class/aws/default.yaml
 
@@ -17,7 +17,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/aws-storage-
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/aws-storage-class --version 0.1.9
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/aws-storage-class --version 0.1.10
 ```
 
 To install the chart with the release name `my-release`:
@@ -42,19 +42,23 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/aws-storage-class
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| storage_classes.ebs_gp2.allowVolumeExpansion | bool | `true` |  |
 | storage_classes.ebs_gp2.default | bool | `false` |  |
 | storage_classes.ebs_gp2.provisioner | string | `"ebs.csi.aws.com"` |  |
 | storage_classes.ebs_gp2.type | string | `"gp2"` |  |
 | storage_classes.ebs_gp2.volumeBindingMode | string | `"WaitForFirstConsumer"` |  |
+| storage_classes.ebs_gp3.allowVolumeExpansion | bool | `true` |  |
 | storage_classes.ebs_gp3.default | bool | `false` |  |
 | storage_classes.ebs_gp3.provisioner | string | `"ebs.csi.aws.com"` |  |
 | storage_classes.ebs_gp3.type | string | `"gp3"` |  |
 | storage_classes.ebs_gp3.volumeBindingMode | string | `"WaitForFirstConsumer"` |  |
+| storage_classes.ebs_io1_10.allowVolumeExpansion | bool | `true` |  |
 | storage_classes.ebs_io1_10.default | bool | `false` |  |
 | storage_classes.ebs_io1_10.provisioner | string | `"ebs.csi.aws.com"` |  |
 | storage_classes.ebs_io1_10.reclaimPolicy | string | `"Retain"` |  |
 | storage_classes.ebs_io1_10.type | string | `"io1"` |  |
 | storage_classes.ebs_io1_10.volumeBindingMode | string | `"WaitForFirstConsumer"` |  |
+| storage_classes.ebs_io1_20.allowVolumeExpansion | bool | `true` |  |
 | storage_classes.ebs_io1_20.default | bool | `false` |  |
 | storage_classes.ebs_io1_20.iopsPerGB | int | `20` |  |
 | storage_classes.ebs_io1_20.provisioner | string | `"ebs.csi.aws.com"` |  |

--- a/stable/aws-storage-class/templates/storageclass.yaml
+++ b/stable/aws-storage-class/templates/storageclass.yaml
@@ -1,4 +1,4 @@
-{{ range $k,$v:= .Values.storage_classes }}
+{{- range $k, $v := .Values.storage_classes }}
 {{- $sc_name := $k }}
 ---
 apiVersion: storage.k8s.io/v1
@@ -7,18 +7,21 @@ metadata:
   name: {{ kebabcase $sc_name }}
   annotations:
     storageclass.kubernetes.io/is-default-class: {{ default "false" .default | quote }}
-provisioner: {{ default "ebs.csi.aws.com" .provisioner  | quote }}
+provisioner: {{ default "ebs.csi.aws.com" .provisioner | quote }}
 parameters:
   type: {{ .type }}
   encrypted: "true"
-{{ if eq "gp2" .type }}
-  fsType: {{ default "ext4" .fsType  | quote }}
-{{ end }}
-{{ if eq "io1" .type }}
-  iopsPerGB: {{ default "10" .iopsPerGB  | quote }}
-{{ end }}
-{{ if or (empty .provisioner) (eq "ebs.csi.aws.com" .provisioner ) }}
-reclaimPolicy: {{ default "Delete" .reclaimPolicy  | quote }}
-{{ end }}
+{{- if eq "gp2" .type }}
+  fsType: {{ default "ext4" .fsType | quote }}
+{{- end }}
+{{- if eq "io1" .type }}
+  iopsPerGB: {{ default "10" .iopsPerGB | quote }}
+{{- end }}
+{{- if or (empty .provisioner) (eq "ebs.csi.aws.com" .provisioner) }}
+reclaimPolicy: {{ default "Delete" .reclaimPolicy | quote }}
+{{- end }}
 volumeBindingMode: {{ .volumeBindingMode }}
+{{- if hasKey $v "allowVolumeExpansion" }}
+allowVolumeExpansion: {{ .allowVolumeExpansion }}
+{{- end }}
 {{ end }}

--- a/stable/aws-storage-class/values.schema.json
+++ b/stable/aws-storage-class/values.schema.json
@@ -1,0 +1,210 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "storage_classes": {
+            "properties": {
+                "ebs_gp2": {
+                    "properties": {
+                        "allowVolumeExpansion": {
+                            "description": "Enables resizing of volumes",
+                            "type": [
+                                "boolean"
+                            ]
+                        },
+                        "default": {
+                            "description": "Whether this is the default storage class",
+                            "type": [
+                                "boolean"
+                            ]
+                        },
+                        "provisioner": {
+                            "description": "CSI provisioner name",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "type": {
+                            "description": "EBS volume type",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "volumeBindingMode": {
+                            "description": "Volume binding mode",
+                            "enum": [
+                                "Immediate",
+                                "WaitForFirstConsumer"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ebs_gp3": {
+                    "properties": {
+                        "allowVolumeExpansion": {
+                            "description": "Enables resizing of volumes",
+                            "type": [
+                                "boolean"
+                            ]
+                        },
+                        "default": {
+                            "description": "Whether this is the default storage class",
+                            "type": [
+                                "boolean"
+                            ]
+                        },
+                        "provisioner": {
+                            "description": "CSI provisioner name",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "type": {
+                            "description": "EBS volume type",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "volumeBindingMode": {
+                            "description": "Volume binding mode",
+                            "enum": [
+                                "Immediate",
+                                "WaitForFirstConsumer"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ebs_io1_10": {
+                    "properties": {
+                        "allowVolumeExpansion": {
+                            "description": "Enables resizing of volumes",
+                            "type": [
+                                "boolean"
+                            ]
+                        },
+                        "default": {
+                            "description": "Whether this is the default storage class",
+                            "type": [
+                                "boolean"
+                            ]
+                        },
+                        "provisioner": {
+                            "description": "CSI provisioner name",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "reclaimPolicy": {
+                            "description": "Reclaim policy for volumes",
+                            "enum": [
+                                "Delete",
+                                "Retain"
+                            ],
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "EBS volume type",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "volumeBindingMode": {
+                            "description": "Volume binding mode",
+                            "enum": [
+                                "Immediate",
+                                "WaitForFirstConsumer"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ebs_io1_20": {
+                    "properties": {
+                        "allowVolumeExpansion": {
+                            "description": "Enables resizing of volumes",
+                            "type": [
+                                "boolean"
+                            ]
+                        },
+                        "default": {
+                            "description": "Whether this is the default storage class",
+                            "type": [
+                                "boolean"
+                            ]
+                        },
+                        "iopsPerGB": {
+                            "description": "Optional, specific to io1",
+                            "type": [
+                                "integer"
+                            ]
+                        },
+                        "provisioner": {
+                            "description": "CSI provisioner name",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "type": {
+                            "description": "EBS volume type",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "volumeBindingMode": {
+                            "description": "Volume binding mode",
+                            "enum": [
+                                "Immediate",
+                                "WaitForFirstConsumer"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "gp2": {
+                    "properties": {
+                        "default": {
+                            "description": "Whether this is the default storage class",
+                            "type": [
+                                "boolean"
+                            ]
+                        },
+                        "fsType": {
+                            "description": "Filesystem type (optional, for gp2)",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "provisioner": {
+                            "description": "Legacy in-tree provisioner",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "type": {
+                            "description": "EBS volume type",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "volumeBindingMode": {
+                            "description": "Volume binding mode",
+                            "enum": [
+                                "Immediate",
+                                "WaitForFirstConsumer"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object"
+}

--- a/stable/aws-storage-class/values.yaml
+++ b/stable/aws-storage-class/values.yaml
@@ -1,29 +1,37 @@
 storage_classes:
   gp2:
-    default: false
-    volumeBindingMode: WaitForFirstConsumer
-    provisioner: "kubernetes.io/aws-ebs"
-    type: "gp2"
-    fsType: "ext4"
+    default: false                          # @schema type:boolean; description: Whether this is the default storage class
+    volumeBindingMode: WaitForFirstConsumer # @schema enum:[Immediate, WaitForFirstConsumer]; description: Volume binding mode
+    provisioner: "kubernetes.io/aws-ebs"    # @schema type:string; description: Legacy in-tree provisioner
+    type: "gp2"                             # @schema type:string; description: EBS volume type
+    fsType: "ext4"                          # @schema type:string; description: Filesystem type (optional, for gp2)
+
   ebs_gp2:
-    default: false
-    type: "gp2"
-    volumeBindingMode: WaitForFirstConsumer
-    provisioner: "ebs.csi.aws.com"
+    default: false                          # @schema type:boolean; description: Whether this is the default storage class
+    volumeBindingMode: WaitForFirstConsumer # @schema enum:[Immediate, WaitForFirstConsumer]; description: Volume binding mode
+    provisioner: "ebs.csi.aws.com"          # @schema type:string; description: CSI provisioner name
+    type: "gp2"                             # @schema type:string; description: EBS volume type
+    allowVolumeExpansion: true              # @schema type:boolean; description: Enables resizing of volumes
+
   ebs_gp3:
-    default: false
-    type: "gp3"
-    volumeBindingMode: WaitForFirstConsumer
-    provisioner: "ebs.csi.aws.com"
+    default: false                          # @schema type:boolean; description: Whether this is the default storage class
+    volumeBindingMode: WaitForFirstConsumer # @schema enum:[Immediate, WaitForFirstConsumer]; description: Volume binding mode
+    provisioner: "ebs.csi.aws.com"          # @schema type:string; description: CSI provisioner name
+    type: "gp3"                             # @schema type:string; description: EBS volume type
+    allowVolumeExpansion: true              # @schema type:boolean; description: Enables resizing of volumes
+
   ebs_io1_10:
-    default: false
-    volumeBindingMode: WaitForFirstConsumer
-    provisioner: "ebs.csi.aws.com"
-    type: "io1"
-    reclaimPolicy: "Retain"
+    default: false                          # @schema type:boolean; description: Whether this is the default storage class
+    volumeBindingMode: WaitForFirstConsumer # @schema enum:[Immediate, WaitForFirstConsumer]; description: Volume binding mode
+    provisioner: "ebs.csi.aws.com"          # @schema type:string; description: CSI provisioner name
+    type: "io1"                             # @schema type:string; description: EBS volume type
+    reclaimPolicy: "Retain"                 # @schema enum:["Delete", "Retain"]; description: Reclaim policy for volumes
+    allowVolumeExpansion: true              # @schema type:boolean; description: Enables resizing of volumes
+
   ebs_io1_20:
-    default: false
-    volumeBindingMode: WaitForFirstConsumer
-    provisioner: "ebs.csi.aws.com"
-    type: "io1"
-    iopsPerGB: 20
+    default: false                          # @schema type:boolean; description: Whether this is the default storage class
+    volumeBindingMode: WaitForFirstConsumer # @schema enum:[Immediate, WaitForFirstConsumer]; description: Volume binding mode
+    provisioner: "ebs.csi.aws.com"          # @schema type:string; description: CSI provisioner name
+    type: "io1"                             # @schema type:string; description: EBS volume type
+    iopsPerGB: 20                           # @schema type:integer; description: Optional, specific to io1
+    allowVolumeExpansion: true              # @schema type:boolean; description: Enables resizing of volumes


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

This PR is adding support for `allowVolumeExpansion`  and I also took this opportunity to give it a try to values schema, using https://github.com/losisin/helm-values-schema-json - maybe this is something we could enable to the whole repo.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
