### PR TITLE
[stable/node-problem-detector]: Add option to disable mounting host localtime volume

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-problem-detector
-version: 2.3.18
+version: 2.3.19
 appVersion: v0.8.20
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.3.18](https://img.shields.io/badge/Version-2.3.18-informational?style=flat-square) ![AppVersion: v0.8.20](https://img.shields.io/badge/AppVersion-v0.8.20-informational?style=flat-square)
+![Version: 2.3.19](https://img.shields.io/badge/Version-2.3.19-informational?style=flat-square) ![AppVersion: v0.8.20](https://img.shields.io/badge/AppVersion-v0.8.20-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -17,7 +17,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector --version 2.3.18
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector --version 2.3.19
 ```
 
 To install the chart with the release name `my-release`:
@@ -99,6 +99,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-problem-dete
 | tolerations[0].effect | string | `"NoSchedule"` |  |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | string | `"RollingUpdate"` | Manage the daemonset update strategy |
+| volume.localtime.enabled | bool | `true` |  |
 | volume.localtime.type | string | `"FileOrCreate"` |  |
 
 ## Maintainers

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -110,10 +110,12 @@ spec:
         - name: log
           hostPath:
             path: {{ default "/var/log/" .Values.logDir.host }}
+        {{- if ((.Values.volume).localtime).enabled }}
         - name: localtime
           hostPath:
             path: /etc/localtime
             type: {{ default "FileOrCreate" .Values.volume.localtime.type }}
+        {{- end }}
         - name: custom-config
           configMap:
             name: {{ include "node-problem-detector.customConfig" . }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -80,6 +80,7 @@ dnsPolicy: "ClusterFirst"
 
 volume:
   localtime:
+    enabled: true
     type: "FileOrCreate"
 
 priorityClassName: system-node-critical


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

On clusters that runs both flatcar and ubuntu nodes pods are not starting properly because the host `/etc/localtime` location is a file on flatcar and a directory on ubuntu OS.

This PR adds an option to disable mounting the host localtime into the NPD daemonset. If timezone is UTC on the host, disabling this mounting will have no effect.

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [x] Github actions are passing
