### PR TITLE
[stable/field-exporter] update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @deliveryhero/helm-chart-admins
 /stable                @deliveryhero/helm-chart-maintainers
 /stable/mlflow         @deliveryhero/helm-chart-maintainers @deliveryhero/dh-logistics-ml-engineering
-stable/field-exporter  @deliveryhero/helm-chart-maintainers @deliveryhero/gcp
+stable/field-exporter  @deliveryhero/helm-chart-maintainers @deliveryhero/cloud-infrastructure


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Update codeowners to replace a no longer existent team.

Note to reviewer: Please also change the repo permission accordingly, removing `deliveryhero/gcp` and adding `deliveryhero/cloud-infrastructure` in it's place please.

<!--- Describe your changes in detail -->

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`) - **not applicable**
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [X] Github actions are passing
