### PR TITLE
[stable/priority-class] feat: add support for preemptionPolicy and globalDefault in PriorityClass

### DIFF
--- a/stable/priority-class/Chart.yaml
+++ b/stable/priority-class/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 appVersion: "1.0"
 description: A very simple chart that creates priority classes
 name: priority-class
-version: 0.1.2
+version: 0.2.0
 home: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 maintainers:
-- name: max-rocket-internet
-  url: https://github.com/max-rocket-internet
+  - name: max-rocket-internet
+    url: https://github.com/max-rocket-internet
 
 annotations:
   artifacthub.io/links: |

--- a/stable/priority-class/README.md
+++ b/stable/priority-class/README.md
@@ -1,6 +1,6 @@
 # priority-class
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A very simple chart that creates priority classes
 
@@ -17,7 +17,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/priority-cla
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/priority-class --version 0.1.2
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/priority-class --version 0.2.0
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/priority-class/README.md
+++ b/stable/priority-class/README.md
@@ -1,6 +1,6 @@
 # priority-class
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A very simple chart that creates priority classes
 
@@ -42,7 +42,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/priority-class -f
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| PriorityClasses | list | `[{"name":"high","value":1000},{"name":"medium","value":100},{"name":"low","value":10}]` | A list of PriorityClass to create |
+| PriorityClasses | list | `[{"description":"This priority class will not cause other pods to be preempted.","globalDefault":false,"name":"high-priority-nonpreempting","preemptionPolicy":"Never","value":10000},{"name":"high","value":1000},{"name":"medium","value":100},{"name":"low","value":10}]` | A list of PriorityClass to create |
 
 ## Maintainers
 

--- a/stable/priority-class/templates/priorityclass.yaml
+++ b/stable/priority-class/templates/priorityclass.yaml
@@ -2,12 +2,18 @@
 {{- range $PriorityClass := .Values.PriorityClasses }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
-description: A high priority class to be used for important pods
+description: {{ default "A high priority class to be used for important pods" $PriorityClass.description | quote }}
 metadata:
   name: {{ $PriorityClass.name }}
   labels:
 {{ include "priority-class.labels" $ | indent 4 }}
 value: {{ $PriorityClass.value }}
+{{- if hasKey $PriorityClass "preemptionPolicy" }}
+preemptionPolicy: {{ $PriorityClass.preemptionPolicy }}
+{{- end }}
+{{- if hasKey $PriorityClass "globalDefault" }}
+globalDefault: {{ $PriorityClass.globalDefault }}
+{{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/stable/priority-class/values.yaml
+++ b/stable/priority-class/values.yaml
@@ -1,5 +1,10 @@
 # PriorityClasses -- A list of PriorityClass to create
 PriorityClasses:
+  - name: high-priority-nonpreempting
+    value: 10000
+    preemptionPolicy: Never
+    globalDefault: false
+    description: "This priority class will not cause other pods to be preempted."
   - name: high
     value: 1000
   - name: medium


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

This PR enhances the priority-class Helm chart to support optional fields preemptionPolicy, globalDefault, and custom description per priority class.
	•	If `description` is not set, it defaults to "A high priority class to be used for important pods" (the previous static one).
	•	`globalDefault` and `preemptionPolicy` are rendered only if explicitly defined in values.yaml (even if set to false).
	•	Maintains backward compatibility for existing configurations.

<!--- Describe your changes in detail -->

## Checklist

- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [X] Github actions are passing
