### PR TITLE
[stable/prometheus-k8s-events-exporter] feat: enable pod labels via extraLabels in prometheus-k8s-events-exporter

### DIFF
--- a/stable/prometheus-k8s-events-exporter/Chart.yaml
+++ b/stable/prometheus-k8s-events-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.0.0
 description: Exporter for kubernetes events
 name: prometheus-k8s-events-exporter
-version: 0.2.2
+version: 0.2.3
 home: https://github.com/caicloud/event_exporter
 sources:
   - https://github.com/caicloud/event_exporter

--- a/stable/prometheus-k8s-events-exporter/README.md
+++ b/stable/prometheus-k8s-events-exporter/README.md
@@ -17,7 +17,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/prometheus-k
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/prometheus-k8s-events-exporter --version 0.2.2
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/prometheus-k8s-events-exporter --version 0.2.3
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/prometheus-k8s-events-exporter/README.md
+++ b/stable/prometheus-k8s-events-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-k8s-events-exporter
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Exporter for kubernetes events
 

--- a/stable/prometheus-k8s-events-exporter/templates/deployment.yaml
+++ b/stable/prometheus-k8s-events-exporter/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "prometheus-k8s-events-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         prometheus.io/scrape: "{{ $.Values.prometheus.scrape }}"
         prometheus.io/path: "{{ $.Values.prometheus.path }}"


### PR DESCRIPTION
## Description

Enables custom pod labeling for prometheus-k8s-events-exporter by linking the existing `extraLabels` configuration to the deployment pod template.

### Changes
- Connected `extraLabels` from values.yaml to pod metadata labels in deployment.yaml
- Users can now add custom labels to pods via the `extraLabels` configuration

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
