### PR TITLE
stable/node-local-dns feat: allow to override port names

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.4.0
+version: 2.5.0
 appVersion: 1.26.7
 maintainers:
   - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
+![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -23,7 +23,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-d
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.4.0
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.5.0
 ```
 
 To install the chart with the release name `my-release`:
@@ -60,7 +60,9 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-local-dns -f
 | config.healthPort | int | `8080` | Port used for the health endpoint |
 | config.localDns | string | `"169.254.20.25"` |  |
 | config.noIPv6Lookups | bool | `false` | If true, return NOERROR when attempting to resolve an IPv6 address |
-| config.port | int | `53` | Port used for DNS traffic |
+| config.port.number | int | `53` | Port used for DNS traffic |
+| config.port.tcp | string | `"dns-tcp"` | Port name used for TCP DNS traffic |
+| config.port.udp | string | `"dns"` | Port name used for UDP DNS traffic |
 | config.prefetch | object | `{"amount":3,"duration":"30s","enabled":false,"percentage":"20%"}` | If enabled, coredns will prefetch popular items when they are about to be expunged from the cache. https://coredns.io/plugins/cache/ |
 | config.setupInterface | bool | `true` |  |
 | config.setupIptables | bool | `true` |  |

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -87,11 +87,11 @@ spec:
           {{- toYaml .Values.securityContext | nindent 10 }}
         {{- end }}
         ports:
-        - containerPort: {{ .Values.config.port }}
-          name: dns
+        - containerPort: {{ .Values.config.port.number }}
+          name: {{ .Values.config.port.udp}}
           protocol: UDP
-        - containerPort: {{ .Values.config.port }}
-          name: dns-tcp
+        - containerPort: {{ .Values.config.port.number }}
+          name: {{ .Values.config.port.tcp}}
           protocol: TCP
         - containerPort: 9253
           name: metrics

--- a/stable/node-local-dns/templates/service-upstream.yaml
+++ b/stable/node-local-dns/templates/service-upstream.yaml
@@ -8,11 +8,11 @@ metadata:
     {{- include "node-local-dns.labels" . | nindent 4 }}
 spec:
   ports:
-  - name: dns
+  - name: {{ .Values.config.port.udp }}
     port: 53
     protocol: UDP
     targetPort: 53
-  - name: dns-tcp
+  - name: {{ .Values.config.port.tcp }}
     port: 53
     protocol: TCP
     targetPort: 53

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -54,8 +54,13 @@ config:
   # -- Overrides the generated configuration with specified one.
   customConfig: ""
 
-  # -- Port used for DNS traffic
-  port: 53
+  port:
+    # -- Port used for DNS traffic
+    number: 53
+    # -- Port name used for TCP DNS traffic
+    tcp: dns-tcp
+    # -- Port name used for UDP DNS traffic
+    udp: dns
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
Allow to override ports naming, on the official chart of coredns it's tcp-53 & udp-53 and with cilium we need to align them https://github.com/cilium/cilium/issues/43800 / https://github.com/cilium/cilium/issues/43944

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
