### PR TITLE
[‎stable/node-local-dns] Allow for configuration of additional options when forwarding

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.6.0
+version: 2.7.0
 appVersion: 1.26.7
 maintainers:
   - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.6.0](https://img.shields.io/badge/Version-2.6.0-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
+![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -23,7 +23,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-d
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.6.0
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.7.0
 ```
 
 To install the chart with the release name `my-release`:
@@ -67,6 +67,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-local-dns -f
 | config.setupInterface | bool | `true` |  |
 | config.setupIptables | bool | `true` |  |
 | config.skipTeardown | bool | `false` |  |
+| config.upstreamForwardConfig | object | `{}` | Allows for configuration of upstream server forwarding for the default server block |
 | config.upstreamServers | string | `"__PILLAR__UPSTREAM__SERVERS__"` | Overrides the upstream servers used for default server block |
 | config.upstreamServiceSelector | object | `{"k8s-app":"kube-dns"}` | Use a custom upstream service selector |
 | configMapAnnotations | object | `{}` |  |

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -118,7 +118,11 @@ data:
     {{- else }}
         bind 0.0.0.0
     {{- end }}
-        forward . {{ .Values.config.upstreamServers }}
+        forward . {{ .Values.config.upstreamServers }} {
+        {{- range .Values.config.upstreamForwardConfig }}
+          {{ . }}
+        {{- end }}
+        }
         prometheus :9253
     {{- if .Values.config.noIPv6Lookups }}
         template IN AAAA {

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -65,6 +65,9 @@ config:
   # -- Overrides the upstream servers used for default server block
   upstreamServers: "__PILLAR__UPSTREAM__SERVERS__"
 
+  # -- Allows for configuration of upstream server forwarding for the default server block
+  upstreamForwardConfig: {}
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
…o upstream servers

<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Allows for the configuration of additional options on the main forward block. Can be used for any of the extended syntax options in coredns: https://coredns.io/plugins/forward/#syntax

Example output:

`.:53 {
    errors
    cache 30
    reload
    loop
    bind 169.254.20.25 172.20.0.10
    forward . 1.1.1.1 /etc/resolv.conf {
      max_fails 5
      health_check 30s
      policy sequential
    }
    prometheus :9253
    }
`

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
