### PR TITLE
[stable/node-problem-detector] Add initContainers support

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-problem-detector
-version: 2.4.0
+version: 2.4.1
 appVersion: v1.35.1
 home: https://github.com/kubernetes/node-problem-detector
 description: |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,6 +1,6 @@
 # node-problem-detector
 
-![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![AppVersion: v1.35.1](https://img.shields.io/badge/AppVersion-v1.35.1-informational?style=flat-square)
+![Version: 2.4.1](https://img.shields.io/badge/Version-2.4.1-informational?style=flat-square) ![AppVersion: v1.35.1](https://img.shields.io/badge/AppVersion-v1.35.1-informational?style=flat-square)
 
 This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
 
@@ -17,7 +17,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector --version 2.4.0
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector --version 2.4.1
 ```
 
 To install the chart with the release name `my-release`:
@@ -64,6 +64,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-problem-dete
 | image.repository | string | `"registry.k8s.io/node-problem-detector/node-problem-detector"` |  |
 | image.tag | string | `"v1.35.1"` |  |
 | imagePullSecrets | list | `[]` |  |
+| initContainers | list | `[]` |  |
 | labels | object | `{}` |  |
 | logDir.host | string | `"/var/log/"` | log directory on k8s host |
 | logDir.pod | string | `""` | log directory in pod (volume mount), use logDir.host if empty |

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -53,6 +53,10 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers:
+      {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.image.digest }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -165,6 +165,8 @@ extraVolumes: []
 
 extraVolumeMounts: []
 
+initContainers: []
+
 extraContainers: []
 
 # updateStrategy -- Manage the daemonset update strategy


### PR DESCRIPTION
<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description

Add initContainers support to the node-problem-detector DaemonSet, following the same pattern as the existing extraContainers field. Users can specify a list of init containers in their values to run before the main node-problem-detector container starts.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
