### PR TITLE
[stable/k8s-event-logger] Add events.k8s.io API group to cluster role

### DIFF
--- a/stable/k8s-event-logger/Chart.yaml
+++ b/stable/k8s-event-logger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "2.4"
-version: 1.1.10
+version: 1.2.0
 description: |
   This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
 
@@ -17,16 +17,16 @@ description: |
 home: https://github.com/max-rocket-internet/k8s-event-logger
 name: k8s-event-logger
 maintainers:
-- name: max-rocket-internet
-  url: https://github.com/max-rocket-internet
+  - name: max-rocket-internet
+    url: https://github.com/max-rocket-internet
 engine: gotpl
 icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
 keywords:
-- events
-- logging
-- Auditing
+  - events
+  - logging
+  - Auditing
 sources:
-- https://github.com/max-rocket-internet/k8s-event-logger
+  - https://github.com/max-rocket-internet/k8s-event-logger
 
 annotations:
   artifacthub.io/links: |

--- a/stable/k8s-event-logger/README.md
+++ b/stable/k8s-event-logger/README.md
@@ -1,6 +1,6 @@
 # k8s-event-logger
 
-![Version: 1.1.10](https://img.shields.io/badge/Version-1.1.10-informational?style=flat-square) ![AppVersion: 2.4](https://img.shields.io/badge/AppVersion-2.4-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 2.4](https://img.shields.io/badge/AppVersion-2.4-informational?style=flat-square)
 
 This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
 
@@ -28,7 +28,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/k8s-event-lo
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/k8s-event-logger --version 1.1.10
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/k8s-event-logger --version 1.2.0
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/k8s-event-logger/templates/clusterrole.yaml
+++ b/stable/k8s-event-logger/templates/clusterrole.yaml
@@ -6,6 +6,6 @@ metadata:
     app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
     {{- include "k8s-event-logger.labels" . | nindent 4 }}
 rules:
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources: ["events"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION


<!-- Thank you for contributing to deliveryhero/helm-charts! -->

## Description
  Add permissions for the events.k8s.io API group in the ClusterRole to allow
  the event logger to access events from the Events API group in addition to
  core API events. Combined both API groups into a single rule for cleaner
  configuration.
<!--- Describe your changes in detail -->

## Checklist

- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [ ] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
