### PR TITLE
[stable/node-local-dns] Make liveness probe configurable

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.7.0
+version: 2.7.1
 appVersion: 1.26.7
 maintainers:
   - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
+![Version: 2.7.1](https://img.shields.io/badge/Version-2.7.1-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -23,7 +23,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-d
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.7.0
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.7.1
 ```
 
 To install the chart with the release name `my-release`:
@@ -82,6 +82,16 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-local-dns -f
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| livenessProbe | object | `{"failureThreshold":null,"httpGet":{"host":"","path":"/health","port":null,"scheme":"HTTP"},"initialDelaySeconds":60,"periodSeconds":null,"successThreshold":null,"timeoutSeconds":5}` | Liveness probe configuration for the node-cache container. |
+| livenessProbe.failureThreshold | string | `nil` | When a probe fails, Kubernetes will try failureThreshold times before giving up. |
+| livenessProbe.httpGet.host | string | `""` | Host used for the liveness probe HTTP request. Leave empty to use the pod IP. |
+| livenessProbe.httpGet.path | string | `"/health"` | Path used for the liveness probe HTTP request. |
+| livenessProbe.httpGet.port | string | `nil` | Port used for the liveness probe HTTP request. Defaults to config.healthPort when unset. |
+| livenessProbe.httpGet.scheme | string | `"HTTP"` | Scheme used for the liveness probe HTTP request. |
+| livenessProbe.initialDelaySeconds | int | `60` |  |
+| livenessProbe.periodSeconds | string | `nil` | How often in seconds to perform the probe. |
+| livenessProbe.successThreshold | string | `nil` | Minimum consecutive successes for the probe to be considered successful after having failed. |
+| livenessProbe.timeoutSeconds | int | `5` |  |
 | nameOverride | string | `""` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -98,10 +98,25 @@ spec:
           protocol: TCP
         livenessProbe:
           httpGet:
-            path: /health
-            port: {{ .Values.config.healthPort }}
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
+            path: {{ .Values.livenessProbe.httpGet.path | quote }}
+            port: {{ default .Values.config.healthPort .Values.livenessProbe.httpGet.port }}
+            {{- with .Values.livenessProbe.httpGet.host }}
+            host: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.livenessProbe.httpGet.scheme }}
+            scheme: {{ . }}
+            {{- end }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          {{- with .Values.livenessProbe.periodSeconds }}
+          periodSeconds: {{ . }}
+          {{- end }}
+          {{- with .Values.livenessProbe.successThreshold }}
+          successThreshold: {{ . }}
+          {{- end }}
+          {{- with .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ . }}
+          {{- end }}
         volumeMounts:
         - mountPath: /run/xtables.lock
           name: xtables-lock

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -68,6 +68,26 @@ config:
   # -- Allows for configuration of upstream server forwarding for the default server block
   upstreamForwardConfig: {}
 
+# -- Liveness probe configuration for the node-cache container.
+livenessProbe:
+  httpGet:
+    # -- Host used for the liveness probe HTTP request. Leave empty to use the pod IP.
+    host: ""
+    # -- Path used for the liveness probe HTTP request.
+    path: /health
+    # -- Port used for the liveness probe HTTP request. Defaults to config.healthPort when unset.
+    port:
+    # -- Scheme used for the liveness probe HTTP request.
+    scheme: HTTP
+  initialDelaySeconds: 60
+  timeoutSeconds: 5
+  # -- How often in seconds to perform the probe.
+  periodSeconds:
+  # -- Minimum consecutive successes for the probe to be considered successful after having failed.
+  successThreshold:
+  # -- When a probe fails, Kubernetes will try failureThreshold times before giving up.
+  failureThreshold:
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
## Overview
This PR makes the `node-local-dns` chart liveness probe configurable instead of hardcoding the probe request to `/health` on `config.healthPort` with fixed timing values. The change is backward-compatible: existing installs keep the same effective probe behavior unless the new `livenessProbe` values are explicitly set.

## Context & Rationale
In our network, we want this service to listen only locally on the node for NodeLocal DNS traffic and not rely on externally reachable probe behavior. In particular, when the health listener is bound to a local node address, the liveness probe needs to be able to target that same host explicitly, for example via `livenessProbe.httpGet.host`.

Without this, the chart only allows configuring the probe port, which is not sufficient for environments where the health endpoint should remain local to the node and not be exposed more broadly just to satisfy liveness checks.

## Detailed Changes
### Probe templating
- **`stable/node-local-dns/templates/daemonset.yaml`**: Replaced the hardcoded liveness probe with values-driven fields.
- Added support for:
  - `livenessProbe.httpGet.host`
  - `livenessProbe.httpGet.path`
  - `livenessProbe.httpGet.port`
  - `livenessProbe.httpGet.scheme`
  - `livenessProbe.initialDelaySeconds`
  - `livenessProbe.timeoutSeconds`
  - `livenessProbe.periodSeconds`
  - `livenessProbe.successThreshold`
  - `livenessProbe.failureThreshold`
- Kept `config.healthPort` as the fallback for the probe port so existing releases do not need to change values.

### Chart values
- **`stable/node-local-dns/values.yaml`**: Added a new `livenessProbe` configuration block with defaults matching the previous chart behavior.
- This allows users to set a local probe target such as:
  ```yaml
  livenessProbe:
    httpGet:
      host: 169.254.20.10
      port: 8080
  ```

### Documentation and versioning
- **`stable/node-local-dns/README.md`**: Documented the new `livenessProbe` values.
- **`stable/node-local-dns/Chart.yaml`**: Bumped the chart version from `2.7.0` to `2.7.1`.

## Verification
- [x] `helm lint stable/node-local-dns`
- [x] Rendered the chart with defaults using `helm template test stable/node-local-dns`
- [x] Verified the rendered default probe remains effectively unchanged:
  - path `/health`
  - port `8080` via `config.healthPort`
  - `initialDelaySeconds: 60`
  - `timeoutSeconds: 5`
- [x] Rendered the chart with `--set livenessProbe.httpGet.host=169.254.20.10 --set livenessProbe.httpGet.port=8080`
- [x] Confirmed the manifest emits `httpGet.host: "169.254.20.10"` in the daemonset probe

## Impact
- **Behavioral impact**: No change for existing users unless they opt into the new `livenessProbe` settings.
- **Compatibility**: Backward-compatible due to fallback to `config.healthPort`.
- **Reviewer focus**: Main review area is the daemonset probe templating and whether the added configuration surface is the right chart-level API.

## Task Tracking
- No existing upstream issue linked.
