### PR TITLE
[stable/cluster-overprovisioner] adding security defaults

### DIFF
--- a/ci/README.md.gotmpl
+++ b/ci/README.md.gotmpl
@@ -43,6 +43,26 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/{{ template "char
 
 {{ template "chart.requirementsSection" . }}
 
+{{ if eq .Name "cluster-overprovisioner" -}}
+## Security
+
+The chart ships with hardened security defaults for both the pod and container level, following least-privilege principles.
+
+**Container security context** (`containerSecurityContext`):
+
+- `allowPrivilegeEscalation: false` — prevents the process from gaining additional privileges at runtime
+- `readOnlyRootFilesystem: true` — the container filesystem is mounted read-only
+- `runAsNonRoot: true` / `runAsUser: 65534` — container runs as the unprivileged `nobody` user
+- `capabilities.drop: [ALL]` — all Linux capabilities are dropped
+- `seccompProfile.type: RuntimeDefault` — syscall filtering via the container runtime's default seccomp profile
+
+**Pod security context** (`podSecurityContext`):
+
+- `runAsNonRoot: true` / `runAsUser: 65534` — enforced at pod level as an additional guard
+- `fsGroup: 65534` — volume ownership is set to `nobody`
+- `seccompProfile.type: RuntimeDefault` — seccomp applied at the pod level
+
+{{ end -}}
 {{ template "chart.valuesSection" . }}
 
 {{ template "chart.maintainersSection" . }}

--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.7.14
+version: 0.7.15
 maintainers:
   - name: max-rocket-internet
     url: https://github.com/max-rocket-internet

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -48,6 +48,24 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/cluster-overprovi
 * <https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler>
 * <https://github.com/kubernetes/kubernetes/tree/master/build/pause>
 
+## Security
+
+The chart ships with hardened security defaults for both the pod and container level, following least-privilege principles.
+
+**Container security context** (`containerSecurityContext`):
+
+- `allowPrivilegeEscalation: false` — prevents the process from gaining additional privileges at runtime
+- `readOnlyRootFilesystem: true` — the container filesystem is mounted read-only
+- `runAsNonRoot: true` / `runAsUser: 65534` — container runs as the unprivileged `nobody` user
+- `capabilities.drop: [ALL]` — all Linux capabilities are dropped
+- `seccompProfile.type: RuntimeDefault` — syscall filtering via the container runtime's default seccomp profile
+
+**Pod security context** (`podSecurityContext`):
+
+- `runAsNonRoot: true` / `runAsUser: 65534` — enforced at pod level as an additional guard
+- `fsGroup: 65534` — volume ownership is set to `nobody`
+- `seccompProfile.type: RuntimeDefault` — seccomp applied at the pod level
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,6 +1,6 @@
 # cluster-overprovisioner
 
-![Version: 0.7.14](https://img.shields.io/badge/Version-0.7.14-informational?style=flat-square) ![AppVersion: 3.9](https://img.shields.io/badge/AppVersion-3.9-informational?style=flat-square)
+![Version: 0.7.15](https://img.shields.io/badge/Version-0.7.15-informational?style=flat-square) ![AppVersion: 3.9](https://img.shields.io/badge/AppVersion-3.9-informational?style=flat-square)
 
 This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
 
@@ -21,7 +21,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/cluster-over
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/cluster-overprovisioner --version 0.7.14
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/cluster-overprovisioner --version 0.7.15
 ```
 
 To install the chart with the release name `my-release`:
@@ -70,7 +70,8 @@ The chart ships with hardened security defaults for both the pod and container l
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| containerSecurityContext | object | `{}` | Container security context object |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context object |
+| containerSecurityContext.allowPrivilegeEscalation | bool | `false` | prevents the process from gaining additional privileges at runtime |
 | deployments | list | [] | Define optional additional deployments - A default deployment is included by default |
 | deployments[0].affinity | object | `{}` | Default Deployment - Map of node/pod affinities |
 | deployments[0].annotations | object | `{}` | Default Deployment - Annotations to add to the deployment |
@@ -95,14 +96,14 @@ The chart ships with hardened security defaults for both the pod and container l
 | image.repository | string | `"registry.k8s.io/pause"` | Image repository |
 | image.tag | string | `.Chart.AppVersion` | Image tag |
 | nameOverride | string | `""` | Override the name of the chart |
-| podSecurityContext | object | `{}` | Pod security context object |
+| podSecurityContext | object | `{"fsGroup":65534,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod security context object |
 | priorityClassDefault.enabled | bool | `true` | If true, enable default priorityClass |
 | priorityClassDefault.name | string | `"default"` | Name of the default priorityClass |
 | priorityClassDefault.value | int | `0` | Priority value of the default priorityClass |
 | priorityClassOverprovision.name | string | `"overprovisioning"` | Name of the overprovision priorityClass |
 | priorityClassOverprovision.value | int | `-1` | Priority value of the overprovision priorityClass |
 | serviceAccount.annotations | object | `{}` | Additional Service Account annotations |
-| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for a Service Account |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Automount API credentials for a Service Account. Disabled by default: pause pods make no Kubernetes API calls, so mounting a token is unnecessary and increases attack surface. |
 | serviceAccount.create | bool | `true` | Determine whether a Service Account should be created or it should reuse an exiting one |
 | serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is `true`, a name is generated using the fullname template |
 | terminationGracePeriodSeconds | int | `0` | Time for graceful pod termination |

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -57,14 +57,17 @@ spec:
     spec:
       serviceAccountName: {{ $serviceAccountName }}
       priorityClassName: {{ $priorityClassName }}
+      {{- with $podSecurityContext }}
       securityContext:
-        {{- toYaml $podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ $chartName }}
           image: "{{ $repository }}:{{ $imageTag }}"
           imagePullPolicy: {{ $pullPolicy }}
-          {{- if $containerSecurityContext }}
-          securityContext: {{ toYaml $containerSecurityContext | nindent 12 }}
+          {{- with $containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .resources | nindent 12 }}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -1,5 +1,6 @@
 # containerSecurityContext -- Container security context object
 containerSecurityContext:
+  # containerSecurityContext.allowPrivilegeEscalation -- prevents the process from gaining additional privileges at runtime
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   runAsNonRoot: true

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -1,11 +1,24 @@
 # containerSecurityContext -- Container security context object
-containerSecurityContext: {}
-# allowPrivilegeEscalation: false
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 # podSecurityContext -- Pod security context object
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
 
 priorityClassOverprovision:
   # priorityClassOverprovision.name -- Name of the overprovision priorityClass
@@ -107,5 +120,6 @@ serviceAccount:
   name:
   # serviceAccount.annotations -- Additional Service Account annotations
   annotations: {}
-  # serviceAccount.automountServiceAccountToken -- Automount API credentials for a Service Account
-  automountServiceAccountToken: true
+  # serviceAccount.automountServiceAccountToken -- Automount API credentials for a Service Account.
+  # Disabled by default: pause pods make no Kubernetes API calls, so mounting a token is unnecessary and increases attack surface.
+  automountServiceAccountToken: false


### PR DESCRIPTION
## Description

**[stable/cluster-overprovisioner] Harden security defaults and fix SecurityContext rendering**

This PR introduces security hardening for the `cluster-overprovisioner` chart by fixing a template rendering bug and setting least-privilege defaults out of the box.

### Bug fix: SecurityContext template rendering (`deployments.yaml`)

- **Container `securityContext`**: `toYaml ... | nindent 12` was placed inline after the key (`securityContext: {{ ... }}`), producing invalid YAML block mapping. Moved the value to a new line.
- **Pod `securityContext`**: The block was always rendered even when the value was an empty map (`{}`), resulting in `securityContext:\n  {}`. Wrapped in `{{- with ... }}` so it is only emitted when a value is set.

### Security defaults (`values.yaml`)

Hardened defaults are now set for the `pause` container, which requires no filesystem writes, no Linux capabilities, and no Kubernetes API access:

**`containerSecurityContext`**
- `allowPrivilegeEscalation: false`
- `readOnlyRootFilesystem: true`
- `runAsNonRoot: true` / `runAsUser: 65534` (nobody)
- `capabilities.drop: [ALL]`
- `seccompProfile.type: RuntimeDefault`

**`podSecurityContext`**
- `runAsNonRoot: true` / `runAsUser/Group: 65534`
- `fsGroup: 65534`
- `seccompProfile.type: RuntimeDefault`

**`serviceAccount.automountServiceAccountToken: false`**  
The `pause` pods make no Kubernetes API calls, so mounting a service account token is unnecessary and increases attack surface.

### Documentation (`README.md`)

Added a **Security** section explaining each hardened setting and the rationale behind it, including a note on how to override individual values if needed.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/cluster-overprovisioner]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
