### PR TITLE
[stable/node-local-dns]: add configurable container lifecycle hooks

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.7.0
+version: 2.8.0
 appVersion: 1.26.7
 maintainers:
   - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -82,6 +82,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-local-dns -f
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| lifecycle | object | `{}` | Container lifecycle hooks for the node-cache pod. |
 | nameOverride | string | `""` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
+![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -23,7 +23,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-d
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.7.0
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.8.0
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/node-local-dns/templates/daemonset.yaml
+++ b/stable/node-local-dns/templates/daemonset.yaml
@@ -102,6 +102,10 @@ spec:
             port: {{ .Values.config.healthPort }}
           initialDelaySeconds: 60
           timeoutSeconds: 5
+        {{- with .Values.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /run/xtables.lock
           name: xtables-lock

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -164,6 +164,12 @@ resources:
   limits:
     memory: 128Mi
 
+# -- Container lifecycle hooks for the node-cache pod.
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sh", "-c", "sleep 30"]
+
 # -- Resize policy for in-place pod vertical scaling.
 # [Container resize policies](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
 resizePolicy: []


### PR DESCRIPTION
## Description

Currently, the node-local-dns chart does not allow users to define lifecycle hooks. This is a critical limitation for clusters using autoscalers like Karpenter or Cluster Autoscaler that frequently perform node consolidation.

The Problem:
When a node is drained, the kubelet sends a SIGTERM to all pods on the node. node-local-dns (a DaemonSet) often terminates immediately. However, application pods on the same node that are still performing a graceful shutdown (draining connections) may attempt final DNS lookups (e.g., to authentication services or logging endpoints). Since the local DNS cache is already dead, these apps surface ConnectTimeout or Temporary failure in name resolution errors, leading to 500s during deployment/consolidation events.

The Solution:
By adding support for lifecycle hooks, users can inject a preStop sleep. This forces the node-local-dns pod to wait (e.g., sleep 30) before terminating, ensuring it remains available to serve the last remaining application pods on the node.

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing
