### PR TITLE
[stable/node-local-dns]: add configurable cache TTL

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.8.0
+version: 2.9.0
 appVersion: 1.26.7
 maintainers:
   - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -23,7 +23,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-d
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.8.0
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.9.0
 ```
 
 To install the chart with the release name `my-release`:

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
+![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -50,6 +50,7 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-local-dns -f
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | config.bindIp | bool | `false` | If false, it will bind 0.0.0.0, otherwise dnsServer and localDns will be used. https://github.com/bottlerocket-os/bottlerocket/issues/3711#issuecomment-1907087528 |
+| config.cacheTTL | int | `30` | Cache TTL in seconds for DNS records. https://coredns.io/plugins/cache/ |
 | config.commProtocol | string | `"force_tcp"` | Set communication protocol. Options are `prefer_udp` or `force_tcp` |
 | config.customConfig | string | `""` | Overrides the generated configuration with specified one. |
 | config.customUpstreamsvc | string | `""` | Use a custom upstreamsvc for -upstreamsvc |

--- a/stable/node-local-dns/templates/configmap.yaml
+++ b/stable/node-local-dns/templates/configmap.yaml
@@ -50,11 +50,11 @@ data:
     in-addr.arpa:53 {
         errors
     {{- if .Values.config.prefetch.enabled}}
-        cache 30 {
+        cache {{ .Values.config.cacheTTL }} {
                 prefetch {{ .Values.config.prefetch.amount }} {{ .Values.config.prefetch.duration }} {{ .Values.config.prefetch.percentage }}
         }
     {{- else }}
-        cache 30
+        cache {{ .Values.config.cacheTTL }}
     {{- end }}
         reload
         loop
@@ -76,11 +76,11 @@ data:
     ip6.arpa:53 {
         errors
     {{- if .Values.config.prefetch.enabled}}
-        cache 30 {
+        cache {{ .Values.config.cacheTTL }} {
                 prefetch {{ .Values.config.prefetch.amount }} {{ .Values.config.prefetch.duration }} {{ .Values.config.prefetch.percentage }}
         }
     {{- else }}
-        cache 30
+        cache {{ .Values.config.cacheTTL }}
     {{- end }}
         reload
         loop
@@ -105,11 +105,11 @@ data:
     {{- end }}
         errors
     {{- if .Values.config.prefetch.enabled}}
-        cache 30 {
+        cache {{ .Values.config.cacheTTL }} {
                 prefetch {{ .Values.config.prefetch.amount }} {{ .Values.config.prefetch.duration }} {{ .Values.config.prefetch.percentage }}
         }
     {{- else }}
-        cache 30
+        cache {{ .Values.config.cacheTTL }}
     {{- end }}
         reload
         loop

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -32,6 +32,9 @@ config:
   # -- If true, return NOERROR when attempting to resolve an IPv6 address
   noIPv6Lookups: false
 
+  # -- Cache TTL in seconds for DNS records. https://coredns.io/plugins/cache/
+  cacheTTL: 30
+
   # -- If enabled, coredns will prefetch popular items when they are about to be expunged from the cache. https://coredns.io/plugins/cache/
   prefetch:
     enabled: false


### PR DESCRIPTION
## Description

The cache TTL for DNS records is currently hardcoded to 30 seconds in the Corefile template. This is too aggressive for external hostnames with longer upstream TTLs (e.g. AWS ALBs return 60s TTLs), causing unnecessary cache misses and upstream lookups.

This adds a `config.cacheTTL` value (default `30`) so users can tune the cache TTL without needing to override the entire Corefile via `customConfig`.

The `cluster.local` zone is not affected — its `success 9984 30` and `denial 9984 5` cache settings remain unchanged as they serve a different purpose (max entries + TTL for internal DNS).

## Changes

- Add `config.cacheTTL` to `values.yaml` (default: `30`, backwards-compatible)
- Replace hardcoded `cache 30` in `configmap.yaml` template with `cache {{ .Values.config.cacheTTL }}`
- Regenerate README
- Bump chart version to 2.9.0

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing