### PR TITLE
[stable/node-local-dns]: add preDelete hook

### DIFF
--- a/stable/node-local-dns/Chart.yaml
+++ b/stable/node-local-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: node-local-dns
-version: 2.9.1
+version: 2.10.0
 appVersion: 1.26.7
 maintainers:
   - name: gabrieladt

--- a/stable/node-local-dns/README.md
+++ b/stable/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![AppVersion: 1.26.7](https://img.shields.io/badge/AppVersion-1.26.7-informational?style=flat-square)
 
 A chart to install node-local-dns.
 
@@ -23,7 +23,7 @@ helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-d
 To install a specific version of this chart:
 
 ```console
-helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.9.1
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-local-dns --version 2.10.0
 ```
 
 To install the chart with the release name `my-release`:
@@ -79,6 +79,11 @@ helm install my-release oci://ghcr.io/deliveryhero/helm-charts/node-local-dns -f
 | dashboard.label | string | `"grafana_dashboard"` | label that grafana sidecar is configured to look for |
 | dashboard.namespace | string | `"kube-system"` | namespace where grafana sidecar is configured to look for dashboards. e.g. "monitoring" |
 | fullnameOverride | string | `""` |  |
+| hooks.preDelete | object | See below | Gracefully delete the DaemonSet and wait for its pods to terminate before Helm removes its dependencies on uninstall |
+| hooks.preDelete.activeDeadlineSeconds | int | `180` | Job deadline in seconds |
+| hooks.preDelete.backoffLimit | int | `1` | Number of retries before the hook Job is marked failed |
+| hooks.preDelete.enabled | bool | `false` | Enable the pre-delete hook |
+| hooks.preDelete.image.tag | string | `"1.34.9"` | Pin to a version compatible with your cluster |
 | image.repository | string | `"registry.k8s.io/dns/k8s-dns-node-cache"` |  |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |

--- a/stable/node-local-dns/templates/hooks/pre-delete/job.yaml
+++ b/stable/node-local-dns/templates/hooks/pre-delete/job.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.hooks.preDelete.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}-cleanup
+  namespace: kube-system
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.hooks.preDelete.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.hooks.preDelete.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "node-local-dns.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: cleanup
+    spec:
+      serviceAccountName: {{ include "node-local-dns.fullname" . }}-cleanup
+      restartPolicy: Never
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: cleanup
+          image: "{{ .Values.hooks.preDelete.image.repository }}:{{ .Values.hooks.preDelete.image.tag }}"
+          imagePullPolicy: {{ .Values.hooks.preDelete.image.pullPolicy }}
+          {{- with .Values.hooks.preDelete.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              DS="{{ include "node-local-dns.fullname" . }}"
+              NS="kube-system"
+              # Match DaemonSet pods only; exclude this Job's own pod.
+              SELECTOR="app.kubernetes.io/name={{ include "node-local-dns.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component!=cleanup"
+
+              echo "[cleanup] looking for daemonset ${DS} in ${NS}"
+              if ! kubectl -n "${NS}" get daemonset "${DS}" >/dev/null 2>&1; then
+                echo "[cleanup] daemonset ${DS} not found, nothing to do"
+                exit 0
+              fi
+
+              echo "[cleanup] gracefully deleting daemonset ${DS} (no --force, teardown must run)"
+              kubectl -n "${NS}" delete daemonset "${DS}" --wait=false
+
+              echo "[cleanup] waiting for pods (${SELECTOR}) to terminate"
+              kubectl -n "${NS}" wait --for=delete pod -l "${SELECTOR}" --timeout=-1s
+
+              echo "[cleanup] all node-local-dns pods terminated; safe for Helm to remove dependent resources"
+{{- end }}

--- a/stable/node-local-dns/templates/hooks/pre-delete/role.yaml
+++ b/stable/node-local-dns/templates/hooks/pre-delete/role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.hooks.preDelete.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}-cleanup
+  namespace: kube-system
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/stable/node-local-dns/templates/hooks/pre-delete/rolebinding.yaml
+++ b/stable/node-local-dns/templates/hooks/pre-delete/rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.hooks.preDelete.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}-cleanup
+  namespace: kube-system
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "node-local-dns.fullname" . }}-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "node-local-dns.fullname" . }}-cleanup
+    namespace: kube-system
+{{- end }}

--- a/stable/node-local-dns/templates/hooks/pre-delete/serviceaccount.yaml
+++ b/stable/node-local-dns/templates/hooks/pre-delete/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.hooks.preDelete.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}-cleanup
+  namespace: kube-system
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- end }}

--- a/stable/node-local-dns/values.yaml
+++ b/stable/node-local-dns/values.yaml
@@ -74,6 +74,29 @@ config:
 nameOverride: ""
 fullnameOverride: ""
 
+# Lifecycle hooks for the chart
+hooks:
+  # -- Gracefully delete the DaemonSet and wait for its pods to terminate before Helm removes its dependencies on uninstall
+  # @default -- See below
+  preDelete:
+    # -- Enable the pre-delete hook
+    enabled: false
+    image:
+      repository: alpine/k8s
+      # -- Pin to a version compatible with your cluster
+      tag: "1.34.9"
+      pullPolicy: IfNotPresent
+    # -- Job deadline in seconds
+    activeDeadlineSeconds: 180
+    # -- Number of retries before the hook Job is marked failed
+    backoffLimit: 1
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 64Mi
+
 serviceAccount:
   # -- Specifies whether a service account should be created.
   create: true


### PR DESCRIPTION
## Description

The `node-local-dns` chart has no ordering control on `helm uninstall`. Helm deletes regular resources in its built-in order and does not wait for the DaemonSet pods to terminate before removing the resources those pods depend on at runtime — the ConfigMap and the `-upstream` Service.

When those dependencies are removed first, a pod that restarts or reschedules during the uninstall breaks: with the ConfigMap gone it cannot mount the volume and is stuck in `ContainerCreating`, and with the `-upstream` Service gone node-cache enters `CrashLoopBackOff`. The DaemonSet's deletion then blocks on these stuck pods and the release fails. The only way to recover was to force-delete the DaemonSet, which is not something that should be relied on as standard uninstall procedure.

This adds an optional `pre-delete` hook (default disabled) that gracefully drains the DaemonSet and waits for its pods to terminate before Helm removes its dependencies, so the pods shut down cleanly.

## Changes

- Add `hooks.preDelete` to `values.yaml` (default `enabled: false`, backwards-compatible)
- Add `templates/hooks/pre-delete/` with a dedicated ServiceAccount, Role, RoleBinding and drain Job, gated behind `hooks.preDelete.enabled`
- The Job gracefully deletes the DaemonSet (no `--force`) and waits for its pods before Helm proceeds; on timeout it fails the uninstall rather than leaving stuck pods
- Regenerate README
- Bump chart version to 2.10.0

## Checklist

- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] I have read the [contribution instructions](https://github.com/deliveryhero/helm-charts#opening-a-pr), bumped chart version and regenerated the docs
- [ ] Github actions are passing