### PR TITLE
[stable/no-chart] Update all github actions

### DIFF
--- a/.github/workflows/chart-testing.yml
+++ b/.github/workflows/chart-testing.yml
@@ -6,22 +6,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: Azure/setup-helm@v3.3
+        uses: Azure/setup-helm@v5.0.0
         with:
           version: v3.9.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5.3.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.13'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.0
+        uses: helm/chart-testing-action@v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -35,7 +35,7 @@ jobs:
         run: ct lint --validate-maintainers=false --config ci/ct.yaml
 
       - name: Kind Cluster
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@v1.14.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
       - uses: deepakputhraya/action-pr-title@master
         with:
           regex: '^\[stable\/+.+].*'

--- a/.github/workflows/helm-conftest.yaml
+++ b/.github/workflows/helm-conftest.yaml
@@ -8,7 +8,7 @@ jobs:
       image: alpine/helm:latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
 
       - name: Install Dependencies
         run: apk add --no-cache curl tar yq

--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -5,7 +5,7 @@ jobs:
     name: Check all docs
     runs-on: ubuntu-latest
     container:
-      image: jnorwood/helm-docs:v1.11.0
+      image: jnorwood/helm-docs:v1.14.2
     steps:
     - name: Checkout
       uses: actions/checkout@v7.0.0

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5.0.0
         with:
           version: v3.16.4
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -74,12 +74,12 @@ jobs:
         shell: bash
         run: helm repo index . --merge index.yaml
       - name: Update URLs in index.yaml with yq
-        uses: mikefarah/yq@v4.44.6
+        uses: mikefarah/yq@v4.53.3
         with:
           cmd: yq eval -i '. |= .entries[][] |= .urls[0] = "oci://" + env(REGISTRY) + "/" + .name + ":" + .version' index.yaml
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           commit-message: "Updating index.yaml for ${{ github.ref }}"
           branch: update-index

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5.0.0
         with:
           version: v3.12.3 # Lock version for now, helm v3.13.0 contains bugs related to oci that will be fixed in v3.13.1. https://github.com/helm/helm/issues/12423
       - name: Run helm lint
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v7.0.0
     - name: Run lint
       uses: avto-dev/markdown-lint@v1.5.0
       with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5.1.1
+      - uses: actions/stale@v10.3.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-issue-label: 'no-issue-activity'


### PR DESCRIPTION
We are seeing this error in the checkout actions on [this PR](https://github.com/deliveryhero/helm-charts/pull/803):

```
Run actions/checkout@v7.0.0
  with:
    repository: deliveryhero/helm-charts
    token: ***
    ssh-strict: true
    ssh-user: git
    persist-credentials: true
    clean: true
    sparse-checkout-cone-mode: true
    fetch-depth: 1
    fetch-tags: false
    show-progress: true
    lfs: false
    submodules: false
    set-safe-directory: true
    allow-unsafe-pr-checkout: false
/usr/bin/docker exec  04b576a44ce4a6871737aa1e5367819751dbeecb1cfa1d283c02f1d3a19ac1d4 sh -c "cat /etc/*release | grep ^ID"
Error relocating /__e/node24_alpine/bin/node: pthread_getname_np: symbol not found
```

So I'll just try a low-effort update of all actions first...